### PR TITLE
Bulk update of Manifest versions due to changes since the latest release

### DIFF
--- a/org.eclipse.wb.core.databinding.xml/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core.databinding.xml/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.core.databinding.xml;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-Activator: org.eclipse.wb.internal.core.databinding.xml.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wb.core.databinding/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core.databinding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.core.databinding;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-Activator: org.eclipse.wb.internal.core.databinding.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wb.core.java/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core.java/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.core.java;singleton:=true
-Bundle-Version: 1.9.2.qualifier
+Bundle-Version: 1.9.3.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.core.java.Activator
 Bundle-Vendor: %providerName

--- a/org.eclipse.wb.core.lib/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core.lib/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.core.lib;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.wb.core.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.core.ui;singleton:=true
-Bundle-Version: 1.10.0.qualifier
+Bundle-Version: 1.10.1.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wb.core.xml/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core.xml/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.core.xml;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.core.xml.Activator
 Bundle-Vendor: %providerName

--- a/org.eclipse.wb.doc.user/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.doc.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.doc.user; singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.wb.jdt.fragment/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.jdt.fragment/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.wb.jdt.fragment;singleton:=true
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-Localization: fragment
 Fragment-Host: org.eclipse.jdt.core;bundle-version="3.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.wb.layout.group/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.layout.group/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.layout.group;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.wb.os.linux/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.os.linux/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.os.linux;singleton:=true
-Bundle-Version: 1.9.2.qualifier
+Bundle-Version: 1.9.3.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-PlatformFilter: (& (osgi.ws=gtk) (osgi.os=linux))

--- a/org.eclipse.wb.os.linux/pom.xml
+++ b/org.eclipse.wb.os.linux/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.eclipse.wb</groupId>
     <artifactId>org.eclipse.wb.os.linux</artifactId>
-    <version>1.9.2-SNAPSHOT</version>
+    <version>1.9.3-SNAPSHOT</version>
     <packaging>eclipse-plugin</packaging>
 
     <build>

--- a/org.eclipse.wb.os.macosx/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.os.macosx/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.os.macosx;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-PlatformFilter: (osgi.os=macosx)

--- a/org.eclipse.wb.os.macosx/pom.xml
+++ b/org.eclipse.wb.os.macosx/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.eclipse.wb</groupId>
     <artifactId>org.eclipse.wb.os.macosx</artifactId>
-    <version>1.9.1-SNAPSHOT</version>
+    <version>1.9.2-SNAPSHOT</version>
     <packaging>eclipse-plugin</packaging>
 
     <build>

--- a/org.eclipse.wb.os.win32/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.os.win32/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.os.win32;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime,

--- a/org.eclipse.wb.os.win32/pom.xml
+++ b/org.eclipse.wb.os.win32/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.eclipse.wb</groupId>
     <artifactId>org.eclipse.wb.os.win32</artifactId>
-    <version>1.9.1-SNAPSHOT</version>
+    <version>1.9.2-SNAPSHOT</version>
     <packaging>eclipse-plugin</packaging>
 
     <build>

--- a/org.eclipse.wb.os/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.os/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.os;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-Activator: org.eclipse.wb.os.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wb.rcp.SWT_AWT/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp.SWT_AWT/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.rcp.SWT_AWT;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-Activator: org.eclipse.wb.internal.rcp.swtawt.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/org.eclipse.wb.rcp.databinding.emf/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp.databinding.emf/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.rcp.databinding.emf;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-Activator: org.eclipse.wb.internal.rcp.databinding.emf.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wb.rcp.databinding.xwt/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp.databinding.xwt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.rcp.databinding.xwt;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-Activator: org.eclipse.wb.internal.rcp.databinding.xwt.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wb.rcp.databinding/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp.databinding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.rcp.databinding;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-Activator: org.eclipse.wb.internal.rcp.databinding.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wb.rcp.doc.user/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp.doc.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.rcp.doc.user;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.wb.rcp.nebula/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp.nebula/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.rcp.nebula;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-Activator: org.eclipse.wb.internal.rcp.nebula.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wb.rcp.swing2swt/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp.swing2swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.rcp.swing2swt;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-Activator: org.eclipse.wb.internal.rcp.swing2swt.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wb.rcp/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.rcp;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.rcp.Activator
 Bundle-Vendor: %providerName

--- a/org.eclipse.wb.runtime/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.runtime/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.runtime;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.wb.swing.FormLayout.lib/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing.FormLayout.lib/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swing.FormLayout.lib;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-ClassPath: jgoodies-common-1.8.0.jar,
  jgoodies-forms-1.8.0.jar
 Bundle-Vendor: %providerName

--- a/org.eclipse.wb.swing.FormLayout/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing.FormLayout/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swing.FormLayout;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.swing.FormLayout.Activator
 Bundle-Vendor: %providerName

--- a/org.eclipse.wb.swing.MigLayout.lib/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing.MigLayout.lib/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swing.MigLayout.lib;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ClassPath: ideutil.jar,

--- a/org.eclipse.wb.swing.MigLayout/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing.MigLayout/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swing.MigLayout;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-Activator: org.eclipse.wb.internal.swing.MigLayout.Activator
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.wb.swing.databinding/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing.databinding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swing.databinding;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-Activator: org.eclipse.wb.internal.swing.databinding.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wb.swing.doc.user/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing.doc.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swing.doc.user;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.wb.swing.java6/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing.java6/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swing.java6;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.wb.swing.jsr296/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing.jsr296/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swing.jsr296;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-Activator: org.eclipse.wb.internal.swing.jsr296.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wb.swing/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swing;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.swing.Activator
 Bundle-Vendor: %providerName

--- a/org.eclipse.wb.swt.widgets.baseline/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swt.widgets.baseline/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swt.widgets.baseline;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-Activator: org.eclipse.wb.swt.widgets.baseline.BaselineActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.wb.swt/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swt;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.swt.Activator
 Bundle-Vendor: %providerName

--- a/org.eclipse.wb.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: WindowBuilder Tests
 Bundle-SymbolicName: org.eclipse.wb.tests;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-Activator: org.eclipse.wb.tests.designer.tests.Activator
 Bundle-Vendor: Google
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.wb.tests/pom.xml
+++ b/org.eclipse.wb.tests/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.wb</groupId>
   <artifactId>org.eclipse.wb.tests</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>1.2.1-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
  

--- a/org.eclipse.wb.xwt/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.xwt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.xwt;singleton:=true
-Bundle-Version: 1.9.1.qualifier
+Bundle-Version: 1.9.2.qualifier
 Bundle-ClassPath: .,
  lib/org.pushingpixels.trident_1.2.0.v20100204-1500.jar,
  lib/org.eclipse.e4.xwt_0.9.1.SNAPSHOT.jar,


### PR DESCRIPTION
The Manifest/pom files of all projects have been updated to reflect the
changes since the latest release. Since none of the public APIs have
been changed, only the micro version is increased. All bundles are
affected, primarily due to the Java 17 update.