### PR TITLE
[GEF] Figure should implement the IFigure interface.

### DIFF
--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/border/Border.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/border/Border.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,8 @@ package org.eclipse.wb.draw2d.border;
 import org.eclipse.wb.draw2d.Figure;
 
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Rectangle;
 
@@ -23,7 +25,7 @@ import org.eclipse.draw2d.geometry.Rectangle;
  * @author lobas_av
  * @coverage gef.draw2d
  */
-public abstract class Border {
+public abstract class Border implements org.eclipse.draw2d.Border {
 	private final Insets m_insets;
 
 	////////////////////////////////////////////////////////////////////////////
@@ -46,14 +48,22 @@ public abstract class Border {
 	/**
 	 * Get border insets.
 	 */
-	public Insets getInsets() {
+	public Insets getInsets(IFigure figure) {
 		return m_insets;
+	}
+
+	public Dimension getPreferredSize(IFigure figure) {
+		return figure.getPreferredSize();
+	}
+
+	public boolean isOpaque() {
+		return false;
 	}
 
 	/**
 	 * Paint border for <code>owner</code> {@link Figure}.
 	 */
-	public final void paint(Figure owner, Graphics graphics) {
+	public final void paint(IFigure owner, Graphics graphics, Insets insets) {
 		Rectangle bounds = owner.getBounds();
 		paint(bounds.width, bounds.height, graphics);
 	}

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/border/CompoundBorder.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/border/CompoundBorder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,7 @@
 package org.eclipse.wb.draw2d.border;
 
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Insets;
 
 /**
@@ -73,13 +74,13 @@ public class CompoundBorder extends Border {
 	 * Get border insets.
 	 */
 	@Override
-	public Insets getInsets() {
+	public Insets getInsets(IFigure figure) {
 		Insets insets = new Insets();
 		if (m_inner != null) {
-			insets.add(m_inner.getInsets());
+			insets.add(m_inner.getInsets(figure));
 		}
 		if (m_outer != null) {
-			insets.add(m_outer.getInsets());
+			insets.add(m_outer.getInsets(figure));
 		}
 		return insets;
 	}
@@ -95,7 +96,7 @@ public class CompoundBorder extends Border {
 			}
 			// update bounds for inner
 			{
-				Insets insets = m_outer.getInsets();
+				Insets insets = m_outer.getInsets(null);
 				graphics.translate(insets.left, insets.top);
 				ownerWidth -= insets.getWidth();
 				ownerHeight -= insets.getHeight();

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/EventManager.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/EventManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -200,12 +200,10 @@ public class EventManager implements MouseListener, MouseMoveListener, MouseTrac
 		Figure figure = m_captureFigure == null ? m_cursorFigure : m_captureFigure;
 		//
 		if (figure != null) {
-			List<T> listeners = figure.getListeners(listenerClass);
-			if (listeners != null && !listeners.isEmpty()) {
+			Iterator<T> listeners = figure.getListeners(listenerClass);
+			if (listeners != null && listeners.hasNext()) {
 				MouseEvent event = new MouseEvent(m_canvas, e, figure);
-				for (Iterator<T> I = listeners.iterator(); !event.isConsumed() && I.hasNext();) {
-					invoker.invokeListener(I.next(), event);
-				}
+				listeners.forEachRemaining(listener -> invoker.invokeListener(listener, event));
 				m_eventConsumed = event.isConsumed();
 			}
 		}

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/JustifyLabel.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/JustifyLabel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -58,7 +58,7 @@ public class JustifyLabel extends Figure {
 	/**
 	 * Returns the desirable size for this label's text.
 	 */
-	public Dimension getPreferredSize() {
+	public Dimension getPreferredSize(int wHint, int hHint) {
 		return m_preferredSize;
 	}
 

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/Label.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/Label.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -53,7 +53,7 @@ public class Label extends Figure {
 	/**
 	 * Returns the desirable size for this label's text.
 	 */
-	public Dimension getPreferredSize() {
+	public Dimension getPreferredSize(int wHint, int hHint) {
 		if (m_preferredSize == null) {
 			m_preferredSize = FigureUtils.calculateTextSize(m_text, getFont());
 			Insets insets = getInsets();

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/RootFigure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/RootFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -80,7 +80,7 @@ public class RootFigure extends Figure implements IRootFigure {
 	/**
 	 * Returns the desirable size for this container figure.
 	 */
-	public Dimension getPreferredSize() {
+	public Dimension getPreferredSize(int wHint, int hHint) {
 		// check preferred size
 		if (m_preferredSize == null) {
 			// calculate preferred size

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/VerticalLabel.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/VerticalLabel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -40,7 +40,7 @@ public final class VerticalLabel extends Label {
 	 * Returns the desirable size for this label's text.
 	 */
 	@Override
-	public Dimension getPreferredSize() {
+	public Dimension getPreferredSize(int wHint, int hHint) {
 		if (m_preferredSize == null) {
 			m_preferredSize = FigureUtils.calculateTextSize(getText(), getFont());
 			Insets insets = getInsets();

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/handles/Handle.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/handles/Handle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -47,14 +47,14 @@ public abstract class Handle extends Figure implements IAncestorListener {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void addNotify() {
+	public void addNotify() {
 		super.addNotify();
 		getOwnerFigure().addAncestorListener(this);
 		revalidate();
 	}
 
 	@Override
-	protected void removeNotify() {
+	public void removeNotify() {
 		getOwnerFigure().removeAncestorListener(this);
 		super.removeNotify();
 	}
@@ -74,7 +74,7 @@ public abstract class Handle extends Figure implements IAncestorListener {
 	// Revalidate
 	//
 	////////////////////////////////////////////////////////////////////////////
-	private void revalidate() {
+	public void revalidate() {
 		getLocator().relocate(this);
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
@@ -338,7 +338,7 @@ public final class PaletteComposite extends Composite {
 		/**
 		 * Lays out {@link CategoryFigure}'s of palette.
 		 */
-		private void layout() {
+		protected void layout() {
 			int width = m_figureCanvas.getClientArea().width;
 			width -= getInsets().getWidth();
 			//
@@ -381,7 +381,7 @@ public final class PaletteComposite extends Composite {
 		public CategoryFigure(ICategory category) {
 			m_category = category;
 			hookEvents();
-			setToolTip(this, null, m_category.getToolTipText());
+			PaletteComposite.setToolTip(this, null, m_category.getToolTipText());
 			onPreferencesUpdate();
 			// add entry figures
 			for (Object element : m_category.getEntries()) {
@@ -730,7 +730,7 @@ public final class PaletteComposite extends Composite {
 			if (m_entry.isEnabled()) {
 				hookEvents();
 			}
-			setToolTip(this, m_entry.getText(), m_entry.getToolTipText());
+			PaletteComposite.setToolTip(this, m_entry.getText(), m_entry.getToolTipText());
 			onPreferencesUpdate();
 		}
 

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/selection/ResizeHintFigure.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/selection/ResizeHintFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -88,7 +88,7 @@ public final class ResizeHintFigure extends Figure {
 	/**
 	 * @return the desirable size for this {@link ResizeHintFigure}.
 	 */
-	private Dimension getPreferredSize() {
+	public Dimension getPreferredSize(int wHint, int hHint) {
 		Font font = getFont();
 		int width = 0;
 		int height = 0;

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/selection/ResizeHintFigure.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/selection/ResizeHintFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -73,7 +73,7 @@ public final class ResizeHintFigure extends Figure {
 	/**
 	 * @return the desirable size for this {@link ResizeHintFigure}.
 	 */
-	private Dimension getPreferredSize() {
+	public Dimension getPreferredSize(int wHint, int hHint) {
 		GC gc = new GC(HIDDEN_SHELL);
 		try {
 			Graphics graphics = new SWTGraphics(gc);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/CompoundBorderTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/CompoundBorderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -41,7 +41,7 @@ public class CompoundBorderTest extends Draw2dFigureTestCase {
 		// check init state new empty border
 		assertNull(border.getInnerBorder());
 		assertNull(border.getOuterBorder());
-		assertEquals(new Insets(), border.getInsets());
+		assertEquals(new Insets(), border.getInsets(null));
 	}
 
 	public void test_constructor_Border_Border() throws Exception {
@@ -53,24 +53,24 @@ public class CompoundBorderTest extends Draw2dFigureTestCase {
 		//
 		assertSame(lineBorder, border.getOuterBorder());
 		assertSame(marginBorder, border.getInnerBorder());
-		assertEquals(new Insets(8, 9, 10, 11), border.getInsets());
+		assertEquals(new Insets(8, 9, 10, 11), border.getInsets(null));
 		//
 		// check work when out = LineBorder and inner = null
 		border = new CompoundBorder(lineBorder, null);
 		assertSame(lineBorder, border.getOuterBorder());
 		assertNull(border.getInnerBorder());
-		assertEquals(new Insets(7), border.getInsets());
+		assertEquals(new Insets(7), border.getInsets(null));
 		//
 		// check work when out = null and inner = MarginBorder
 		border = new CompoundBorder(null, marginBorder);
 		assertNull(border.getOuterBorder());
 		assertSame(marginBorder, border.getInnerBorder());
-		assertEquals(new Insets(1, 2, 3, 4), border.getInsets());
+		assertEquals(new Insets(1, 2, 3, 4), border.getInsets(null));
 		//
 		// check work when out = null and inner = null
 		border = new CompoundBorder(null, null);
 		assertNull(border.getInnerBorder());
 		assertNull(border.getOuterBorder());
-		assertEquals(new Insets(), border.getInsets());
+		assertEquals(new Insets(), border.getInsets(null));
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigureTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigureTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -872,7 +872,7 @@ public class FigureTest extends Draw2dFigureTestCase {
 		testFigure.addMouseListener(listener1);
 		//
 		// check add IMouseListener
-		List<IMouseListener> list = testFigure.getListeners(IMouseListener.class);
+		List<IMouseListener> list = Lists.newArrayList(testFigure.getListeners(IMouseListener.class));
 		assertNotNull(list);
 		assertEquals(1, list.size());
 		assertSame(listener1, list.get(0));
@@ -893,7 +893,7 @@ public class FigureTest extends Draw2dFigureTestCase {
 		testFigure.addMouseListener(listener2);
 		//
 		// again check add IMouseListener
-		list = testFigure.getListeners(IMouseListener.class);
+		list = Lists.newArrayList(testFigure.getListeners(IMouseListener.class));
 		assertNotNull(list);
 		assertEquals(2, list.size());
 		assertSame(listener1, list.get(0));
@@ -901,14 +901,14 @@ public class FigureTest extends Draw2dFigureTestCase {
 		//
 		// check remove IMouseListener
 		testFigure.removeMouseListener(listener1);
-		list = testFigure.getListeners(IMouseListener.class);
+		list = Lists.newArrayList(testFigure.getListeners(IMouseListener.class));
 		assertNotNull(list);
 		assertEquals(1, list.size());
 		assertSame(listener2, list.get(0));
 		//
 		// again check remove IMouseListener
 		testFigure.removeMouseListener(listener2);
-		list = testFigure.getListeners(IMouseListener.class);
+		list = Lists.newArrayList(testFigure.getListeners(IMouseListener.class));
 		assertNotNull(list);
 		assertEquals(0, list.size());
 	}
@@ -927,7 +927,7 @@ public class FigureTest extends Draw2dFigureTestCase {
 		//
 		// check add IMouseMoveListener
 		testFigure.addMouseMoveListener(listener1);
-		List<IMouseMoveListener> list = testFigure.getListeners(IMouseMoveListener.class);
+		List<IMouseMoveListener> list = Lists.newArrayList(testFigure.getListeners(IMouseMoveListener.class));
 		assertNotNull(list);
 		assertEquals(1, list.size());
 		assertSame(listener1, list.get(0));
@@ -940,7 +940,7 @@ public class FigureTest extends Draw2dFigureTestCase {
 		//
 		// again check add IMouseMoveListener
 		testFigure.addMouseMoveListener(listener2);
-		list = testFigure.getListeners(IMouseMoveListener.class);
+		list = Lists.newArrayList(testFigure.getListeners(IMouseMoveListener.class));
 		assertNotNull(list);
 		assertEquals(2, list.size());
 		assertSame(listener1, list.get(0));
@@ -948,14 +948,14 @@ public class FigureTest extends Draw2dFigureTestCase {
 		//
 		// check remove IMouseMoveListener
 		testFigure.removeMouseMoveListener(listener1);
-		list = testFigure.getListeners(IMouseMoveListener.class);
+		list = Lists.newArrayList(testFigure.getListeners(IMouseMoveListener.class));
 		assertNotNull(list);
 		assertEquals(1, list.size());
 		assertSame(listener2, list.get(0));
 		//
 		// again check remove IMouseMoveListener
 		testFigure.removeMouseMoveListener(listener2);
-		list = testFigure.getListeners(IMouseMoveListener.class);
+		list = Lists.newArrayList(testFigure.getListeners(IMouseMoveListener.class));
 		assertNotNull(list);
 		assertEquals(0, list.size());
 	}
@@ -978,7 +978,7 @@ public class FigureTest extends Draw2dFigureTestCase {
 		testFigure.addFigureListener(listener1);
 		//
 		// check add IFigureListener
-		List<IFigureListener> list = testFigure.getListeners(IFigureListener.class);
+		List<IFigureListener> list = Lists.newArrayList(testFigure.getListeners(IFigureListener.class));
 		assertNotNull(list);
 		assertEquals(1, list.size());
 		assertSame(listener1, list.get(0));
@@ -995,7 +995,7 @@ public class FigureTest extends Draw2dFigureTestCase {
 		testFigure.addFigureListener(listener2);
 		//
 		// again check add IFigureListener
-		list = testFigure.getListeners(IFigureListener.class);
+		list = Lists.newArrayList(testFigure.getListeners(IFigureListener.class));
 		assertNotNull(list);
 		assertEquals(2, list.size());
 		assertSame(listener1, list.get(0));
@@ -1003,14 +1003,14 @@ public class FigureTest extends Draw2dFigureTestCase {
 		//
 		// check remove IFigureListener
 		testFigure.removeFigureListener(listener1);
-		list = testFigure.getListeners(IFigureListener.class);
+		list = Lists.newArrayList(testFigure.getListeners(IFigureListener.class));
 		assertNotNull(list);
 		assertEquals(1, list.size());
 		assertSame(listener2, list.get(0));
 		//
 		// again check remove IFigureListener
 		testFigure.removeFigureListener(listener2);
-		list = testFigure.getListeners(IFigureListener.class);
+		list = Lists.newArrayList(testFigure.getListeners(IFigureListener.class));
 		assertNotNull(list);
 		assertEquals(0, list.size());
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/LineBorderTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/LineBorderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -38,7 +38,7 @@ public class LineBorderTest extends Draw2dFigureTestCase {
 		// check init state properties for new border
 		assertNull(border.getColor());
 		assertEquals(1, border.getWidth());
-		assertEquals(new Insets(1), border.getInsets());
+		assertEquals(new Insets(1), border.getInsets(null));
 	}
 
 	public void test_constructor_int() throws Exception {
@@ -46,7 +46,7 @@ public class LineBorderTest extends Draw2dFigureTestCase {
 		// check init state properties for border constructor(int)
 		assertNull(border.getColor());
 		assertEquals(3, border.getWidth());
-		assertEquals(new Insets(3), border.getInsets());
+		assertEquals(new Insets(3), border.getInsets(null));
 	}
 
 	public void test_constructor_Color() throws Exception {
@@ -54,7 +54,7 @@ public class LineBorderTest extends Draw2dFigureTestCase {
 		// check init state properties for border constructor(Color)
 		assertSame(red, border.getColor());
 		assertEquals(1, border.getWidth());
-		assertEquals(new Insets(1), border.getInsets());
+		assertEquals(new Insets(1), border.getInsets(null));
 	}
 
 	public void test_constructor_Color_int() throws Exception {
@@ -62,6 +62,6 @@ public class LineBorderTest extends Draw2dFigureTestCase {
 		LineBorder border = new LineBorder(blue, 7);
 		assertSame(blue, border.getColor());
 		assertEquals(7, border.getWidth());
-		assertEquals(new Insets(7), border.getInsets());
+		assertEquals(new Insets(7), border.getInsets(null));
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/MarginBorderTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/MarginBorderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,9 +35,9 @@ public class MarginBorderTest extends Draw2dFigureTestCase {
 	////////////////////////////////////////////////////////////////////////////
 	public void test_constructor() throws Exception {
 		// check work constructor (int, int, int, int)
-		assertEquals(new Insets(1, 2, 3, 4), new MarginBorder(new Insets(1, 2, 3, 4)).getInsets());
+		assertEquals(new Insets(1, 2, 3, 4), new MarginBorder(new Insets(1, 2, 3, 4)).getInsets(null));
 		//
 		// check work constructor (int)
-		assertEquals(new Insets(7, 7, 7, 7), new MarginBorder(7).getInsets());
+		assertEquals(new Insets(7, 7, 7, 7), new MarginBorder(7).getInsets(null));
 	}
 }


### PR DESCRIPTION
Most of the GEF/Draw2D API expects an object of type IFigure as an argument. In order to simplify the migration to downstream GEF, our own figure implementation should implement this interface so that we can gradually build back our own classes.

Instead of implementing the entire IFigure interface, we instead extend the Figure base class, overwriting all non-trivial (and non-final) methods with the already existing implementation. Due to a bi-directional relation between Figure and Border, it is also necessary for our Border base-class to implement the corresponding Draw2D interface.