### PR TITLE
Remove deleted IWorkbenchWindowConfigurer methods from wbp-component.xml

### DIFF
--- a/org.eclipse.wb.rcp/wbp-meta/org/eclipse/ui/application/IWorkbenchWindowConfigurer.wbp-component.xml
+++ b/org.eclipse.wb.rcp/wbp-meta/org/eclipse/ui/application/IWorkbenchWindowConfigurer.wbp-component.xml
@@ -6,9 +6,6 @@
 	<property id="setShowCoolBar(boolean)">
 		<defaultValue value="true"/>
 	</property>
-	<property id="setShowFastViewBars(boolean)">
-		<defaultValue value="false"/>
-	</property>
 	<property id="setShowMenuBar(boolean)">
 		<defaultValue value="true"/>
 	</property>

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/rcp/ActionBarAdvisorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/rcp/ActionBarAdvisorTest.java
@@ -277,7 +277,6 @@ public class ActionBarAdvisorTest extends RcpModelTest {
     assertNotNull(advisor.getPropertyByTitle("initialSize"));
     assertNotNull(advisor.getPropertyByTitle("shellStyle"));
     assertNotNull(advisor.getPropertyByTitle("showCoolBar"));
-    assertNotNull(advisor.getPropertyByTitle("showFastViewBars"));
     assertNotNull(advisor.getPropertyByTitle("showMenuBar"));
     assertNotNull(advisor.getPropertyByTitle("showPerspectiveBar"));
     assertNotNull(advisor.getPropertyByTitle("showProgressIndicator"));


### PR DESCRIPTION
This method has been deprecated decades ago and removed with the Eclipse 2022-12.