### PR TITLE
Fix: Swing components only partial captured when larger than screen

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/top/SwingTopBoundsSupport.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/top/SwingTopBoundsSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -69,7 +69,12 @@ public class SwingTopBoundsSupport extends TopBoundsSupport {
 		{
 			Component component = (Component) m_component.getObject();
 			org.eclipse.draw2d.geometry.Dimension size = getResourceSize();
-			component.setSize(size.width, size.height);
+			java.awt.Dimension awtSize = new java.awt.Dimension(size.width, size.height);
+			// The real size might be smaller than the preferred size (e.g. limited by the
+			// screen resolution). Store it as preferred size for later use when taking the
+			// screenshot.
+			component.setSize(awtSize);
+			component.setPreferredSize(awtSize);
 		}
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/top/JFrameTopBoundsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/top/JFrameTopBoundsTest.java
@@ -104,10 +104,21 @@ public class JFrameTopBoundsTest extends SwingGefTest {
 				"  }",
 				"}"));
 		waitForAutoBuild();
-		//
+		// Expand horizontally
 		Dimension oldSize = new Dimension(500, 400);
-		Dimension resizeSize = new Dimension(5000, 5000);
+		Dimension resizeSize = new Dimension(5000, 400);
 		ICompilationUnit unit = check_resize("MyVeryBigFrame",
+				"// no size",
+				"// none",
+				oldSize,
+				resizeSize,
+				resizeSize,
+				"// no size");
+		assert_sameSizeAfterReparse(unit, resizeSize);
+		// Expand vertically
+		oldSize = new Dimension(5000, 400);
+		resizeSize = new Dimension(500, 4000);
+		unit = check_resize("MyVeryBigFrame",
 				"// no size",
 				"// none",
 				oldSize,

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/top/JFrameTopBoundsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/top/JFrameTopBoundsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -89,6 +89,31 @@ public class JFrameTopBoundsTest extends SwingGefTest {
 						resizeSize,
 						resizeSize,
 						"// no size");
+		assert_sameSizeAfterReparse(unit, resizeSize);
+	}
+
+	/**
+	 * The size of the JFrame should be able to exceed the display resolution.
+	 */
+	@Test
+	public void test_JFrame_veryBig() throws Exception {
+		setFileContentSrc("test/MyVeryBigFrame.java",
+				getTestSource("public class MyVeryBigFrame extends JFrame {",
+				"  public MyVeryBigFrame() {",
+				"    setSize(500, 400);",
+				"  }",
+				"}"));
+		waitForAutoBuild();
+		//
+		Dimension oldSize = new Dimension(500, 400);
+		Dimension resizeSize = new Dimension(5000, 5000);
+		ICompilationUnit unit = check_resize("MyVeryBigFrame",
+				"// no size",
+				"// none",
+				oldSize,
+				resizeSize,
+				resizeSize,
+				"// no size");
 		assert_sameSizeAfterReparse(unit, resizeSize);
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/top/JPanelTopBoundsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/top/JPanelTopBoundsTest.java
@@ -94,13 +94,22 @@ public class JPanelTopBoundsTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_resize_veryBig() throws Exception {
+		// expand horizontally
 		Dimension oldSize = new Dimension(500, 400);
-		Dimension newSize = new Dimension(5000, 5000);
+		Dimension newSize = new Dimension(5000, 400);
 		check_resize_JPanel(
 				"setSize(new Dimension(500, 400));",
 				oldSize,
 				newSize,
-				"setSize(new Dimension(5000, 5000));");
+				"setSize(new Dimension(5000, 400));");
+		// expand vertically
+		oldSize = new Dimension(5000, 400);
+		newSize = new Dimension(500, 4000);
+		check_resize_JPanel(
+				"setSize(new Dimension(5000, 400));",
+				oldSize,
+				newSize,
+				"setSize(new Dimension(500, 4000));");
 	}
 
 	/**

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/top/JPanelTopBoundsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/top/JPanelTopBoundsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -87,6 +87,20 @@ public class JPanelTopBoundsTest extends SwingGefTest {
 		Dimension oldSize = new Dimension(300, 200);
 		Dimension newSize = new Dimension(400, 300);
 		check_resize_JPanel("setSize(300, 200);", oldSize, newSize, "setSize(400, 300);");
+	}
+
+	/**
+	 * The size of the JPanel should be able to exceed the display resolution.
+	 */
+	@Test
+	public void test_resize_veryBig() throws Exception {
+		Dimension oldSize = new Dimension(500, 400);
+		Dimension newSize = new Dimension(5000, 5000);
+		check_resize_JPanel(
+				"setSize(new Dimension(500, 400));",
+				oldSize,
+				newSize,
+				"setSize(new Dimension(5000, 5000));");
 	}
 
 	/**


### PR DESCRIPTION
When the size of the frame exceeds the size of the screen, then the
frame will be maximized instead. As a result, the edges of the frame
outside the visible area won't be captured. This behavior can be
explicitly disabled by simply clearing the "resizable" flag.