### PR TITLE
Enhanced classes should be directly injected in the parent class-loader

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/creation/ThisCreationSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/creation/ThisCreationSupport.java
@@ -74,6 +74,7 @@ import org.eclipse.jdt.core.dom.TypeDeclaration;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.TypeCache;
 import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.implementation.MethodDelegation;
 import net.bytebuddy.implementation.bind.annotation.AllArguments;
 import net.bytebuddy.implementation.bind.annotation.Origin;
@@ -410,7 +411,7 @@ public final class ThisCreationSupport extends CreationSupport {
         .method(ElementMatchers.noneOf(getIgnoredMethods(componentClass))) //
         .intercept(MethodDelegation.to(new StubMethodInterceptor(), MethodInterceptor.class));
 
-    PROXY_CACHE.findOrInsert(getClassLoader(), proxyKey, () -> builder.make().load(getClassLoader()).getLoaded());
+    PROXY_CACHE.findOrInsert(getClassLoader(), proxyKey, () -> builder.make().load(getClassLoader(), ClassLoadingStrategy.Default.INJECTION).getLoaded());
   }
 
   /**


### PR DESCRIPTION
Using this strategy does not create a new class loader but injects all classes into the given ClassLoader by reflective access. This prevents the loading of classes with cyclic load-time dependencies but avoids the creation of an additional class loader.

Note that this strategy usually yields a better runtime performance.