### PR TITLE
Update to Tycho 5 nightly build.

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho</groupId>
     <artifactId>tycho-build</artifactId>
-    <version>3.0.4</version>
+    <version>4.0.0</version>
   </extension>
 </extensions> 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
 
   <properties>
-    <tycho.version>4.0.0-SNAPSHOT</tycho.version>
+    <tycho.version>5.0.0-SNAPSHOT</tycho.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <eclipse-jarsigner-version>1.3.2</eclipse-jarsigner-version>
     <baseline.repo>https://download.eclipse.org/windowbuilder/updates/release/latest</baseline.repo>


### PR DESCRIPTION
Tycho 4 has been released last week, meaning that the 4.0.0 nightly builds are no longer available. Instead of using the 4.0.0 release, we should continue to use the nightly builds, in order to respond to incompatibilities as fast as possible.

Even though Tycho 5 is still using Maven 3.9 right now, it will eventually require Maven 4 in the future.