### PR TITLE
 Specify a global timeout of 90 min. for the GitHub build jobs

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -16,6 +16,7 @@ jobs:
         java: [ 17 ]
     runs-on: ${{ matrix.os }}   
     name: OS ${{ matrix.os }} Java ${{ matrix.java }} compile
+    timeout-minutes: 90
     steps:
     - uses: actions/checkout@v3
       with:

--- a/org.eclipse.wb.tests/pom.xml
+++ b/org.eclipse.wb.tests/pom.xml
@@ -73,7 +73,6 @@
 				<configuration>
 					<argLine>${ui.test.vmargs}</argLine>
 					<appArgLine>-nl de -clearPersistedState -consoleLog</appArgLine>
-					<forkedProcessTimeoutInSeconds>3600</forkedProcessTimeoutInSeconds>
 					<useUIHarness>true</useUIHarness>
 					<useUIThread>true</useUIThread>
 					<application>org.eclipse.ui.ide.workbench</application>


### PR DESCRIPTION
The Jenkins build currently sets two timeouts. A 90 min. timeout for the
entire build and a 60 min. timeout for the JUnit tests.

Whenever we want to adjust the timeout, we have to separate places to
edit (the pom.xml file on the test bundle and the Jenkinsfile). We
should drop the timeout of the tests and simply rely on the global
timeout.

Note that we GitHub workflow already has a timeout of 5h by default. It
is lowered to 90min to avoid excessive build times in case it ever gets
stuck and to keep in in sync with the Jenkins build.
