### PR TITLE
Remove deleted PopupDialog constructor from wbp-component.xml.

### DIFF
--- a/org.eclipse.wb.rcp/wbp-meta/org/eclipse/jface/dialogs/PopupDialog.wbp-component.xml
+++ b/org.eclipse.wb.rcp/wbp-meta/org/eclipse/jface/dialogs/PopupDialog.wbp-component.xml
@@ -10,6 +10,7 @@
 			<parameter type="boolean"/>
 			<parameter type="boolean"/>
 			<parameter type="boolean"/>
+			<parameter type="boolean"/>
 			<parameter type="java.lang.String" property="setTitleText(java.lang.String)"/>
 			<parameter type="java.lang.String" property="setInfoText(java.lang.String)"/>
 		</constructor>

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/PopupDialogTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/PopupDialogTest.java
@@ -41,7 +41,7 @@ public class PopupDialogTest extends RcpModelTest {
             "import org.eclipse.jface.dialogs.*;",
             "public class Test extends org.eclipse.jface.dialogs.PopupDialog {",
             "  public Test(Shell parentShell) {",
-            "    super(parentShell, SWT.DIALOG_TRIM, true, true, true, true, 'Title text', 'Info text');",
+            "    super(parentShell, SWT.DIALOG_TRIM, true, true, true, true, true, 'Title text', 'Info text');",
             "  }",
             "  protected Control createDialogArea(Composite parent) {",
             "    Composite container = (Composite) super.createDialogArea(parent);",
@@ -69,7 +69,7 @@ public class PopupDialogTest extends RcpModelTest {
             "import org.eclipse.jface.dialogs.*;",
             "public class Test extends org.eclipse.jface.dialogs.PopupDialog {",
             "  public Test(Shell parentShell) {",
-            "    super(parentShell, SWT.DIALOG_TRIM, true, true, true, true, 'Title text', 'Info text');",
+            "    super(parentShell, SWT.DIALOG_TRIM, true, true, true, true, true, 'Title text', 'Info text');",
             "  }",
             "}");
     // set properties
@@ -80,7 +80,7 @@ public class PopupDialogTest extends RcpModelTest {
         "import org.eclipse.jface.dialogs.*;",
         "public class Test extends org.eclipse.jface.dialogs.PopupDialog {",
         "  public Test(Shell parentShell) {",
-        "    super(parentShell, 0, true, true, true, true, 'New title text', 'New info text');",
+        "    super(parentShell, 0, true, true, true, true, true, 'New title text', 'New info text');",
         "  }",
         "}");
   }


### PR DESCRIPTION
This constructor has been removed with 2022-12. Use the non-deprecated constructor instead.