### PR TITLE
Switch to the ImageDescriptor in EntryInfo instead of Image.

### DIFF
--- a/org.eclipse.wb.core.java/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core.java/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.core.java;singleton:=true
-Bundle-Version: 1.9.4.qualifier
+Bundle-Version: 1.10.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.core.java.Activator
 Bundle-Vendor: %providerName

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/core/editor/palette/model/EntryInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/core/editor/palette/model/EntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,7 @@ import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.state.EditorState;
 
 import org.eclipse.jdt.core.IJavaProject;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * Model of entry on palette.
@@ -62,7 +62,7 @@ public abstract class EntryInfo extends AbstractElementInfo {
 	/**
 	 * @return the icon for visual.
 	 */
-	public abstract Image getIcon();
+	public abstract ImageDescriptor getIcon();
 
 	////////////////////////////////////////////////////////////////////////////
 	//

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/core/editor/palette/model/entry/ChooseComponentEntryInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/core/editor/palette/model/entry/ChooseComponentEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,7 +26,7 @@ import org.eclipse.wb.internal.core.utils.jdt.core.CodeUtils;
 import org.eclipse.wb.internal.core.utils.jdt.ui.JdtUiUtils;
 
 import org.eclipse.jface.dialogs.MessageDialog;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.widgets.Shell;
 
 import java.text.MessageFormat;
@@ -40,7 +40,7 @@ import java.util.List;
  * @coverage core.editor.palette
  */
 public final class ChooseComponentEntryInfo extends ToolEntryInfo {
-	private static final Image ICON = DesignerPlugin.getImage("palette/ChooseComponent.gif");
+	private static final ImageDescriptor ICON = DesignerPlugin.getImageDescriptor("palette/ChooseComponent.gif");
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -58,7 +58,7 @@ public final class ChooseComponentEntryInfo extends ToolEntryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		return ICON;
 	}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/core/editor/palette/model/entry/ComponentEntryInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/core/editor/palette/model/entry/ComponentEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -49,6 +49,7 @@ import org.eclipse.wb.internal.core.utils.ui.UiUtils;
 
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Shell;
@@ -70,7 +71,7 @@ import java.util.WeakHashMap;
  */
 public final class ComponentEntryInfo extends ToolEntryInfo {
 	public static final String KEY_SIMULATE_PRESENTATION = "ComponentEntryInfo.simulatePresentation";
-	public static final Image DEFAULT_ICON = DesignerPlugin.getImage("palette/Object.png");
+	public static final ImageDescriptor DEFAULT_ICON = DesignerPlugin.getImageDescriptor("palette/Object.png");
 	private String m_className;
 	private String m_creationId;
 	private String m_enabledScript;
@@ -308,11 +309,11 @@ public final class ComponentEntryInfo extends ToolEntryInfo {
 	}
 
 	@Override
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		if (m_icon == null) {
 			return DEFAULT_ICON;
 		}
-		return m_icon;
+		return ImageDescriptor.createFromImage(m_icon);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/core/editor/palette/model/entry/MarqueeSelectionToolEntryInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/core/editor/palette/model/entry/MarqueeSelectionToolEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,7 @@ import org.eclipse.wb.gef.graphical.tools.MarqueeSelectionTool;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.editor.Messages;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * Implementation of {@link EntryInfo} that activates {@link MarqueeSelectionTool}.
@@ -25,7 +25,7 @@ import org.eclipse.swt.graphics.Image;
  * @coverage core.editor.palette
  */
 public final class MarqueeSelectionToolEntryInfo extends ToolEntryInfo {
-	private static final Image ICON = DesignerPlugin.getImage("palette/MarqueeSelectionTool.png");
+	private static final ImageDescriptor ICON = DesignerPlugin.getImageDescriptor("palette/MarqueeSelectionTool.png");
 	private final MarqueeSelectionTool m_marqueeSelectionTool = new MarqueeSelectionTool();
 
 	////////////////////////////////////////////////////////////////////////////
@@ -43,7 +43,7 @@ public final class MarqueeSelectionToolEntryInfo extends ToolEntryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		return ICON;
 	}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/core/editor/palette/model/entry/SelectionToolEntryInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/core/editor/palette/model/entry/SelectionToolEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,7 @@ import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.editor.Messages;
 import org.eclipse.wb.internal.core.editor.palette.model.entry.IDefaultEntryInfo;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * Implementation of {@link EntryInfo} that activates {@link SelectionTool}.
@@ -26,7 +26,7 @@ import org.eclipse.swt.graphics.Image;
  * @coverage core.editor.palette
  */
 public class SelectionToolEntryInfo extends ToolEntryInfo implements IDefaultEntryInfo {
-	private static final Image ICON = DesignerPlugin.getImage("palette/SelectionTool.gif");
+	private static final ImageDescriptor ICON = DesignerPlugin.getImageDescriptor("palette/SelectionTool.gif");
 	private final SelectionTool m_selectionTool = new SelectionTool();
 
 	////////////////////////////////////////////////////////////////////////////
@@ -44,7 +44,7 @@ public class SelectionToolEntryInfo extends ToolEntryInfo implements IDefaultEnt
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		return ICON;
 	}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/core/editor/palette/model/entry/TabOrderToolEntryInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/core/editor/palette/model/entry/TabOrderToolEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,7 @@ import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.editor.Messages;
 import org.eclipse.wb.internal.core.gef.tools.TabOrderTool;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.util.List;
 
@@ -28,7 +28,7 @@ import java.util.List;
  * @coverage core.editor.palette
  */
 public final class TabOrderToolEntryInfo extends ToolEntryInfo {
-	private static final Image ICON = DesignerPlugin.getImage("palette/tab_order.gif");
+	private static final ImageDescriptor ICON = DesignerPlugin.getImageDescriptor("palette/tab_order.gif");
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -58,7 +58,7 @@ public final class TabOrderToolEntryInfo extends ToolEntryInfo {
 	}
 
 	@Override
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		return ICON;
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPalette.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPalette.java
@@ -278,7 +278,7 @@ public class DesignerPalette {
 
 					@Override
 					public ImageDescriptor getIcon() {
-						return ImageDescriptor.createFromImage(entryInfo.getIcon());
+						return entryInfo.getIcon();
 					}
 
 					@Override

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/dialogs/PaletteManagerDialog.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/dialogs/PaletteManagerDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -44,6 +44,9 @@ import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.action.Separator;
 import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.resource.LocalResourceManager;
+import org.eclipse.jface.resource.ResourceManager;
 import org.eclipse.jface.viewers.CheckStateChangedEvent;
 import org.eclipse.jface.viewers.CheckboxTreeViewer;
 import org.eclipse.jface.viewers.DoubleClickEvent;
@@ -85,6 +88,7 @@ import org.apache.commons.lang.ArrayUtils;
 
 import java.text.MessageFormat;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -355,10 +359,20 @@ public final class PaletteManagerDialog extends ResizableTitleAreaDialog {
 		// providers
 		m_viewer.setContentProvider(m_contentProvider);
 		m_viewer.setLabelProvider(new LabelProvider() {
+			private final ResourceManager m_resourceManager = new LocalResourceManager(JFaceResources.getResources());
+
+			@Override
+			public void dispose() {
+				super.dispose();
+				m_resourceManager.dispose();
+			}
+
 			@Override
 			public Image getImage(Object element) {
 				if (element instanceof EntryInfo) {
-					return ((EntryInfo) element).getIcon();
+					return Optional.ofNullable(((EntryInfo) element).getIcon()) //
+							.map(m_resourceManager::createImage) //
+							.orElse(null);
 				}
 				return IMAGE_CATEGORY;
 			}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/model/entry/FactoryEntryInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/model/entry/FactoryEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,6 +27,7 @@ import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.jdt.core.ProjectUtils;
 import org.eclipse.wb.internal.core.utils.state.EditorWarning;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
 
 import org.apache.commons.lang.StringUtils;
@@ -229,8 +230,8 @@ public abstract class FactoryEntryInfo extends ToolEntryInfo {
 	}
 
 	@Override
-	public final Image getIcon() {
-		return m_icon;
+	public final ImageDescriptor getIcon() {
+		return ImageDescriptor.createFromImage(m_icon);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/editor/palette/DesignerPalette.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/editor/palette/DesignerPalette.java
@@ -262,7 +262,7 @@ public class DesignerPalette {
 
 					@Override
 					public ImageDescriptor getIcon() {
-						return ImageDescriptor.createFromImage(entryInfo.getIcon());
+						return entryInfo.getIcon();
 					}
 
 					@Override

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/editor/palette/dialogs/PaletteManagerDialog.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/editor/palette/dialogs/PaletteManagerDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -38,6 +38,9 @@ import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.resource.LocalResourceManager;
+import org.eclipse.jface.resource.ResourceManager;
 import org.eclipse.jface.viewers.CheckStateChangedEvent;
 import org.eclipse.jface.viewers.CheckboxTreeViewer;
 import org.eclipse.jface.viewers.DoubleClickEvent;
@@ -79,6 +82,7 @@ import org.apache.commons.lang.ArrayUtils;
 
 import java.text.MessageFormat;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -351,10 +355,20 @@ public final class PaletteManagerDialog extends ResizableTitleAreaDialog {
 		// providers
 		m_viewer.setContentProvider(m_contentProvider);
 		m_viewer.setLabelProvider(new LabelProvider() {
+			private final ResourceManager m_resourceManager = new LocalResourceManager(JFaceResources.getResources());
+
+			@Override
+			public void dispose() {
+				super.dispose();
+				m_resourceManager.dispose();
+			}
+
 			@Override
 			public Image getImage(Object element) {
 				if (element instanceof EntryInfo) {
-					return ((EntryInfo) element).getIcon();
+					return Optional.ofNullable(((EntryInfo) element).getIcon()) //
+							.map(m_resourceManager::createImage) //
+							.orElse(null);
 				}
 				return IMAGE_CATEGORY;
 			}

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/editor/palette/model/ChooseComponentEntryInfo.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/editor/palette/model/ChooseComponentEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ import org.eclipse.wb.internal.core.xml.editor.palette.command.CategoryAddComman
 import org.eclipse.wb.internal.core.xml.editor.palette.command.Command;
 import org.eclipse.wb.internal.core.xml.editor.palette.command.ComponentAddCommand;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.widgets.Shell;
 
 import java.text.MessageFormat;
@@ -34,7 +34,7 @@ import java.util.List;
  * @coverage XML.editor.palette
  */
 public final class ChooseComponentEntryInfo extends ToolEntryInfo {
-	private static final Image ICON = DesignerPlugin.getImage("palette/ChooseComponent.gif");
+	private static final ImageDescriptor ICON = DesignerPlugin.getImageDescriptor("palette/ChooseComponent.gif");
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -52,7 +52,7 @@ public final class ChooseComponentEntryInfo extends ToolEntryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		return ICON;
 	}
 

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/editor/palette/model/ComponentEntryInfo.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/editor/palette/model/ComponentEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -40,6 +40,7 @@ import org.eclipse.wb.internal.core.xml.model.description.CreationDescription;
 import org.eclipse.wb.internal.core.xml.model.utils.XmlObjectUtils;
 
 import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Shell;
 
@@ -58,7 +59,7 @@ import java.util.WeakHashMap;
  */
 public final class ComponentEntryInfo extends ToolEntryInfo {
 	public static final String KEY_SIMULATE_PRESENTATION = "ComponentEntryInfo.simulatePresentation";
-	public static final Image DEFAULT_ICON = DesignerPlugin.getImage("palette/Object.png");
+	public static final ImageDescriptor DEFAULT_ICON = DesignerPlugin.getImageDescriptor("palette/Object.png");
 	private String m_className;
 	private String m_creationId;
 	private String m_enabledScript;
@@ -296,11 +297,11 @@ public final class ComponentEntryInfo extends ToolEntryInfo {
 	}
 
 	@Override
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		if (m_icon == null) {
 			return DEFAULT_ICON;
 		}
-		return m_icon;
+		return ImageDescriptor.createFromImage(m_icon);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/editor/palette/model/EntryInfo.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/editor/palette/model/EntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,7 @@ import org.eclipse.wb.internal.core.xml.model.EditorContext;
 import org.eclipse.wb.internal.core.xml.model.XmlObjectInfo;
 
 import org.eclipse.jdt.core.IJavaProject;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * Model of entry on palette.
@@ -59,7 +59,7 @@ public abstract class EntryInfo extends AbstractElementInfo {
 	/**
 	 * @return the icon for visual.
 	 */
-	public abstract Image getIcon();
+	public abstract ImageDescriptor getIcon();
 
 	////////////////////////////////////////////////////////////////////////////
 	//

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/editor/palette/model/MarqueeSelectionToolEntryInfo.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/editor/palette/model/MarqueeSelectionToolEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,7 @@ import org.eclipse.wb.gef.graphical.tools.MarqueeSelectionTool;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.xml.Messages;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * Implementation of {@link EntryInfo} that activates {@link MarqueeSelectionTool}.
@@ -24,7 +24,7 @@ import org.eclipse.swt.graphics.Image;
  * @coverage XML.editor.palette
  */
 public final class MarqueeSelectionToolEntryInfo extends ToolEntryInfo {
-	private static final Image ICON = DesignerPlugin.getImage("palette/MarqueeSelectionTool.png");
+	private static final ImageDescriptor ICON = DesignerPlugin.getImageDescriptor("palette/MarqueeSelectionTool.png");
 	private final MarqueeSelectionTool m_marqueeSelectionTool = new MarqueeSelectionTool();
 
 	////////////////////////////////////////////////////////////////////////////
@@ -42,7 +42,7 @@ public final class MarqueeSelectionToolEntryInfo extends ToolEntryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		return ICON;
 	}
 

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/editor/palette/model/SelectionToolEntryInfo.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/editor/palette/model/SelectionToolEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,7 @@ import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.editor.palette.model.entry.IDefaultEntryInfo;
 import org.eclipse.wb.internal.core.xml.Messages;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * Implementation of {@link EntryInfo} that activates {@link SelectionTool}.
@@ -25,7 +25,7 @@ import org.eclipse.swt.graphics.Image;
  * @coverage XML.editor.palette
  */
 public class SelectionToolEntryInfo extends ToolEntryInfo implements IDefaultEntryInfo {
-	private static final Image ICON = DesignerPlugin.getImage("palette/SelectionTool.gif");
+	private static final ImageDescriptor ICON = DesignerPlugin.getImageDescriptor("palette/SelectionTool.gif");
 	private final SelectionTool m_selectionTool = new SelectionTool();
 
 	////////////////////////////////////////////////////////////////////////////
@@ -43,7 +43,7 @@ public class SelectionToolEntryInfo extends ToolEntryInfo implements IDefaultEnt
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		return ICON;
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/ui/UiUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/ui/UiUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ import com.google.common.collect.Lists;
 
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.FocusListener;
 import org.eclipse.swt.events.MenuAdapter;
@@ -544,8 +545,32 @@ public class UiUtils {
 			return false;
 		}
 		// check ImageData's
-		ImageData imageData_1 = image_1.getImageData();
-		ImageData imageData_2 = image_2.getImageData();
+		return equals(image_1.getImageData(), image_2.getImageData());
+	}
+
+	/**
+	 * @return <code>true</code> if two {@link ImageDescriptor}'s are equal.
+	 */
+	public static boolean equals(ImageDescriptor imageDesc_1, ImageDescriptor imageDesc_2) {
+		// try to compare as plain Object's
+		if (ObjectUtils.equals(imageDesc_1, imageDesc_2)) {
+			return true;
+		}
+		// compare bounds
+		if (imageDesc_1.getImageData(100).width != imageDesc_2.getImageData(100).width) {
+			return false;
+		}
+		if (imageDesc_1.getImageData(100).height != imageDesc_2.getImageData(100).height) {
+			return false;
+		}
+		// check ImageData's
+		return equals(imageDesc_1.getImageData(100), imageDesc_2.getImageData(100));
+	}
+
+	/**
+	 * @return <code>true</code> if two {@link ImageData}'s are equal.
+	 */
+	private static boolean equals(ImageData imageData_1, ImageData imageData_2) {
 		if (imageData_1.depth != imageData_2.depth) {
 			return false;
 		}

--- a/org.eclipse.wb.rcp.SWT_AWT/src/org/eclipse/wb/internal/rcp/swtawt/palette/SwingCompositeEntryInfo.java
+++ b/org.eclipse.wb.rcp.SWT_AWT/src/org/eclipse/wb/internal/rcp/swtawt/palette/SwingCompositeEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,9 +29,9 @@ import org.eclipse.wb.internal.rcp.swtawt.Messages;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 import org.eclipse.wb.internal.swing.model.layout.BorderLayoutInfo;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.awt.SWT_AWT;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
 
 import java.awt.BorderLayout;
@@ -46,7 +46,7 @@ import javax.swing.JRootPane;
  * @coverage rcp.editor.palette
  */
 public final class SwingCompositeEntryInfo extends ToolEntryInfo {
-	private static final Image ICON = Activator.getImage("info/SWT_AWT/Composite_SWT_AWT.png");
+	private static final ImageDescriptor ICON = Activator.getImageDescriptor("info/SWT_AWT/Composite_SWT_AWT.png");
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -65,7 +65,7 @@ public final class SwingCompositeEntryInfo extends ToolEntryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		return ICON;
 	}
 

--- a/org.eclipse.wb.rcp.nebula/src/org/eclipse/wb/internal/rcp/nebula/Activator.java
+++ b/org.eclipse.wb.rcp.nebula/src/org/eclipse/wb/internal/rcp/nebula/Activator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@ package org.eclipse.wb.internal.rcp.nebula;
 
 import org.eclipse.wb.internal.core.BundleResourceProvider;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 
@@ -68,5 +69,12 @@ public class Activator extends AbstractUIPlugin {
 	 */
 	public static Image getImage(String path) {
 		return m_resourceProvider.getImage(path);
+	}
+
+	/**
+	 * @return the {@link ImageDescriptor} from "/" directory, with caching.
+	 */
+	public static ImageDescriptor getImageDescriptor(String path) {
+		return m_resourceProvider.getImageDescriptor(path);
 	}
 }

--- a/org.eclipse.wb.rcp.nebula/src/org/eclipse/wb/internal/rcp/nebula/collapsiblebuttons/CollapsibleButtonEntryInfo.java
+++ b/org.eclipse.wb.rcp.nebula/src/org/eclipse/wb/internal/rcp/nebula/collapsiblebuttons/CollapsibleButtonEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,7 @@ import org.eclipse.wb.internal.core.utils.jdt.core.ProjectUtils;
 import org.eclipse.wb.internal.rcp.nebula.Activator;
 import org.eclipse.wb.internal.rcp.nebula.Messages;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * {@link EntryInfo} that allows user to drop new {@link CustomButton} on {@link CollapsibleButtons}
@@ -29,8 +29,8 @@ import org.eclipse.swt.graphics.Image;
  * @coverage nebula.palette
  */
 public final class CollapsibleButtonEntryInfo extends ToolEntryInfo {
-	private static final Image ICON =
-			Activator.getImage("wbp-meta/org/eclipse/nebula/widgets/collapsiblebuttons/CustomButton.png");
+	private static final ImageDescriptor ICON = Activator
+			.getImageDescriptor("wbp-meta/org/eclipse/nebula/widgets/collapsiblebuttons/CustomButton.png");
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -48,7 +48,7 @@ public final class CollapsibleButtonEntryInfo extends ToolEntryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		return ICON;
 	}
 

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/ActionExternalEntryInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/ActionExternalEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,7 +22,7 @@ import org.eclipse.wb.internal.rcp.gef.policy.rcp.perspective.ViewDropTool;
 import org.eclipse.wb.internal.rcp.model.jface.action.ActionInfo;
 
 import org.eclipse.jdt.core.IType;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import javax.swing.Action;
 
@@ -34,7 +34,7 @@ import javax.swing.Action;
  * @coverage rcp.editor.palette
  */
 public final class ActionExternalEntryInfo extends ToolEntryInfo {
-	private static final Image ICON = Activator.getImage("info/Action/action_open.gif");
+	private static final ImageDescriptor ICON = Activator.getImageDescriptor("info/Action/action_open.gif");
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -53,7 +53,7 @@ public final class ActionExternalEntryInfo extends ToolEntryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		return ICON;
 	}
 

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/ActionFactoryNewEntryInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/ActionFactoryNewEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,6 +21,7 @@ import org.eclipse.wb.internal.rcp.gef.policy.jface.action.ActionDropTool;
 import org.eclipse.wb.internal.rcp.model.jface.action.ActionInfo;
 import org.eclipse.wb.internal.rcp.model.rcp.ActionFactoryCreationSupport;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.actions.ActionFactory;
 import org.eclipse.ui.actions.ActionFactory.IWorkbenchAction;
@@ -82,8 +83,8 @@ public final class ActionFactoryNewEntryInfo extends ToolEntryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
-		return m_icon;
+	public ImageDescriptor getIcon() {
+		return ImageDescriptor.createFromImage(m_icon);
 	}
 
 	@Override

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/ActionNewEntryInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/ActionNewEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,7 @@ import org.eclipse.wb.internal.rcp.gef.policy.jface.action.ActionDropTool;
 import org.eclipse.wb.internal.rcp.model.jface.action.ActionContainerInfo;
 import org.eclipse.wb.internal.rcp.model.jface.action.ActionInfo;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import javax.swing.Action;
 
@@ -30,7 +30,7 @@ import javax.swing.Action;
  * @coverage rcp.editor.palette
  */
 public final class ActionNewEntryInfo extends ToolEntryInfo {
-	private static final Image ICON = Activator.getImage("info/Action/action_new.gif");
+	private static final ImageDescriptor ICON = Activator.getImageDescriptor("info/Action/action_new.gif");
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -49,7 +49,7 @@ public final class ActionNewEntryInfo extends ToolEntryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		return ICON;
 	}
 

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/ActionUseEntryInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/ActionUseEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,6 +21,7 @@ import org.eclipse.wb.internal.rcp.model.jface.action.ActionInfo;
 
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.IContributionManager;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
 
 import org.apache.commons.lang.ObjectUtils;
@@ -55,13 +56,14 @@ public final class ActionUseEntryInfo extends ToolEntryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<Image>() {
-			@Override
-			public Image runObject() throws Exception {
-				return m_action.getPresentation().getIcon();
-			}
-		}, ICON);
+	public ImageDescriptor getIcon() {
+		return ImageDescriptor.createFromImage(ExecutionUtils.runObjectLog(
+			new RunnableObjectEx<Image>() {
+				@Override
+				public Image runObject() throws Exception {
+					return m_action.getPresentation().getIcon();
+				}
+			}, ICON));
 	}
 
 	@Override

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/DialogButtonEntryInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/DialogButtonEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,7 @@ import org.eclipse.wb.gef.core.tools.Tool;
 import org.eclipse.wb.internal.rcp.Activator;
 import org.eclipse.wb.internal.rcp.gef.policy.jface.DialogButtonDropTool;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import javax.swing.AbstractButton;
 import javax.swing.Action;
@@ -32,7 +32,7 @@ import javax.swing.JToolBar;
  * @coverage rcp.editor.palette
  */
 public final class DialogButtonEntryInfo extends ToolEntryInfo {
-	private static final Image ICON = Activator.getImage("info/Dialog/button.gif");
+	private static final ImageDescriptor ICON = Activator.getImageDescriptor("info/Dialog/button.gif");
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -51,7 +51,7 @@ public final class DialogButtonEntryInfo extends ToolEntryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		return ICON;
 	}
 

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/DoubleFieldEditorEntryInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/DoubleFieldEditorEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,17 +16,14 @@ import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.gef.core.requests.ICreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.gef.core.tools.Tool;
+import org.eclipse.wb.internal.core.BundleResourceProvider;
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
 import org.eclipse.wb.internal.core.model.creation.ConstructorCreationSupport;
 import org.eclipse.wb.internal.core.model.creation.CreationSupport;
 import org.eclipse.wb.internal.core.utils.jdt.core.ProjectUtils;
 import org.eclipse.wb.internal.rcp.Activator;
 
-import org.eclipse.swt.graphics.Image;
-
-import org.apache.commons.io.IOUtils;
-
-import java.io.InputStream;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * {@link EntryInfo} for adding <code>DoubleFieldEditor</code>.
@@ -36,16 +33,8 @@ import java.io.InputStream;
  */
 public final class DoubleFieldEditorEntryInfo extends ToolEntryInfo {
 	private static final String TYPE_NAME = "org.eclipse.wb.swt.DoubleFieldEditor";
-	private static final Image ICON = loadIcon();
-
-	private static Image loadIcon() {
-		InputStream input = Activator.getFile("wbp-meta/org/eclipse/wb/swt/DoubleFieldEditor.png");
-		try {
-			return new Image(null, input);
-		} finally {
-			IOUtils.closeQuietly(input);
-		}
-	}
+	private static final ImageDescriptor ICON = BundleResourceProvider.get(Activator.PLUGIN_ID)
+			.getImageDescriptor("wbp-meta/org/eclipse/wb/swt/DoubleFieldEditor.png");
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -64,7 +53,7 @@ public final class DoubleFieldEditorEntryInfo extends ToolEntryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		return ICON;
 	}
 

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/PerspectivePerspectiveDropEntryInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/PerspectivePerspectiveDropEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,7 @@ import org.eclipse.wb.internal.rcp.gef.policy.rcp.perspective.PerspectiveDropToo
 import org.eclipse.wb.internal.rcp.model.rcp.PdeUtils.PerspectiveInfo;
 import org.eclipse.wb.internal.rcp.model.rcp.perspective.PageLayoutInfo;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * {@link EntryInfo} that allows user to drop new perspective on {@link PageLayoutInfo}.
@@ -46,8 +46,8 @@ public final class PerspectivePerspectiveDropEntryInfo extends ToolEntryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
-		return m_perspective.getIcon();
+	public ImageDescriptor getIcon() {
+		return ImageDescriptor.createFromImage(m_perspective.getIcon());
 	}
 
 	@Override

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/PerspectiveViewDropEntryInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/PerspectiveViewDropEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,7 @@ import org.eclipse.wb.internal.rcp.gef.policy.rcp.perspective.ViewDropTool;
 import org.eclipse.wb.internal.rcp.model.rcp.PdeUtils.ViewInfo;
 import org.eclipse.wb.internal.rcp.model.rcp.perspective.PageLayoutInfo;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * {@link EntryInfo} that allows user to drop new view on {@link PageLayoutInfo}.
@@ -46,8 +46,8 @@ public final class PerspectiveViewDropEntryInfo extends ToolEntryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
-		return m_view.getIcon();
+	public ImageDescriptor getIcon() {
+		return ImageDescriptor.createFromImage(m_view.getIcon());
 	}
 
 	@Override

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/TableCompositeEntryInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/TableCompositeEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,7 +28,7 @@ import org.eclipse.wb.internal.swt.model.layout.RowLayoutInfo;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Table;
 
@@ -40,8 +40,8 @@ import org.eclipse.swt.widgets.Table;
  * @coverage rcp.editor.palette
  */
 public final class TableCompositeEntryInfo extends ToolEntryInfo {
-	private static final Image ICON =
-			Activator.getImage("info/AbstractColumnLayout/TableComposite.gif");
+	private static final ImageDescriptor ICON = Activator
+			.getImageDescriptor("info/AbstractColumnLayout/TableComposite.gif");
 	private final ComponentEntryInfo m_compositeEntry;
 
 	////////////////////////////////////////////////////////////////////////////
@@ -62,7 +62,7 @@ public final class TableCompositeEntryInfo extends ToolEntryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		return ICON;
 	}
 

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/TableViewerCompositeEntryInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/TableViewerCompositeEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,8 +29,8 @@ import org.eclipse.wb.internal.swt.model.layout.RowLayoutInfo;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.TableViewer;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Table;
 
@@ -42,8 +42,8 @@ import org.eclipse.swt.widgets.Table;
  * @coverage rcp.editor.palette
  */
 public final class TableViewerCompositeEntryInfo extends ToolEntryInfo {
-	private static final Image ICON =
-			Activator.getImage("info/AbstractColumnLayout/TableViewerComposite.gif");
+	private static final ImageDescriptor ICON = Activator
+			.getImageDescriptor("info/AbstractColumnLayout/TableViewerComposite.gif");
 	private final ComponentEntryInfo m_compositeEntry;
 
 	////////////////////////////////////////////////////////////////////////////
@@ -64,7 +64,7 @@ public final class TableViewerCompositeEntryInfo extends ToolEntryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		return ICON;
 	}
 

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/TreeCompositeEntryInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/TreeCompositeEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,7 +28,7 @@ import org.eclipse.wb.internal.swt.model.layout.RowLayoutInfo;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Tree;
 
@@ -40,8 +40,8 @@ import org.eclipse.swt.widgets.Tree;
  * @coverage rcp.editor.palette
  */
 public final class TreeCompositeEntryInfo extends ToolEntryInfo {
-	private static final Image ICON =
-			Activator.getImage("info/AbstractColumnLayout/TreeComposite.gif");
+	private static final ImageDescriptor ICON =
+			Activator.getImageDescriptor("info/AbstractColumnLayout/TreeComposite.gif");
 	private final ComponentEntryInfo m_compositeEntry;
 
 	////////////////////////////////////////////////////////////////////////////
@@ -62,7 +62,7 @@ public final class TreeCompositeEntryInfo extends ToolEntryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		return ICON;
 	}
 

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/TreeViewerCompositeEntryInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/TreeViewerCompositeEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,8 +29,8 @@ import org.eclipse.wb.internal.swt.model.layout.RowLayoutInfo;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.TreeViewer;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Tree;
 
@@ -42,8 +42,8 @@ import org.eclipse.swt.widgets.Tree;
  * @coverage rcp.editor.palette
  */
 public final class TreeViewerCompositeEntryInfo extends ToolEntryInfo {
-	private static final Image ICON =
-			Activator.getImage("info/AbstractColumnLayout/TreeViewerComposite.gif");
+	private static final ImageDescriptor ICON = Activator
+			.getImageDescriptor("info/AbstractColumnLayout/TreeViewerComposite.gif");
 	private final ComponentEntryInfo m_compositeEntry;
 
 	////////////////////////////////////////////////////////////////////////////
@@ -64,7 +64,7 @@ public final class TreeViewerCompositeEntryInfo extends ToolEntryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		return ICON;
 	}
 

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/palette/DefaultComponentFactoryCreateLabelEntryInfo.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/palette/DefaultComponentFactoryCreateLabelEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,7 @@ import org.eclipse.wb.internal.core.model.JavaInfoUtils;
 import org.eclipse.wb.internal.swing.FormLayout.Activator;
 import org.eclipse.wb.internal.swing.FormLayout.parser.DefaultComponentFactoryCreationSupport;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import com.jgoodies.forms.factories.DefaultComponentFactory;
 
@@ -32,8 +32,8 @@ import com.jgoodies.forms.factories.DefaultComponentFactory;
 public final class DefaultComponentFactoryCreateLabelEntryInfo
 extends
 DefaultComponentFactoryEntryInfo {
-	private static final Image ICON =
-			Activator.getImage("DefaultComponentFactory/createLabel_java.lang.String_.gif");
+	private static final ImageDescriptor ICON = Activator
+			.getImageDescriptor("DefaultComponentFactory/createLabel_java.lang.String_.gif");
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -51,7 +51,7 @@ DefaultComponentFactoryEntryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		return ICON;
 	}
 

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/palette/DefaultComponentFactoryCreateTitleEntryInfo.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/palette/DefaultComponentFactoryCreateTitleEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,7 @@ import org.eclipse.wb.internal.core.model.JavaInfoUtils;
 import org.eclipse.wb.internal.swing.FormLayout.Activator;
 import org.eclipse.wb.internal.swing.FormLayout.parser.DefaultComponentFactoryCreationSupport;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import com.jgoodies.forms.factories.DefaultComponentFactory;
 
@@ -32,8 +32,8 @@ import com.jgoodies.forms.factories.DefaultComponentFactory;
 public final class DefaultComponentFactoryCreateTitleEntryInfo
 extends
 DefaultComponentFactoryEntryInfo {
-	private static final Image ICON =
-			Activator.getImage("DefaultComponentFactory/createTitle_java.lang.String_.gif");
+	private static final ImageDescriptor ICON = Activator
+			.getImageDescriptor("DefaultComponentFactory/createTitle_java.lang.String_.gif");
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -51,7 +51,7 @@ DefaultComponentFactoryEntryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		return ICON;
 	}
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/palette/AbsoluteLayoutEntryInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/palette/AbsoluteLayoutEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,7 @@ import org.eclipse.wb.gef.core.tools.Tool;
 import org.eclipse.wb.internal.swing.Activator;
 import org.eclipse.wb.internal.swing.model.layout.absolute.AbsoluteLayoutInfo;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * Implementation of {@link ToolEntryInfo} that adds {@link AbsoluteLayoutInfo}.
@@ -26,7 +26,7 @@ import org.eclipse.swt.graphics.Image;
  * @coverage swing.editor.palette
  */
 public final class AbsoluteLayoutEntryInfo extends ToolEntryInfo {
-	private static final Image ICON = Activator.getImage("info/layout/absolute/layout.gif");
+	private static final ImageDescriptor ICON = Activator.getImageDescriptor("info/layout/absolute/layout.gif");
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -44,7 +44,7 @@ public final class AbsoluteLayoutEntryInfo extends ToolEntryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		return ICON;
 	}
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/palette/ActionExternalEntryInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/palette/ActionExternalEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,7 +22,7 @@ import org.eclipse.wb.internal.swing.Activator;
 import org.eclipse.wb.internal.swing.model.bean.ActionInfo;
 
 import org.eclipse.jdt.core.IType;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import javax.swing.Action;
 
@@ -33,7 +33,7 @@ import javax.swing.Action;
  * @coverage swing.editor.palette
  */
 public final class ActionExternalEntryInfo extends ToolEntryInfo {
-	private static final Image ICON = Activator.getImage("info/Action/action_open.gif");
+	private static final ImageDescriptor ICON = Activator.getImageDescriptor("info/Action/action_open.gif");
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -51,7 +51,7 @@ public final class ActionExternalEntryInfo extends ToolEntryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		return ICON;
 	}
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/palette/ActionNewEntryInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/palette/ActionNewEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,7 @@ import org.eclipse.wb.gef.core.tools.Tool;
 import org.eclipse.wb.internal.swing.Activator;
 import org.eclipse.wb.internal.swing.model.bean.ActionInfo;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import javax.swing.Action;
 
@@ -28,7 +28,7 @@ import javax.swing.Action;
  * @coverage swing.editor.palette
  */
 public final class ActionNewEntryInfo extends ToolEntryInfo {
-	private static final Image ICON = Activator.getImage("info/Action/action_new.gif");
+	private static final ImageDescriptor ICON = Activator.getImageDescriptor("info/Action/action_new.gif");
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -46,7 +46,7 @@ public final class ActionNewEntryInfo extends ToolEntryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		return ICON;
 	}
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/palette/ActionUseEntryInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/palette/ActionUseEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,6 +21,7 @@ import org.eclipse.wb.internal.swing.Activator;
 import org.eclipse.wb.internal.swing.model.ModelMessages;
 import org.eclipse.wb.internal.swing.model.bean.ActionInfo;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
 
 import org.apache.commons.lang.ObjectUtils;
@@ -60,12 +61,14 @@ public final class ActionUseEntryInfo extends ToolEntryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<Image>() {
-			public Image runObject() throws Exception {
-				return m_action.getPresentation().getIcon();
-			}
-		}, ICON);
+	public ImageDescriptor getIcon() {
+		return ImageDescriptor.createFromImage(ExecutionUtils.runObjectLog(
+			new RunnableObjectEx<Image>() {
+				@Override
+				public Image runObject() throws Exception {
+					return m_action.getPresentation().getIcon();
+				}
+			}, ICON));
 	}
 
 	@Override

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/palette/SwingPaletteEntryInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/palette/SwingPaletteEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,8 +23,8 @@ import org.eclipse.wb.internal.gef.core.IActiveToolListener;
 import org.eclipse.wb.internal.swing.Activator;
 import org.eclipse.wb.internal.swing.preferences.IPreferenceConstants;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.FillLayout;
@@ -43,7 +43,7 @@ import org.eclipse.swt.widgets.Shell;
  * @coverage swing.editor.palette
  */
 public final class SwingPaletteEntryInfo extends EntryInfo {
-	private static final Image ICON = Activator.getImage("popup_palette.png");
+	private static final ImageDescriptor ICON = Activator.getImageDescriptor("popup_palette.png");
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -62,7 +62,7 @@ public final class SwingPaletteEntryInfo extends EntryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		return ICON;
 	}
 

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/palette/AbsoluteLayoutEntryInfo.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/palette/AbsoluteLayoutEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ import org.eclipse.wb.internal.swt.model.ModelMessages;
 import org.eclipse.wb.internal.swt.model.layout.absolute.AbsoluteLayoutCreationSupport;
 import org.eclipse.wb.internal.swt.model.layout.absolute.AbsoluteLayoutInfo;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * Implementation of {@link ToolEntryInfo} that adds {@link AbsoluteLayoutInfo}.
@@ -29,7 +29,7 @@ import org.eclipse.swt.graphics.Image;
  * @coverage swt.editor.palette
  */
 public final class AbsoluteLayoutEntryInfo extends ToolEntryInfo {
-	private static final Image ICON = Activator.getImage("info/layout/absolute/layout.gif");
+	private static final ImageDescriptor ICON = Activator.getImageDescriptor("info/layout/absolute/layout.gif");
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -47,7 +47,7 @@ public final class AbsoluteLayoutEntryInfo extends ToolEntryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		return ICON;
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/palette/ComponentEntryInfoTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/palette/ComponentEntryInfoTest.java
@@ -39,6 +39,7 @@ import org.eclipse.wb.tests.gef.UiContext;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IType;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
@@ -155,10 +156,10 @@ public class ComponentEntryInfoTest extends AbstractPaletteTest {
 		assertEquals("my name", entry.getName());
 		// we have icon in palette entry, so it is not "null"
 		{
-			Image icon = entry.getIcon();
+			ImageDescriptor icon = entry.getIcon();
 			assertNotNull(icon);
-			assertEquals(16, icon.getBounds().width);
-			assertEquals(16, icon.getBounds().height);
+			assertEquals(16, icon.getImageData(100).width);
+			assertEquals(16, icon.getImageData(100).height);
 		}
 		assertFalse(entry.isVisible());
 	}
@@ -236,7 +237,7 @@ public class ComponentEntryInfoTest extends AbstractPaletteTest {
 					ComponentDescriptionHelper.getDescription(m_lastContext, Button.class);
 			CreationDescription creation = componentDescription.getCreation(null);
 			assertEquals(creation.getDescription(), entry.getDescription());
-			assertTrue("Same icons.", UiUtils.equals(creation.getIcon(), entry.getIcon()));
+			assertTrue("Same icons.", UiUtils.equals(creation.getIcon(), (Image) ReflectionUtils.getFieldObject(entry.getIcon(), "m_icon")));
 		}
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/palette/EntryInfoTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/palette/EntryInfoTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,7 @@ import org.eclipse.wb.internal.core.xml.editor.palette.model.IPaletteSite;
 import org.eclipse.wb.internal.core.xml.model.XmlObjectInfo;
 import org.eclipse.wb.tests.gef.EmptyEditPartViewer;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * Tests for abstract {@link EntryInfo}.
@@ -37,7 +37,7 @@ public class EntryInfoTest extends AbstractPaletteTest {
 		// prepare ToolEntryInfo
 		EntryInfo toolEntry = new EntryInfo() {
 			@Override
-			public Image getIcon() {
+			public ImageDescriptor getIcon() {
 				return null;
 			}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/palette/ToolEntryInfoTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/palette/ToolEntryInfoTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,7 @@ import org.eclipse.wb.internal.core.xml.editor.palette.model.ToolEntryInfo;
 import org.eclipse.wb.internal.core.xml.model.XmlObjectInfo;
 import org.eclipse.wb.tests.gef.EmptyEditPartViewer;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * Tests for abstract {@link ToolEntryInfo}.
@@ -40,7 +40,7 @@ public class ToolEntryInfoTest extends AbstractPaletteTest {
 		// prepare ToolEntryInfo
 		ToolEntryInfo toolEntry = new ToolEntryInfo() {
 			@Override
-			public Image getIcon() {
+			public ImageDescriptor getIcon() {
 				return null;
 			}
 
@@ -64,7 +64,7 @@ public class ToolEntryInfoTest extends AbstractPaletteTest {
 		// prepare ToolEntryInfo
 		ToolEntryInfo toolEntry = new ToolEntryInfo() {
 			@Override
-			public Image getIcon() {
+			public ImageDescriptor getIcon() {
 				return null;
 			}
 
@@ -88,7 +88,7 @@ public class ToolEntryInfoTest extends AbstractPaletteTest {
 		// prepare ToolEntryInfo
 		ToolEntryInfo toolEntry = new ToolEntryInfo() {
 			@Override
-			public Image getIcon() {
+			public ImageDescriptor getIcon() {
 				return null;
 			}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/palette/ComponentEntryInfoTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/palette/ComponentEntryInfoTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -42,6 +42,7 @@ import org.eclipse.wb.tests.gef.UiContext;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IType;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Shell;
@@ -154,10 +155,10 @@ public class ComponentEntryInfoTest extends AbstractPaletteTest {
 		assertEquals("my name", entry.getName());
 		// we have icon in palette entry, so it is not "null"
 		{
-			Image icon = entry.getIcon();
+			ImageDescriptor icon = entry.getIcon();
 			assertNotNull(icon);
-			assertEquals(16, icon.getBounds().width);
-			assertEquals(16, icon.getBounds().height);
+			assertEquals(16, icon.getImageData(100).width);
+			assertEquals(16, icon.getImageData(100).height);
 		}
 		assertFalse(entry.isVisible());
 	}
@@ -232,7 +233,7 @@ public class ComponentEntryInfoTest extends AbstractPaletteTest {
 					ComponentDescriptionHelper.getDescription(m_lastEditor, JPanel.class);
 			CreationDescription creation = componentDescription.getCreation(null);
 			assertEquals(creation.getDescription(), entry.getDescription());
-			assertTrue("Same icons.", UiUtils.equals(creation.getIcon(), entry.getIcon()));
+			assertTrue("Same icons.", UiUtils.equals(ImageDescriptor.createFromImage(creation.getIcon()), entry.getIcon()));
 		}
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/palette/StaticFactoryEntryInfoTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/palette/StaticFactoryEntryInfoTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,10 +20,11 @@ import org.eclipse.wb.internal.core.model.creation.factory.StaticFactoryCreation
 import org.eclipse.wb.internal.core.model.description.GenericPropertyDescription;
 import org.eclipse.wb.internal.core.model.description.factory.FactoryMethodDescription;
 import org.eclipse.wb.internal.core.model.property.category.PropertyCategory;
+import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.tests.designer.tests.Activator;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -325,10 +326,10 @@ public class StaticFactoryEntryInfoTest extends AbstractPaletteTest {
 		assertTrue(entry.initialize(null, panel));
 		// after successful initialize we can ask for icon
 		{
-			Image icon = entry.getIcon();
+			ImageDescriptor icon = entry.getIcon();
 			assertNotNull(icon);
-			assertEquals(16, icon.getBounds().width);
-			assertEquals(16, icon.getBounds().height);
+			assertEquals(16, icon.getImageData(100).width);
+			assertEquals(16, icon.getImageData(100).height);
 		}
 	}
 
@@ -377,7 +378,7 @@ public class StaticFactoryEntryInfoTest extends AbstractPaletteTest {
 		// initialize
 		assertTrue(entry.initialize(null, panel));
 		assertEquals("Some textual description of method.", entry.getDescription());
-		assertSame(entry.getMethodDescription().getIcon(), entry.getIcon());
+		assertSame(entry.getMethodDescription().getIcon(), ReflectionUtils.getFieldObject(entry, "m_icon"));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/palette/ToolEntryInfoTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/palette/ToolEntryInfoTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,7 @@ import org.eclipse.wb.gef.graphical.tools.SelectionTool;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.tests.gef.EmptyEditPartViewer;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * Tests for abstract {@link ToolEntryInfo}.
@@ -40,7 +40,7 @@ public class ToolEntryInfoTest extends AbstractPaletteTest {
 		// prepare ToolEntryInfo
 		ToolEntryInfo toolEntry = new ToolEntryInfo() {
 			@Override
-			public Image getIcon() {
+			public ImageDescriptor getIcon() {
 				return null;
 			}
 
@@ -64,7 +64,7 @@ public class ToolEntryInfoTest extends AbstractPaletteTest {
 		// prepare ToolEntryInfo
 		ToolEntryInfo toolEntry = new ToolEntryInfo() {
 			@Override
-			public Image getIcon() {
+			public ImageDescriptor getIcon() {
 				return null;
 			}
 
@@ -88,7 +88,7 @@ public class ToolEntryInfoTest extends AbstractPaletteTest {
 		// prepare ToolEntryInfo
 		ToolEntryInfo toolEntry = new ToolEntryInfo() {
 			@Override
-			public Image getIcon() {
+			public ImageDescriptor getIcon() {
 				return null;
 			}
 

--- a/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/palette/AbsoluteLayoutEntryInfo.java
+++ b/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/palette/AbsoluteLayoutEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,7 @@ import org.eclipse.wb.internal.core.xml.editor.palette.model.ToolEntryInfo;
 import org.eclipse.wb.internal.swt.Activator;
 import org.eclipse.wb.internal.xwt.model.layout.AbsoluteLayoutInfo;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * {@link ToolEntryInfo} that adds {@link AbsoluteLayoutInfo}.
@@ -26,7 +26,7 @@ import org.eclipse.swt.graphics.Image;
  * @coverage XWT.editor
  */
 public final class AbsoluteLayoutEntryInfo extends ToolEntryInfo {
-	private static final Image ICON = Activator.getImage("info/layout/absolute/layout.gif");
+	private static final ImageDescriptor ICON = Activator.getImageDescriptor("info/layout/absolute/layout.gif");
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -44,7 +44,7 @@ public final class AbsoluteLayoutEntryInfo extends ToolEntryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		return ICON;
 	}
 


### PR DESCRIPTION
Similar to IEntry, we shouldn't use Images directly inside the data model, due to having to explicitly dispose them, once they are no longer needed. This problem doesn't exist when using ImageDescriptors instead. Where necessary, image instances are created via a resource manager. In order to remain compatible with the old image-based API, images are converted into descriptors via ImageDescriptor.createFromImage()