### PR TITLE
Replace CGLib code generation in WB RCP with ByteBuddy

### DIFF
--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/parser/BindingContextClassLoaderInitializer.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/parser/BindingContextClassLoaderInitializer.java
@@ -21,8 +21,6 @@ import org.eclipse.wb.internal.core.utils.reflect.IClassLoaderInitializer;
 import org.eclipse.wb.internal.core.utils.reflect.ProjectClassLoader;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
-import net.sf.cglib.core.ReflectUtils;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.objectweb.asm.ClassReader;
@@ -126,10 +124,13 @@ public final class BindingContextClassLoaderInitializer implements IClassLoaderI
     byte[] bytes = IOUtils.toByteArray(stream);
     stream.close();
     // inject DefaultBean to project class loader
-    ReflectUtils.defineClass(
+    ReflectionUtils.invokeMethod(
+        projectClassLoader,
+        "defineClass(java.lang.String,byte[],int,int)",
         "org.eclipse.wb.internal.rcp.databinding.parser.DefaultBean",
         bytes,
-        projectClassLoader);
+        0,
+        bytes.length);
   }
 
   private static ProjectClassLoader configureBindings(ClassLoader classLoader) {

--- a/org.eclipse.wb.rcp/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp/META-INF/MANIFEST.MF
@@ -104,7 +104,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.draw2d;bundle-version="3.13.0",
  com.google.guava;bundle-version="30.1.0",
  org.apache.commons.commons-beanutils;bundle-version="1.9.4",
- org.objectweb.asm;bundle-version="9.0.0"
+ org.objectweb.asm;bundle-version="9.0.0",
+ net.bytebuddy.byte-buddy;bundle-version="1.14.4"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.wb.rcp

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/forms/SectionPartInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/forms/SectionPartInfo.java
@@ -39,9 +39,11 @@ import org.eclipse.ui.forms.ManagedForm;
 import org.eclipse.ui.forms.SectionPart;
 import org.eclipse.ui.forms.widgets.ExpandableComposite;
 
-import net.sf.cglib.proxy.Enhancer;
-import net.sf.cglib.proxy.MethodInterceptor;
-import net.sf.cglib.proxy.MethodProxy;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
+
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.implementation.FixedValue;
 
 import java.lang.reflect.Constructor;
 
@@ -139,25 +141,15 @@ public final class SectionPartInfo extends AbstractComponentInfo
     ClassLoader editorLoader = JavaInfoUtils.getClassLoader(this);
     Class<?> class_FormPage = editorLoader.loadClass("org.eclipse.ui.forms.editor.FormPage");
     // create FormPage
-    Enhancer enhancer = new Enhancer();
-    enhancer.setClassLoader(editorLoader);
-    enhancer.setSuperclass(class_FormPage);
-    enhancer.setCallback(new MethodInterceptor() {
-      @Override
-      public Object intercept(Object obj,
-          java.lang.reflect.Method method,
-          Object[] args,
-          MethodProxy proxy) throws Throwable {
-        String signature = ReflectionUtils.getMethodSignature(method);
-        if (signature.equals("getManagedForm()")) {
-          return m_ManagedForm;
-        }
-        // handle in super-Class
-        return proxy.invokeSuper(obj, args);
-      }
-    });
-    m_formPage =
-        enhancer.create(new Class<?>[]{String.class, String.class}, new Object[]{"id", "title"});
+    m_formPage = new ByteBuddy() //
+        .subclass(class_FormPage) //
+        .method(named("getManagedForm").and(takesNoArguments())) //
+        .intercept(FixedValue.reference(m_ManagedForm)) //
+        .make() //
+        .load(editorLoader) //
+        .getLoaded() //
+        .getConstructor(String.class, String.class) //
+        .newInstance("id", "title");
   }
 
   /**

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/WizardPageInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/WizardPageInfo.java
@@ -27,8 +27,7 @@ import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 
-import net.sf.cglib.proxy.Enhancer;
-import net.sf.cglib.proxy.NoOp;
+import net.bytebuddy.ByteBuddy;
 
 /**
  * Model for {@link WizardPage}.
@@ -64,11 +63,13 @@ public final class WizardPageInfo extends DialogPageInfo implements IJavaInfoRen
     Wizard wizard;
     {
       Class<?> wizardClass = editorLoader.loadClass("org.eclipse.jface.wizard.Wizard");
-      Enhancer enhancer = new Enhancer();
-      enhancer.setClassLoader(editorLoader);
-      enhancer.setSuperclass(wizardClass);
-      enhancer.setCallback(NoOp.INSTANCE);
-      wizard = (Wizard) enhancer.create();
+      wizard = (Wizard) new ByteBuddy() //
+          .subclass(wizardClass) //
+          .make() //
+          .load(editorLoader) //
+          .getLoaded() //
+          .getConstructor() //
+          .newInstance();
     }
     // add this WizardPage
     wizard.addPage((WizardPage) getObject());

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/ContributionManagerInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/ContributionManagerInfo.java
@@ -38,8 +38,7 @@ import org.eclipse.jface.action.IContributionItem;
 import org.eclipse.jface.action.IContributionManager;
 import org.eclipse.jface.action.Separator;
 
-import net.sf.cglib.proxy.Enhancer;
-import net.sf.cglib.proxy.NoOp;
+import net.bytebuddy.ByteBuddy;
 
 import java.util.List;
 
@@ -141,11 +140,13 @@ public abstract class ContributionManagerInfo extends AbstractComponentInfo {
       ClassLoader editorLoader = JavaInfoUtils.getClassLoader(this);
       String itemClassName = getArtificialContributionItem_className();
       Class<?> itemClass = editorLoader.loadClass(itemClassName);
-      Enhancer enhancer = new Enhancer();
-      enhancer.setClassLoader(editorLoader);
-      enhancer.setSuperclass(itemClass);
-      enhancer.setCallback(NoOp.INSTANCE);
-      item = enhancer.create();
+      item = new ByteBuddy() //
+          .subclass(itemClass) //
+          .make() //
+          .load(editorLoader) //
+          .getLoaded() //
+          .getConstructor() //
+          .newInstance();
     }
     // do insert
     low_insertContributionItem(index, item);

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/GroupMarkerInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/GroupMarkerInfo.java
@@ -18,8 +18,7 @@ import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
 import org.eclipse.jface.action.GroupMarker;
 
-import net.sf.cglib.proxy.Enhancer;
-import net.sf.cglib.proxy.NoOp;
+import net.bytebuddy.ByteBuddy;
 
 /**
  * Model for {@link GroupMarker}.
@@ -66,11 +65,13 @@ public final class GroupMarkerInfo extends ContributionItemInfo {
     // create Action
     Object action;
     {
-      Enhancer enhancer = new Enhancer();
-      enhancer.setClassLoader(classLoader);
-      enhancer.setSuperclass(classAction);
-      enhancer.setCallback(NoOp.INSTANCE);
-      action = enhancer.create(new Class<?>[]{String.class}, new Object[]{text});
+      action = new ByteBuddy() //
+          .subclass(classAction) //
+          .make() //
+          .load(classLoader) //
+          .getLoaded() //
+          .getConstructor(String.class) //
+          .newInstance(text);
     }
     // wrap Action with item
     return ReflectionUtils.getConstructorBySignature(

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/util/ActivatorGetImagesByteCodeProcessor.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/util/ActivatorGetImagesByteCodeProcessor.java
@@ -13,11 +13,10 @@ package org.eclipse.wb.internal.rcp.model.util;
 import org.eclipse.wb.internal.core.utils.asm.ToBytesClassAdapter;
 import org.eclipse.wb.internal.core.utils.reflect.IByteCodeProcessor;
 import org.eclipse.wb.internal.core.utils.reflect.ProjectClassLoader;
+import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.swt.model.property.editor.image.plugin.WorkspacePluginInfo;
 
 import org.eclipse.core.resources.IProject;
-
-import net.sf.cglib.core.ReflectUtils;
 
 import org.apache.commons.io.IOUtils;
 import org.objectweb.asm.ClassReader;
@@ -72,10 +71,13 @@ public final class ActivatorGetImagesByteCodeProcessor implements IByteCodeProce
       byte[] bytes = IOUtils.toByteArray(stream);
       stream.close();
       // inject InternalImageManager to project class loader
-      ReflectUtils.defineClass(
+      ReflectionUtils.invokeMethod(
+          classLoader,
+          "defineClass(java.lang.String,byte[],int,int)",
           "org.eclipse.wb.internal.rcp.model.util.InternalImageManager",
           bytes,
-          classLoader);
+          0,
+          bytes.length);
     } catch (Throwable e) {
     }
   }


### PR DESCRIPTION
Most of the migration is pretty straight-forward. The only noticeable change is that we have to inject the Dialog-subclass directly into the composite classloader, in order to avoid a NoClassDefFoundException in the CreationSupport classes.