### PR TITLE
Switch from Image to ImageDescriptor for IObservePresentation

### DIFF
--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/IObservePresentation.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/IObservePresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.databinding.model;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * Interface for visual presentation of {@link IObserveInfo} - title and image.
@@ -30,7 +30,7 @@ public interface IObservePresentation {
 	String getTextForBinding() throws Exception;
 
 	/**
-	 * @return the image to display for user.
+	 * @return the image descriptor to display for user.
 	 */
-	Image getImage() throws Exception;
+	ImageDescriptor getImageDescriptor() throws Exception;
 }

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/presentation/JavaInfoDecorator.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/presentation/JavaInfoDecorator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@ import org.eclipse.wb.internal.core.databinding.model.IDatabindingsProvider;
 import org.eclipse.wb.internal.core.databinding.model.IObserveInfo;
 import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
 
 import java.util.Iterator;
@@ -30,7 +31,12 @@ import java.util.Iterator;
  * @coverage bindings.model
  */
 public abstract class JavaInfoDecorator {
+	/**
+	 * @deprecated Use {@link #IMAGE_DESCRIPTOR} instead.
+	 */
+	@Deprecated
 	public static final Image IMAGE = Activator.getImage("decorator.gif");
+	public static final ImageDescriptor IMAGE_DESCRIPTOR = Activator.getImageDescriptor("decorator.gif");
 	private final IDatabindingsProvider m_provider;
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/presentation/JavaInfoObservePresentation.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/presentation/JavaInfoObservePresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,8 +14,9 @@ import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.databinding.model.IObservePresentation;
 import org.eclipse.wb.internal.core.model.util.ObjectsLabelProvider;
+import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * {@link IObservePresentation} for presentation {@link JavaInfo}.
@@ -60,7 +61,8 @@ public class JavaInfoObservePresentation implements IObservePresentation {
 	}
 
 	@Override
-	public Image getImage() throws Exception {
-		return ObjectsLabelProvider.INSTANCE.getImage(m_javaInfo);
+	public ImageDescriptor getImageDescriptor() throws Exception {
+		return ExecutionUtils.runObjectLog(
+				() -> ImageDescriptor.createFromImage(ObjectsLabelProvider.INSTANCE.getImage(m_javaInfo)), null);
 	}
 }

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/presentation/ObservePresentation.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/presentation/ObservePresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,9 +11,9 @@
 package org.eclipse.wb.internal.core.databinding.model.presentation;
 
 import org.eclipse.wb.internal.core.databinding.model.IObservePresentation;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.viewers.DecorationOverlayIcon;
 
 /**
  * Base class for all observable presentations.
@@ -25,7 +25,7 @@ public abstract class ObservePresentation
 implements
 IObservePresentation,
 IObservePresentationDecorator {
-	private Image m_decorateImage;
+	private ImageDescriptor m_decorateImage;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -33,14 +33,14 @@ IObservePresentationDecorator {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public final Image getImage() throws Exception {
+	public final ImageDescriptor getImageDescriptor() throws Exception {
 		return m_decorateImage == null ? getInternalImage() : m_decorateImage;
 	}
 
 	/**
-	 * @return {@link Image} for displaying and decorate.
+	 * @return {@link ImageDescriptor} for displaying and decorate.
 	 */
-	protected abstract Image getInternalImage() throws Exception;
+	protected abstract ImageDescriptor getInternalImage() throws Exception;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -50,9 +50,9 @@ IObservePresentationDecorator {
 	@Override
 	public final void setBindingDecorator(int corner) throws Exception {
 		if (corner != 0) {
-			Image image = getInternalImage();
+			ImageDescriptor image = getInternalImage();
 			if (image != null) {
-				m_decorateImage = SwtResourceManager.decorateImage(image, JavaInfoDecorator.IMAGE, corner);
+				m_decorateImage = new DecorationOverlayIcon(image, JavaInfoDecorator.IMAGE_DESCRIPTOR, corner);
 			}
 		} else {
 			m_decorateImage = null;

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/presentation/SimpleObservePresentation.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/presentation/SimpleObservePresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.databinding.model.presentation;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
 
 /**
@@ -43,8 +44,8 @@ public class SimpleObservePresentation extends ObservePresentation {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected Image getInternalImage() throws Exception {
-		return m_image;
+	protected ImageDescriptor getInternalImage() throws Exception {
+		return m_image == null ? null : ImageDescriptor.createFromImage(m_image);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/property/ObserveAction.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/property/ObserveAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -34,7 +34,7 @@ public class ObserveAction extends ObjectInfoAction {
 		//
 		IObservePresentation presentation = m_property.getObserveProperty().getPresentation();
 		setText(presentation.getText());
-		setIcon(presentation.getImage());
+		setImageDescriptor(presentation.getImageDescriptor());
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/property/SingleObserveBindingAction.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/property/SingleObserveBindingAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,7 +35,7 @@ public class SingleObserveBindingAction extends ObjectInfoAction {
 		//
 		IObservePresentation presentation = m_property.getObserveProperty().getPresentation();
 		setText(presentation.getText());
-		setIcon(presentation.getImage());
+		setImageDescriptor(presentation.getImageDescriptor());
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/providers/ObserveLabelProvider.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/providers/ObserveLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,9 @@ import org.eclipse.wb.internal.core.databinding.model.IObservePresentation;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.resource.LocalResourceManager;
+import org.eclipse.jface.resource.ResourceManager;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.swt.graphics.Image;
 
@@ -25,6 +28,7 @@ import org.eclipse.swt.graphics.Image;
  * @coverage bindings.ui
  */
 public class ObserveLabelProvider extends LabelProvider {
+	private final ResourceManager m_resourceManager = new LocalResourceManager(JFaceResources.getResources());
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Access
@@ -41,6 +45,12 @@ public class ObserveLabelProvider extends LabelProvider {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
+	public void dispose() {
+		super.dispose();
+		m_resourceManager.dispose();
+	}
+
+	@Override
 	public String getText(final Object element) {
 		return ExecutionUtils.runObjectLog(new RunnableObjectEx<String>() {
 			@Override
@@ -55,7 +65,7 @@ public class ObserveLabelProvider extends LabelProvider {
 		return ExecutionUtils.runObjectLog(new RunnableObjectEx<Image>() {
 			@Override
 			public Image runObject() throws Exception {
-				return getPresentation(element).getImage();
+				return m_resourceManager.createImage(getPresentation(element).getImageDescriptor());
 			}
 		}, null);
 	}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/ObjectInfoAction.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/ObjectInfoAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -66,7 +66,10 @@ public abstract class ObjectInfoAction extends Action {
 	////////////////////////////////////////////////////////////////////////////
 	/**
 	 * Sets {@link #setImageDescriptor(ImageDescriptor)} using given {@link Image} icon.
+	 *
+	 * @deprecated Use {@link #setImageDescriptor(ImageDescriptor)} instead.
 	 */
+	@Deprecated
 	public void setIcon(Image icon) {
 		setImageDescriptor(new ImageImageDescriptor(icon));
 	}

--- a/org.eclipse.wb.rcp.databinding.emf/src/org/eclipse/wb/internal/rcp/databinding/emf/model/bindables/EObjectObservePresentation.java
+++ b/org.eclipse.wb.rcp.databinding.emf/src/org/eclipse/wb/internal/rcp/databinding/emf/model/bindables/EObjectObservePresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,7 @@ package org.eclipse.wb.internal.rcp.databinding.emf.model.bindables;
 import org.eclipse.wb.internal.core.databinding.model.presentation.ObservePresentation;
 import org.eclipse.wb.internal.rcp.databinding.emf.Activator;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import org.apache.commons.lang.ClassUtils;
 
@@ -24,7 +24,7 @@ import org.apache.commons.lang.ClassUtils;
  * @coverage bindings.rcp.emf.model
  */
 public final class EObjectObservePresentation extends ObservePresentation {
-	private static final Image IMAGE = Activator.getImage("EObject.gif");
+	private static final ImageDescriptor IMAGE = Activator.getImageDescriptor("EObject.gif");
 	private final EObjectBindableInfo m_eObject;
 
 	////////////////////////////////////////////////////////////////////////////
@@ -42,7 +42,7 @@ public final class EObjectObservePresentation extends ObservePresentation {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected Image getInternalImage() throws Exception {
+	protected ImageDescriptor getInternalImage() throws Exception {
 		return IMAGE;
 	}
 

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanBindablePresentation.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanBindablePresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.databinding.model.presentation.ObservePresentation;
 import org.eclipse.wb.internal.core.databinding.model.reference.IReferenceProvider;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
 
 import org.apache.commons.lang.ClassUtils;
@@ -73,11 +74,12 @@ public final class BeanBindablePresentation extends ObservePresentation {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected Image getInternalImage() throws Exception {
+	protected ImageDescriptor getInternalImage() throws Exception {
 		if (m_beanImage == null && m_javaInfo == null) {
 			return null;
 		}
-		return m_beanImage == null ? m_javaInfo.getPresentation().getIcon() : m_beanImage;
+		Image image = m_beanImage == null ? m_javaInfo.getPresentation().getIcon() : m_beanImage;
+		return image == null ? null : ImageDescriptor.createFromImage(image);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/contentproviders/ChooseClassAndTreePropertiesUiContentProvider.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/contentproviders/ChooseClassAndTreePropertiesUiContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,6 +29,9 @@ import org.eclipse.wb.internal.rcp.databinding.model.beans.bindables.BeanBindabl
 import org.eclipse.wb.internal.rcp.databinding.model.beans.bindables.BeanSupport;
 import org.eclipse.wb.internal.rcp.databinding.model.beans.bindables.PropertyBindableInfo;
 
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.resource.LocalResourceManager;
+import org.eclipse.jface.resource.ResourceManager;
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.CheckStateChangedEvent;
 import org.eclipse.jface.viewers.CheckboxTreeViewer;
@@ -386,6 +389,7 @@ org.eclipse.wb.internal.core.databinding.ui.editor.contentproviders.ChooseClassA
 	IColorProvider,
 	IFontProvider {
 		private final ObserveDecoratingLabelProvider m_labelProvider;
+		private final ResourceManager m_resourceManager;
 
 		////////////////////////////////////////////////////////////////////////////
 		//
@@ -394,6 +398,7 @@ org.eclipse.wb.internal.core.databinding.ui.editor.contentproviders.ChooseClassA
 		////////////////////////////////////////////////////////////////////////////
 		public PropertyAdapterLabelProvider(StructuredViewer viewer) {
 			m_labelProvider = new ObserveDecoratingLabelProvider(viewer);
+			m_resourceManager = new LocalResourceManager(JFaceResources.getResources());
 		}
 
 		////////////////////////////////////////////////////////////////////////////
@@ -405,6 +410,7 @@ org.eclipse.wb.internal.core.databinding.ui.editor.contentproviders.ChooseClassA
 		public void dispose() {
 			super.dispose();
 			m_labelProvider.dispose();
+			m_resourceManager.dispose();
 		}
 
 		@Override
@@ -415,7 +421,7 @@ org.eclipse.wb.internal.core.databinding.ui.editor.contentproviders.ChooseClassA
 		@Override
 		public Image getImage(Object element) {
 			try {
-				return getAdapterProperty(element).getPresentation().getImage();
+				return m_resourceManager.createImage(getAdapterProperty(element).getPresentation().getImageDescriptor());
 			} catch (Throwable e) {
 			}
 			return super.getImage(element);

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/contentproviders/ViewerColumnsUiContentProvider.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/contentproviders/ViewerColumnsUiContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,6 +27,9 @@ import org.eclipse.wb.internal.rcp.databinding.Messages;
 import org.eclipse.wb.internal.rcp.databinding.model.widgets.input.VirtualEditingSupportInfo;
 
 import org.eclipse.jface.dialogs.IDialogSettings;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.resource.LocalResourceManager;
+import org.eclipse.jface.resource.ResourceManager;
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.DoubleClickEvent;
 import org.eclipse.jface.viewers.IDoubleClickListener;
@@ -245,6 +248,14 @@ public class ViewerColumnsUiContentProvider extends UiContentProviderAdapter {
 	private static class EditingSupportLabelProvider extends LabelProvider
 	implements
 	ITableLabelProvider {
+		private final ResourceManager m_resourceManager = new LocalResourceManager(JFaceResources.getResources());
+
+		@Override
+		public void dispose() {
+			super.dispose();
+			m_resourceManager.dispose();
+		}
+
 		////////////////////////////////////////////////////////////////////////////
 		//
 		// ITableLabelProvider
@@ -290,7 +301,7 @@ public class ViewerColumnsUiContentProvider extends UiContentProviderAdapter {
 				return ExecutionUtils.runObjectLog(new RunnableObjectEx<Image>() {
 					@Override
 					public Image runObject() throws Exception {
-						return editingSupport.getViewerColumn().getPresentation().getImage();
+						return m_resourceManager.createImage(editingSupport.getViewerColumn().getPresentation().getImageDescriptor());
 					}
 				}, null);
 			}

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/FieldBeanObservePresentation.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/FieldBeanObservePresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@ package org.eclipse.wb.internal.swing.databinding.model.beans;
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.databinding.model.presentation.ObservePresentation;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
 
 /**
@@ -45,11 +46,12 @@ public final class FieldBeanObservePresentation extends ObservePresentation {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected Image getInternalImage() throws Exception {
+	protected ImageDescriptor getInternalImage() throws Exception {
 		if (m_beanImage == null && m_javaInfo == null) {
 			return null;
 		}
-		return m_beanImage == null ? m_javaInfo.getPresentation().getIcon() : m_beanImage;
+		Image image = m_beanImage == null ? m_javaInfo.getPresentation().getIcon() : m_beanImage;
+		return image == null ? null : ImageDescriptor.createFromImage(image);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/contentproviders/ChooseClassAndPropertiesUiContentProvider.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/contentproviders/ChooseClassAndPropertiesUiContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,6 +35,9 @@ import org.eclipse.wb.internal.swing.databinding.model.properties.ElPropertyInfo
 import org.eclipse.wb.internal.swing.databinding.model.properties.PropertyInfo;
 import org.eclipse.wb.internal.swing.databinding.ui.contentproviders.el.ElPropertyUiConfiguration;
 
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.resource.LocalResourceManager;
+import org.eclipse.jface.resource.ResourceManager;
 import org.eclipse.jface.viewers.CheckStateChangedEvent;
 import org.eclipse.jface.viewers.CheckboxTreeViewer;
 import org.eclipse.jface.viewers.ICheckStateListener;
@@ -407,6 +410,7 @@ org.eclipse.wb.internal.core.databinding.ui.editor.contentproviders.ChooseClassA
 	IColorProvider,
 	IFontProvider {
 		private final ObserveDecoratingLabelProvider m_labelProvider;
+		private final ResourceManager m_resourceManager;
 
 		////////////////////////////////////////////////////////////////////////////
 		//
@@ -415,6 +419,7 @@ org.eclipse.wb.internal.core.databinding.ui.editor.contentproviders.ChooseClassA
 		////////////////////////////////////////////////////////////////////////////
 		public PropertyAdapterLabelProvider(TreeViewer viewer) {
 			m_labelProvider = new ObserveDecoratingLabelProvider(viewer);
+			m_resourceManager = new LocalResourceManager(JFaceResources.getResources());
 		}
 
 		////////////////////////////////////////////////////////////////////////////
@@ -426,6 +431,7 @@ org.eclipse.wb.internal.core.databinding.ui.editor.contentproviders.ChooseClassA
 		public void dispose() {
 			super.dispose();
 			m_labelProvider.dispose();
+			m_resourceManager.dispose();
 		}
 
 		@Override
@@ -436,7 +442,7 @@ org.eclipse.wb.internal.core.databinding.ui.editor.contentproviders.ChooseClassA
 		@Override
 		public Image getImage(Object element) {
 			try {
-				return getAdapterProperty(element).getPresentation().getImage();
+				return m_resourceManager.createImage(getAdapterProperty(element).getPresentation().getImageDescriptor());
 			} catch (Throwable e) {
 			}
 			return super.getImage(element);

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/contentproviders/ColumnBindingUiContentProvider.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/contentproviders/ColumnBindingUiContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,6 +35,9 @@ import org.eclipse.wb.internal.swing.databinding.model.properties.ElPropertyInfo
 import org.eclipse.wb.internal.swing.databinding.model.properties.PropertyInfo;
 import org.eclipse.wb.internal.swing.databinding.ui.contentproviders.el.ElPropertyUiConfiguration;
 
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.resource.LocalResourceManager;
+import org.eclipse.jface.resource.ResourceManager;
 import org.eclipse.jface.viewers.CheckStateChangedEvent;
 import org.eclipse.jface.viewers.CheckboxTreeViewer;
 import org.eclipse.jface.viewers.ICheckStateListener;
@@ -450,6 +453,7 @@ public final class ColumnBindingUiContentProvider implements IUiContentProvider 
 	IColorProvider,
 	IFontProvider {
 		private final ObserveDecoratingLabelProvider m_labelProvider;
+		private final ResourceManager m_resourceManager;
 
 		////////////////////////////////////////////////////////////////////////////
 		//
@@ -458,6 +462,7 @@ public final class ColumnBindingUiContentProvider implements IUiContentProvider 
 		////////////////////////////////////////////////////////////////////////////
 		public PropertyAdapterLabelProvider(TreeViewer viewer) {
 			m_labelProvider = new ObserveDecoratingLabelProvider(viewer);
+			m_resourceManager = new LocalResourceManager(JFaceResources.getResources());
 		}
 
 		////////////////////////////////////////////////////////////////////////////
@@ -469,6 +474,7 @@ public final class ColumnBindingUiContentProvider implements IUiContentProvider 
 		public void dispose() {
 			super.dispose();
 			m_labelProvider.dispose();
+			m_resourceManager.dispose();
 		}
 
 		@Override
@@ -479,7 +485,7 @@ public final class ColumnBindingUiContentProvider implements IUiContentProvider 
 		@Override
 		public Image getImage(Object element) {
 			try {
-				return getAdapterProperty(element).getPresentation().getImage();
+				return m_resourceManager.createImage(getAdapterProperty(element).getPresentation().getImageDescriptor());
 			} catch (Throwable e) {
 			}
 			return super.getImage(element);

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/contentproviders/el/ContentAssistProcessor.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/contentproviders/el/ContentAssistProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,16 +16,19 @@ import org.eclipse.wb.internal.swing.databinding.model.ObserveInfo;
 import org.eclipse.wb.internal.swing.databinding.model.beans.BeanSupport;
 import org.eclipse.wb.internal.swing.databinding.model.generic.ClassGenericType;
 
+import org.eclipse.jface.resource.ResourceManager;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.jface.text.contentassist.IContentAssistProcessor;
 import org.eclipse.jface.text.contentassist.IContextInformation;
 import org.eclipse.jface.text.contentassist.IContextInformationValidator;
+import org.eclipse.swt.graphics.Image;
 
 import org.apache.commons.lang.StringUtils;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * {@link IContentAssistProcessor} for {@code EL} properties.
@@ -37,6 +40,7 @@ public final class ContentAssistProcessor implements IContentAssistProcessor {
 	private static final char[] TOP_LEVEL_AUTO_ACTIVATION_CHARACTERS = {'$', '#'};
 	private static final char[] AUTO_ACTIVATION_CHARACTERS = {'.'};
 	private final IBeanPropertiesSupport m_propertiesSupport;
+	private final ResourceManager m_resourceManager;
 	private final boolean m_topLevel;
 
 	////////////////////////////////////////////////////////////////////////////
@@ -44,8 +48,9 @@ public final class ContentAssistProcessor implements IContentAssistProcessor {
 	// Constructor
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public ContentAssistProcessor(IBeanPropertiesSupport propertiesSupport, boolean topLevel) {
+	public ContentAssistProcessor(IBeanPropertiesSupport propertiesSupport, ResourceManager resourceManager, boolean topLevel) {
 		m_propertiesSupport = propertiesSupport;
+		m_resourceManager = resourceManager;
 		m_topLevel = topLevel;
 	}
 
@@ -134,7 +139,7 @@ public final class ContentAssistProcessor implements IContentAssistProcessor {
 		return null;
 	}
 
-	private static ICompletionProposal[] createProposals(List<ObserveInfo> properties,
+	private ICompletionProposal[] createProposals(List<ObserveInfo> properties,
 			int offset,
 			String begin,
 			String end) throws Exception {
@@ -144,10 +149,13 @@ public final class ContentAssistProcessor implements IContentAssistProcessor {
 			ObserveInfo observe = properties.get(i);
 			String propertyName = observe.getPresentation().getText();
 			String data = begin + propertyName + end;
+			Image image = Optional.ofNullable(observe.getPresentation().getImageDescriptor()) //
+					.map(m_resourceManager::createImage) //
+					.orElse(null);
 			// add proposal
 			proposals[i] =
 					new CompletionProposal(propertyName,
-							observe.getPresentation().getImage(),
+							image,
 							offset,
 							data,
 							offset + data.length());

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/contentproviders/el/EvalutionLanguageConfiguration.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/contentproviders/el/EvalutionLanguageConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,9 @@ package org.eclipse.wb.internal.swing.databinding.ui.contentproviders.el;
 
 import org.eclipse.wb.internal.swing.databinding.Messages;
 
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.resource.LocalResourceManager;
+import org.eclipse.jface.resource.ResourceManager;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IDocumentPartitioner;
 import org.eclipse.jface.text.TextAttribute;
@@ -130,18 +133,19 @@ public final class EvalutionLanguageConfiguration extends SourceViewerConfigurat
 	@Override
 	public IContentAssistant getContentAssistant(ISourceViewer sourceViewer) {
 		final ContentAssistant contentAssistant = new ContentAssistant();
+		final ResourceManager resourceManager = new LocalResourceManager(JFaceResources.getResources());
 		// sets processors
 		contentAssistant.setContentAssistProcessor(
-				new ContentAssistProcessor(m_propertiesSupport, true),
-				IDocument.DEFAULT_CONTENT_TYPE);
-		contentAssistant.setContentAssistProcessor(new ContentAssistProcessor(m_propertiesSupport,
-				false), EXPRESSION_TYPE);
+				new ContentAssistProcessor(m_propertiesSupport, resourceManager, true), IDocument.DEFAULT_CONTENT_TYPE);
+		contentAssistant.setContentAssistProcessor(
+				new ContentAssistProcessor(m_propertiesSupport, resourceManager, false), EXPRESSION_TYPE);
 		// configure
 		contentAssistant.enableAutoActivation(true);
 		contentAssistant.enableAutoInsert(true);
 		contentAssistant.setAutoActivationDelay(200);
 		contentAssistant.setStatusLineVisible(true);
 		contentAssistant.setStatusMessage(Messages.EvalutionLanguageConfiguration_contentAssistMessage);
+		sourceViewer.getTextWidget().addDisposeListener(event -> resourceManager.dispose());
 		// CTRL + SPACE completion
 		sourceViewer.getTextWidget().addKeyListener(new KeyAdapter() {
 			@Override

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/wizards/autobindings/ObservePropertyAdapterLabelProvider.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/wizards/autobindings/ObservePropertyAdapterLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,9 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.databinding.wizards.autobindings;
 
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.resource.LocalResourceManager;
+import org.eclipse.jface.resource.ResourceManager;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.swt.graphics.Image;
 
@@ -20,11 +23,18 @@ import org.eclipse.swt.graphics.Image;
  * @coverage bindings.swing.wizard.auto
  */
 public final class ObservePropertyAdapterLabelProvider extends LabelProvider {
+	private final ResourceManager m_resourceManager = new LocalResourceManager(JFaceResources.getResources());
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// LabelProvider
 	//
 	////////////////////////////////////////////////////////////////////////////
+	@Override
+	public void dispose() {
+		super.dispose();
+		m_resourceManager.dispose();
+	}
+
 	@Override
 	public String getText(Object element) {
 		ObservePropertyAdapter adapter = (ObservePropertyAdapter) element;
@@ -35,7 +45,7 @@ public final class ObservePropertyAdapterLabelProvider extends LabelProvider {
 	public Image getImage(Object element) {
 		try {
 			ObservePropertyAdapter adapter = (ObservePropertyAdapter) element;
-			return adapter.getObserve().getPresentation().getImage();
+			return m_resourceManager.createImage(adapter.getObserve().getPresentation().getImageDescriptor());
 		} catch (Throwable e) {
 			return null;
 		}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/databinding/rcp/model/beans/BeanBindableTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/databinding/rcp/model/beans/BeanBindableTest.java
@@ -13,6 +13,7 @@ package org.eclipse.wb.tests.designer.databinding.rcp.model.beans;
 import org.eclipse.wb.internal.core.databinding.model.IObserveInfo;
 import org.eclipse.wb.internal.core.databinding.model.IObserveInfo.ChildrenContext;
 import org.eclipse.wb.internal.core.databinding.ui.ObserveType;
+import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.rcp.databinding.DatabindingsProvider;
 import org.eclipse.wb.internal.rcp.databinding.model.BindableInfo;
 import org.eclipse.wb.internal.rcp.databinding.model.beans.BeansObserveTypeContainer;
@@ -76,7 +77,7 @@ public class BeanBindableTest extends AbstractBindingTest {
 				FieldBeanBindableInfo.class,
 				"m_shell - Shell|m_shell|org.eclipse.swt.widgets.Shell",
 				observes.get(0));
-		assertSame(shell.getPresentation().getIcon(), observes.get(0).getPresentation().getImage());
+		assertSame(shell.getPresentation().getIcon(), ReflectionUtils.getFieldObject(observes.get(0).getPresentation().getImageDescriptor(), "originalImage"));
 		//
 		assertBindable(
 				FieldBeanBindableInfo.class,
@@ -337,7 +338,7 @@ public class BeanBindableTest extends AbstractBindingTest {
 				FieldBeanBindableInfo.class,
 				"m_shell - Shell|m_shell|org.eclipse.swt.widgets.Shell",
 				observes.get(0));
-		assertSame(shell.getPresentation().getIcon(), observes.get(0).getPresentation().getImage());
+		assertSame(shell.getPresentation().getIcon(), ReflectionUtils.getFieldObject(observes.get(0).getPresentation().getImageDescriptor(), "originalImage"));
 		//
 		assertBindable(
 				FieldBeanBindableInfo.class,


### PR DESCRIPTION
Image instances of those descriptors are handled via a resource manager. The lifecycle of the resource manager is bound to the lifecycle of its UI component.

For the ContentAssistProcessor, the resource manager has to be passed as an argument, due to the lack of a dispose() method. This manager is disposed together with the source viewer.

For the sake of simplicity, The ImageDescriptor.createForImage method is used to transform Images into ImageDescriptors. Example being e.g. the BeanBindablePresentation. Reason being that those images are used at multiple locations. Migrating them to ImageDescriptors would drastically increase the complexity of this change and should be handled by a separate commit.