### PR TITLE
Fix "Widget is Disposed" exception in FontDialogField.

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/dialogfields/FontDialogField.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/dialogfields/FontDialogField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -115,7 +115,9 @@ public class FontDialogField extends DialogField {
 	private void updateFontLabel() {
 		if (isOkToUse(m_fontLabel)) {
 			if (m_fontDataArray != null) {
-				m_fontLabel.setFont(new Font(m_group.getDisplay(), m_fontDataArray));
+				Font font = new Font(m_group.getDisplay(), m_fontDataArray);
+				m_fontLabel.setFont(font);
+				m_fontLabel.addDisposeListener(event -> font.dispose());
 				//
 				FontData fontData = m_fontDataArray[0];
 				//


### PR DESCRIPTION
When updating the font label, WindowBuilder creates a new font instance. This instance is never disposed properly, leading to the mentioned exception.

Given that the dialog field doesn't have a dispose() method, we can't use a resource manager to track this object. Instead, the lifecycle is bound to the lifecycle of the label it is assigned to.