### PR TITLE
Update Tycho to the 4.0.0 nightly build.

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -27,6 +27,10 @@ jobs:
         distribution: 'temurin' # See 'Supported distributions' for available options
         java-version: ${{ matrix.java }}
         cache: 'maven'
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v4.5
+      with:
+        maven-version: 3.9.2
     - name: Build with Maven
       uses: coactions/setup-xvfb@v1
       with:

--- a/pom.xml
+++ b/pom.xml
@@ -19,10 +19,17 @@
 
 
   <properties>
-    <tycho.version>3.0.4</tycho.version>
+    <tycho.version>4.0.0-SNAPSHOT</tycho.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <eclipse-jarsigner-version>1.3.2</eclipse-jarsigner-version>
   </properties>
+  
+  <pluginRepositories>
+    <pluginRepository>
+        <id>tycho-snapshots</id>
+        <url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
 
   <profiles>
     <profile>


### PR DESCRIPTION
Resolving the target-platform definition currently takes forever... Let's try and see if the latest Tycho version can do better.

#481 