### PR TITLE
Update p2 repositories to their latest releases.

### DIFF
--- a/target-platform/wb.target
+++ b/target-platform/wb.target
@@ -3,7 +3,7 @@
 <target name="wb">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/releases/2022-09"/>
+			<repository location="https://download.eclipse.org/releases/2023-06"/>
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.wst.sse.core" version="0.0.0"/>
 			<unit id="org.eclipse.wst.sse.ui" version="0.0.0"/>
@@ -18,13 +18,16 @@
 			<unit id="org.eclipse.nebula.incubation.feature.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/gef/classic/latest/"/>
+			<repository location="https://download.eclipse.org/tools/gef/classic/releases/3.16.0/"/>
 			<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
 		</location>
 		<location type="Target" uri="file:${project_loc:/target-platform}/mvn/wb-mvn.target"/>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/oomph/simrel-maven/milestone/latest/"/>
-			<unit id="org.eclipse.oomph.maven.all.feature.group" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/oomph/simrel-maven/release/4.28.0"/>
+			<unit id="assertj-core" version="0.0.0"/>
+			<unit id="com.google.guava" version="0.0.0"/>
+			<unit id="org.apache.commons.collections" version="0.0.0"/>
+			<unit id="org.mockito.mockito-core" version="0.0.0"/>
 		</location>
 	</locations>
 </target>


### PR DESCRIPTION
This way WindowBuilder is built against the Eclipse 2023-06 and GEF 3.16. Furthermore, we list all required 3rd-party bundles from the SimRel repository, rather than simply importing everything.