### PR TITLE
IPalettePreferences should use FontDescriptor instead of Font

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/PluginPalettePreferences.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/PluginPalettePreferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,12 +13,11 @@ package org.eclipse.wb.internal.core.editor.palette;
 import org.eclipse.wb.core.controls.palette.ICategory;
 import org.eclipse.wb.core.controls.palette.IEntry;
 import org.eclipse.wb.core.controls.palette.IPalettePreferences;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.PreferenceConverter;
+import org.eclipse.jface.resource.FontDescriptor;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.widgets.Display;
 
@@ -30,8 +29,8 @@ import org.eclipse.swt.widgets.Display;
  */
 public final class PluginPalettePreferences implements IPalettePreferences {
   private final IPreferenceStore m_store;
-  private Font m_categoryFont;
-  private Font m_entryFont;
+  private FontDescriptor m_categoryFont;
+  private FontDescriptor m_entryFont;
 
   ////////////////////////////////////////////////////////////////////////////
   //
@@ -87,19 +86,19 @@ public final class PluginPalettePreferences implements IPalettePreferences {
   //
   ////////////////////////////////////////////////////////////////////////////
   @Override
-  public Font getCategoryFont() {
+  public FontDescriptor getCategoryFontDescriptor() {
     if (m_categoryFont == null) {
       FontData[] fontDataArray = PreferenceConverter.getFontDataArray(m_store, m_categoryFontKey);
-      m_categoryFont = SwtResourceManager.getFont(fontDataArray);
+      m_categoryFont = FontDescriptor.createFrom(fontDataArray);
     }
     return m_categoryFont;
   }
 
   @Override
-  public Font getEntryFont() {
+  public FontDescriptor getEntryFontDescriptor() {
     if (m_entryFont == null) {
       FontData[] fontDataArray = PreferenceConverter.getFontDataArray(m_store, m_entryFontKey);
-      m_entryFont = SwtResourceManager.getFont(fontDataArray);
+      m_entryFont = FontDescriptor.createFrom(fontDataArray);
     }
     return m_entryFont;
   }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/dialogs/PalettePreferencesDialog.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/dialogs/PalettePreferencesDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -115,8 +115,8 @@ public final class PalettePreferencesDialog extends AbstractPaletteDialog {
     }
     // initialize fields
     m_minColumnsField.setSelection(new int[]{m_preferences.getMinColumns() - 1});
-    m_categoryFontField.setFontDataArray(m_preferences.getCategoryFont().getFontData());
-    m_entryFontField.setFontDataArray(m_preferences.getEntryFont().getFontData());
+    m_categoryFontField.setFontDataArray(m_preferences.getCategoryFontDescriptor().getFontData());
+    m_entryFontField.setFontDataArray(m_preferences.getEntryFontDescriptor().getFontData());
     m_layoutDialogField.setSelection(new int[]{m_preferences.getLayoutType()});
   }
 

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/editor/palette/PluginPalettePreferences.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/editor/palette/PluginPalettePreferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,12 +14,11 @@ import org.eclipse.wb.core.controls.palette.ICategory;
 import org.eclipse.wb.core.controls.palette.IEntry;
 import org.eclipse.wb.core.controls.palette.IPalettePreferences;
 import org.eclipse.wb.internal.core.editor.palette.DesignerPalette;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.PreferenceConverter;
+import org.eclipse.jface.resource.FontDescriptor;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.widgets.Display;
 
@@ -31,8 +30,8 @@ import org.eclipse.swt.widgets.Display;
  */
 public final class PluginPalettePreferences implements IPalettePreferences {
   private final IPreferenceStore m_store;
-  private Font m_categoryFont;
-  private Font m_entryFont;
+  private FontDescriptor m_categoryFont;
+  private FontDescriptor m_entryFont;
 
   ////////////////////////////////////////////////////////////////////////////
   //
@@ -87,19 +86,19 @@ public final class PluginPalettePreferences implements IPalettePreferences {
   //
   ////////////////////////////////////////////////////////////////////////////
   @Override
-  public Font getCategoryFont() {
+  public FontDescriptor getCategoryFontDescriptor() {
     if (m_categoryFont == null) {
       FontData[] fontDataArray = PreferenceConverter.getFontDataArray(m_store, m_categoryFontKey);
-      m_categoryFont = SwtResourceManager.getFont(fontDataArray);
+      m_categoryFont = FontDescriptor.createFrom(fontDataArray);
     }
     return m_categoryFont;
   }
 
   @Override
-  public Font getEntryFont() {
+  public FontDescriptor getEntryFontDescriptor() {
     if (m_entryFont == null) {
       FontData[] fontDataArray = PreferenceConverter.getFontDataArray(m_store, m_entryFontKey);
-      m_entryFont = SwtResourceManager.getFont(fontDataArray);
+      m_entryFont = FontDescriptor.createFrom(fontDataArray);
     }
     return m_entryFont;
   }

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/editor/palette/dialogs/PalettePreferencesDialog.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/editor/palette/dialogs/PalettePreferencesDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -109,8 +109,8 @@ public final class PalettePreferencesDialog extends AbstractPaletteDialog {
     // initialize fields
     m_onlyIconsField.setSelection(m_preferences.isOnlyIcons());
     m_minColumnsField.setSelection(new int[]{m_preferences.getMinColumns() - 1});
-    m_categoryFontField.setFontDataArray(m_preferences.getCategoryFont().getFontData());
-    m_entryFontField.setFontDataArray(m_preferences.getEntryFont().getFontData());
+    m_categoryFontField.setFontDataArray(m_preferences.getCategoryFontDescriptor().getFontData());
+    m_entryFontField.setFontDataArray(m_preferences.getEntryFontDescriptor().getFontData());
   }
 
   ////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.core;singleton:=true
-Bundle-Version: 1.12.1.qualifier
+Bundle-Version: 1.13.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.core.DesignerPlugin

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/DefaultPalettePreferences.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/DefaultPalettePreferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.eclipse.wb.core.controls.palette;
 
-import org.eclipse.swt.graphics.Font;
+import org.eclipse.jface.resource.FontDescriptor;
 
 /**
  * The default implementation of {@link IPalettePreferences}.
@@ -21,12 +21,12 @@ import org.eclipse.swt.graphics.Font;
  */
 public final class DefaultPalettePreferences implements IPalettePreferences {
   @Override
-  public Font getCategoryFont() {
+  public FontDescriptor getCategoryFontDescriptor() {
     return null;
   }
 
   @Override
-  public Font getEntryFont() {
+  public FontDescriptor getEntryFontDescriptor() {
     return null;
   }
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/IPalettePreferences.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/IPalettePreferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.eclipse.wb.core.controls.palette;
 
-import org.eclipse.swt.graphics.Font;
+import org.eclipse.jface.resource.FontDescriptor;
 
 /**
  * Provider for preferences of {@link PaletteComposite}.
@@ -21,14 +21,14 @@ import org.eclipse.swt.graphics.Font;
  */
 public interface IPalettePreferences {
   /**
-   * @return the {@link Font} for {@link ICategory}.
+   * @return the {@link FontDescriptor} for {@link ICategory}.
    */
-  Font getCategoryFont();
+  FontDescriptor getCategoryFontDescriptor();
 
   /**
-   * @return the {@link Font} for {@link IEntry}.
+   * @return the {@link FontDescriptor} for {@link IEntry}.
    */
-  Font getEntryFont();
+  FontDescriptor getEntryFontDescriptor();
 
   /**
    * @return <code>true</code> if only icons should be displayed for {@link IEntry}'s.

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -32,6 +32,9 @@ import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.resource.LocalResourceManager;
+import org.eclipse.jface.resource.ResourceManager;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.GC;
@@ -105,6 +108,7 @@ public final class PaletteComposite extends Composite {
   private final PaletteFigure m_paletteFigure;
   private final Layer m_feedbackLayer;
   private final Map<ICategory, CategoryFigure> m_categoryFigures = new HashMap<>();
+  private final ResourceManager m_resourceManager = new LocalResourceManager(JFaceResources.getResources());
   private MenuManager m_menuManager;
   private IPalette m_palette;
   private IEntry m_selectedEntry;
@@ -177,6 +181,18 @@ public final class PaletteComposite extends Composite {
     }
     // add actions
     m_palette.addPopupActions(menuManager, targetObject, m_layoutType);
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  //
+  // Dispose
+  //
+  ////////////////////////////////////////////////////////////////////////////
+
+  @Override
+  public void dispose() {
+    super.dispose();
+    m_resourceManager.dispose();
   }
 
   ////////////////////////////////////////////////////////////////////////////
@@ -383,7 +399,7 @@ public final class PaletteComposite extends Composite {
      * This method is invoked when {@link IPalettePreferences} changes.
      */
     public void onPreferencesUpdate() {
-      setFont(m_preferences.getCategoryFont());
+      setFont(m_resourceManager.createFont(m_preferences.getCategoryFontDescriptor()));
       for (Iterator<Figure> I = getChildren().iterator(); I.hasNext();) {
         EntryFigure entryFigure = (EntryFigure) I.next();
         entryFigure.onPreferencesUpdate();
@@ -723,7 +739,7 @@ public final class PaletteComposite extends Composite {
      * This method is invoked when {@link IPalettePreferences} changes.
      */
     public void onPreferencesUpdate() {
-      setFont(m_preferences.getEntryFont());
+      setFont(m_resourceManager.createFont(m_preferences.getEntryFontDescriptor()));
     }
 
     ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Unlike a Font, a FontDescriptor doesn't need to be explicitly disposed, minimizing the chance of a resource leak. The JFace ResourceManager may be used to manage multiple Font objects created from this descriptor.

Prerequisite for deprecating the SwtResourceManager.

See #260 #486 