### PR TITLE
Replace CGLib code generation in Swing JSR296 with ByteBuddy

### DIFF
--- a/org.eclipse.wb.swing.jsr296/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing.jsr296/META-INF/MANIFEST.MF
@@ -10,7 +10,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.wb.core;bundle-version="1.12.0",
  org.eclipse.wb.swing,
  org.eclipse.draw2d;bundle-version="3.13.0",
- com.google.guava;bundle-version="30.1.0"
+ com.google.guava;bundle-version="30.1.0",
+ net.bytebuddy.byte-buddy;bundle-version="1.14.4"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: plugin


### PR DESCRIPTION
We only use CGLib/ByteBuddy to create a non-abstract subclass of the JDesktop Application class.