### PR TITLE
Switch to the ImageDescriptor for IEntry instead of Image.

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPalette.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPalette.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 Google, Inc. and Others.
+ * Copyright (c) 2011, 2023 Google, Inc. and Others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -64,9 +64,9 @@ import org.eclipse.core.runtime.jobs.IJobManager;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jface.action.IMenuManager;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
@@ -277,8 +277,8 @@ public class DesignerPalette {
 					}
 
 					@Override
-					public Image getIcon() {
-						return entryInfo.getIcon();
+					public ImageDescriptor getIcon() {
+						return ImageDescriptor.createFromImage(entryInfo.getIcon());
 					}
 
 					@Override

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/editor/palette/DesignerPalette.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/editor/palette/DesignerPalette.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -53,9 +53,9 @@ import org.eclipse.wb.internal.gef.core.IDefaultToolProvider;
 import org.eclipse.core.runtime.jobs.IJobManager;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.action.IMenuManager;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
@@ -261,8 +261,8 @@ public class DesignerPalette {
 					}
 
 					@Override
-					public Image getIcon() {
-						return entryInfo.getIcon();
+					public ImageDescriptor getIcon() {
+						return ImageDescriptor.createFromImage(entryInfo.getIcon());
 					}
 
 					@Override

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/IEntry.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/IEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.wb.core.controls.palette;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * Single entry on {@link PaletteComposite}.
@@ -32,7 +32,7 @@ public interface IEntry {
 	/**
 	 * @return the icon of {@link IEntry}.
 	 */
-	Image getIcon();
+	ImageDescriptor getIcon();
 
 	/**
 	 * @return the title text of {@link IEntry}.

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
@@ -33,6 +33,7 @@ import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.resource.FontDescriptor;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.resource.LocalResourceManager;
 import org.eclipse.jface.resource.ResourceManager;
@@ -1089,9 +1090,9 @@ public final class PaletteComposite extends Composite {
 		 * @return the icon of this entry.
 		 */
 		private Image getIcon() {
-			Image icon = m_entry.getIcon();
-			if (icon != null && !icon.isDisposed()) {
-				return icon;
+			ImageDescriptor icon = m_entry.getIcon();
+			if (icon != null) {
+				return m_resourceManager.createImage(icon);
 			}
 			return NO_ICON;
 		}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/test/PaletteTest.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/test/PaletteTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,6 +24,7 @@ import org.eclipse.wb.draw2d.IColorConstants;
 import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 
 import org.eclipse.jface.action.IMenuManager;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.GC;
@@ -136,14 +137,14 @@ public class PaletteTest implements IColorConstants {
 	/**
 	 * @return the test icon.
 	 */
-	private final Image createIcon(Color color) {
+	private final ImageDescriptor createIcon(Color color) {
 		int size = 16;
 		Image image = new Image(shell.getDisplay(), size, size);
 		GC gc = new GC(image);
 		gc.setBackground(color);
 		gc.fillRectangle(0, 0, size, size);
 		gc.dispose();
-		return image;
+		return ImageDescriptor.createFromImage(image);
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -256,7 +257,7 @@ public class PaletteTest implements IColorConstants {
 	////////////////////////////////////////////////////////////////////////////
 	private static final class EntryImpl implements IEntry {
 		private final boolean m_enabled;
-		private final Image m_icon;
+		private final ImageDescriptor m_icon;
 		private final String m_text;
 
 		////////////////////////////////////////////////////////////////////////////
@@ -264,7 +265,7 @@ public class PaletteTest implements IColorConstants {
 		// Constructor
 		//
 		////////////////////////////////////////////////////////////////////////////
-		public EntryImpl(boolean enabled, Image icon, String text) {
+		public EntryImpl(boolean enabled, ImageDescriptor icon, String text) {
 			m_enabled = enabled;
 			m_icon = icon;
 			m_text = text;
@@ -281,7 +282,7 @@ public class PaletteTest implements IColorConstants {
 		}
 
 		@Override
-		public Image getIcon() {
+		public ImageDescriptor getIcon() {
 			return m_icon;
 		}
 


### PR DESCRIPTION
ImageDescriptors don't need to be explicitly disposed, reducing the change of a potential resource leak. Where necessary, the corresponding instance is created within the palette-composite via a local resource manager.

#260 #486 