### PR TITLE
IMenuObjectInfo should use ImageDescriptor instead of Image.

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/MenuImageFigure.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/MenuImageFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.internal.core.model.menu.IMenuInfo;
 
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
 
 /**
@@ -41,7 +42,9 @@ public class MenuImageFigure extends Figure {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	protected void paintClientArea(Graphics graphics) {
-		Image image = m_menu.getImage();
+		ImageDescriptor imageDescriptor = m_menu.getImageDescriptor();
+		Image image = imageDescriptor.createImage();
 		graphics.drawImage(image, 0, 0);
+		image.dispose();
 	}
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/MenuItemEditPart.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/MenuItemEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import org.eclipse.wb.internal.core.model.menu.IMenuItemInfo;
 
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
 
 /**
@@ -52,9 +53,11 @@ public final class MenuItemEditPart extends SubmenuAwareEditPart {
 			protected void paintClientArea(Graphics graphics) {
 				// draw image
 				{
-					Image image = m_item.getImage();
-					if (image != null) {
+					ImageDescriptor imageDescriptor = m_item.getImageDescriptor();
+					if (imageDescriptor != null) {
+						Image image = imageDescriptor.createImage();
 						graphics.drawImage(image, 0, 0);
+						image.dispose();
 					}
 				}
 				// highlight "item" with displayed "menu"

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/MenuPopupEditPart.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/MenuPopupEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import org.eclipse.wb.internal.core.model.menu.IMenuPopupInfo;
 
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
 
 /**
@@ -52,9 +53,11 @@ public final class MenuPopupEditPart extends SubmenuAwareEditPart {
 			protected void paintClientArea(Graphics graphics) {
 				// draw image
 				{
-					Image image = m_popup.getImage();
-					if (image != null) {
+					ImageDescriptor imageDescriptor = m_popup.getImageDescriptor();
+					if (imageDescriptor != null) {
+						Image image = imageDescriptor.createImage();
 						graphics.drawImage(image, 0, 0);
+						image.dispose();
 					}
 				}
 				// highlight "item" with displayed "menu"

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/menu/IMenuObjectInfo.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/menu/IMenuObjectInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,7 @@ import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 
 import org.eclipse.draw2d.geometry.Rectangle;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * Common interface for any menu object.
@@ -62,11 +62,11 @@ public interface IMenuObjectInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * @return the {@link Image} to show as presentation, may be <code>null</code>. If
+	 * @return the {@link ImageDescriptor} to show as presentation, may be <code>null</code>. If
 	 *         <code>null</code>, then only {@link #getBounds()} will be used to select area on
 	 *         parent's presentation.
 	 */
-	Image getImage();
+	ImageDescriptor getImageDescriptor();
 	/**
 	 * @return the location/size of this object presentation on parent's presentation.
 	 */

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/MenuManagerAdaptableFactory.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/MenuManagerAdaptableFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,9 @@ import org.eclipse.wb.internal.core.model.menu.IMenuPolicy;
 import org.eclipse.wb.internal.core.utils.IAdaptableFactory;
 
 import org.eclipse.draw2d.geometry.Rectangle;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
+
+import java.util.Optional;
 
 /**
  * Implementation of {@link IAdaptableFactory} for children of {@link MenuManagerInfo}.
@@ -89,8 +91,8 @@ public final class MenuManagerAdaptableFactory implements IAdaptableFactory {
 		//
 		////////////////////////////////////////////////////////////////////////////
 		@Override
-		public Image getImage() {
-			return m_item.getImage();
+		public ImageDescriptor getImageDescriptor() {
+			return Optional.ofNullable(m_item.getImage()).map(ImageDescriptor::createFromImage).orElse(null);
 		}
 
 		@Override

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/MenuManagerInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/MenuManagerInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -36,12 +36,13 @@ import org.eclipse.wb.internal.swt.support.ToolkitSupport;
 
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.jface.action.IMenuManager;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Model for {@link IMenuManager}.
@@ -209,7 +210,7 @@ IAdaptable {
 		//
 		////////////////////////////////////////////////////////////////////////////
 		@Override
-		public Image getImage() {
+		public ImageDescriptor getImageDescriptor() {
 			return null;
 		}
 
@@ -265,8 +266,11 @@ IAdaptable {
 		//
 		////////////////////////////////////////////////////////////////////////////
 		@Override
-		public Image getImage() {
-			return m_visualData.m_menuImage;
+		public ImageDescriptor getImageDescriptor() {
+			if (m_visualData == null || m_visualData.m_menuImage == null) {
+				return null;
+			}
+			return ImageDescriptor.createFromImage(m_visualData.m_menuImage);
 		}
 
 		@Override

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/MenuManagerPopupInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/MenuManagerPopupInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,7 @@ import org.eclipse.wb.internal.core.model.menu.JavaMenuMenuObject;
 import org.eclipse.wb.internal.core.model.menu.MenuObjectInfoUtils;
 
 import org.eclipse.draw2d.geometry.Rectangle;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * Implementation of {@link IMenuPopupInfo} for dropping down some {@link MenuManagerInfo}.
@@ -67,7 +67,7 @@ public final class MenuManagerPopupInfo extends JavaMenuMenuObject implements IM
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getImage() {
+	public ImageDescriptor getImageDescriptor() {
 		return null;
 	}
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/menu/ComponentMenuItemInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/menu/ComponentMenuItemInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,9 @@ import org.eclipse.wb.internal.core.model.menu.IMenuPolicy;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 
 import org.eclipse.draw2d.geometry.Rectangle;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
+
+import java.util.Optional;
 
 /**
  * Implementation of {@link IMenuItemInfo} for any {@link ComponentInfo}.
@@ -52,8 +54,8 @@ public class ComponentMenuItemInfo extends AbstractMenuObject implements IMenuIt
 	// Presentation
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public Image getImage() {
-		return m_component.getImage();
+	public ImageDescriptor getImageDescriptor() {
+		return Optional.ofNullable(m_component.getImage()).map(ImageDescriptor::createFromImage).orElse(null);
 	}
 
 	public Rectangle getBounds() {

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/menu/JMenuBarInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/menu/JMenuBarInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,11 +28,12 @@ import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 import org.eclipse.wb.internal.swing.utils.SwingImageUtils;
 
 import org.eclipse.draw2d.geometry.Rectangle;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.awt.Component;
 import java.awt.Container;
 import java.util.List;
+import java.util.Optional;
 
 import javax.swing.JApplet;
 import javax.swing.JDialog;
@@ -186,8 +187,11 @@ public final class JMenuBarInfo extends ContainerInfo implements IAdaptable {
 		// Presentation
 		//
 		////////////////////////////////////////////////////////////////////////////
-		public Image getImage() {
-			return m_visualData.m_menuImage;
+		public ImageDescriptor getImageDescriptor() {
+			if (m_visualData == null || m_visualData.m_menuImage == null) {
+				return null;
+			}
+			return ImageDescriptor.createFromImage(m_visualData.m_menuImage);
 		}
 
 		public Rectangle getBounds() {

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/menu/JMenuInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/menu/JMenuInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,10 +23,11 @@ import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.swing.utils.SwingImageUtils;
 
 import org.eclipse.draw2d.geometry.Rectangle;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.awt.Component;
 import java.util.List;
+import java.util.Optional;
 
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
@@ -180,7 +181,7 @@ public final class JMenuInfo extends JMenuItemInfo {
 		// Presentation
 		//
 		////////////////////////////////////////////////////////////////////////////
-		public Image getImage() {
+		public ImageDescriptor getImageDescriptor() {
 			return null;
 		}
 
@@ -231,8 +232,11 @@ public final class JMenuInfo extends JMenuItemInfo {
 		// Presentation
 		//
 		////////////////////////////////////////////////////////////////////////////
-		public Image getImage() {
-			return m_visualData.m_menuImage;
+		public ImageDescriptor getImageDescriptor() {
+			if (m_visualData == null || m_visualData.m_menuImage == null) {
+				return null;
+			}
+			return ImageDescriptor.createFromImage(m_visualData.m_menuImage);
 		}
 
 		public Rectangle getBounds() {

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/menu/JMenuItemInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/menu/JMenuItemInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@ import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 
 import org.eclipse.draw2d.geometry.Rectangle;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import javax.swing.JMenuItem;
 
@@ -107,7 +107,7 @@ public class JMenuItemInfo extends ContainerInfo implements IAdaptable {
 		// Presentation
 		//
 		////////////////////////////////////////////////////////////////////////////
-		public Image getImage() {
+		public ImageDescriptor getImageDescriptor() {
 			return null;
 		}
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/menu/JPopupMenuInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/menu/JPopupMenuInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,18 +28,20 @@ import org.eclipse.wb.internal.core.model.order.ComponentOrderFirst;
 import org.eclipse.wb.internal.core.utils.IAdaptable;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 import org.eclipse.wb.internal.swing.utils.SwingImageUtils;
 
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageData;
 
 import java.awt.Component;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.List;
+import java.util.Optional;
 
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
@@ -236,17 +238,14 @@ public final class JPopupMenuInfo extends ContainerInfo implements IAdaptable {
 		// Presentation
 		//
 		////////////////////////////////////////////////////////////////////////////
-		public Image getImage() {
-			return ExecutionUtils.runObjectLog(new RunnableObjectEx<Image>() {
-				public Image runObject() throws Exception {
-					return getPresentation().getIcon();
-				}
-			}, getDescription().getIcon());
+		public ImageDescriptor getImageDescriptor() {
+			Image image = ExecutionUtils.runObjectLog(() -> getPresentation().getIcon(), getDescription().getIcon());
+			return image == null ? null : ImageDescriptor.createFromImage(image);
 		}
 
 		public Rectangle getBounds() {
-			Image image = getImage();
-			return new Rectangle(0, 0, image.getBounds().width, image.getBounds().height);
+			ImageData imageData = getImageDescriptor().getImageData(100);
+			return new Rectangle(0, 0, imageData.width, imageData.height);
 		}
 
 		////////////////////////////////////////////////////////////////////////////
@@ -292,8 +291,11 @@ public final class JPopupMenuInfo extends ContainerInfo implements IAdaptable {
 		// Presentation
 		//
 		////////////////////////////////////////////////////////////////////////////
-		public Image getImage() {
-			return m_visualData.m_menuImage;
+		public ImageDescriptor getImageDescriptor() {
+			if (m_visualData == null || m_visualData.m_menuImage == null) {
+				return null;
+			}
+			return ImageDescriptor.createFromImage(m_visualData.m_menuImage);
 		}
 
 		public Rectangle getBounds() {

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/widgets/menu/MenuInfo.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/widgets/menu/MenuInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -54,7 +54,9 @@ import org.eclipse.wb.internal.swt.support.ToolkitSupport;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Decorations;
 import org.eclipse.swt.widgets.Display;
@@ -62,6 +64,7 @@ import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Model for SWT menu.
@@ -336,19 +339,15 @@ public final class MenuInfo extends WidgetInfo implements IAdaptable {
 		//
 		////////////////////////////////////////////////////////////////////////////
 		@Override
-		public Image getImage() {
-			return ExecutionUtils.runObjectLog(new RunnableObjectEx<Image>() {
-				@Override
-				public Image runObject() throws Exception {
-					return getPresentation().getIcon();
-				}
-			}, getDescription().getIcon());
+		public ImageDescriptor getImageDescriptor() {
+			Image image = ExecutionUtils.runObjectLog(() -> getPresentation().getIcon(), getDescription().getIcon());
+			return image == null ? null : ImageDescriptor.createFromImage(image);
 		}
 
 		@Override
 		public Rectangle getBounds() {
-			Image image = getImage();
-			return new Rectangle(0, 0, image.getBounds().width, image.getBounds().height);
+			ImageData imageData = getImageDescriptor().getImageData(100);
+			return new Rectangle(0, 0, imageData.width, imageData.height);
 		}
 
 		////////////////////////////////////////////////////////////////////////////
@@ -398,8 +397,8 @@ public final class MenuInfo extends WidgetInfo implements IAdaptable {
 		//
 		////////////////////////////////////////////////////////////////////////////
 		@Override
-		public Image getImage() {
-			return m_this.getImage();
+		public ImageDescriptor getImageDescriptor() {
+			return Optional.ofNullable(m_this.getImage()).map(ImageDescriptor::createFromImage).orElse(null);
 		}
 
 		@Override

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/widgets/menu/MenuItemInfo.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/widgets/menu/MenuItemInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -43,9 +43,10 @@ import org.eclipse.wb.internal.swt.support.MenuSupport;
 import org.eclipse.wb.internal.swt.support.SwtSupport;
 
 import org.eclipse.draw2d.geometry.Rectangle;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Class representing menu item model for SWT menu item object.
@@ -298,8 +299,8 @@ org.eclipse.wb.internal.core.utils.IAdaptable {
 		//
 		////////////////////////////////////////////////////////////////////////////
 		@Override
-		public Image getImage() {
-			return m_this.getImage();
+		public ImageDescriptor getImageDescriptor() {
+			return Optional.ofNullable(m_this.getImage()).map(ImageDescriptor::createFromImage).orElse(null);
 		}
 
 		@Override

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XWT/model/widgets/menu/MenuItemTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XWT/model/widgets/menu/MenuItemTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -206,7 +206,7 @@ public class MenuItemTest extends XwtModelTest {
 			assertSame(itemInfo, itemObject.getModel());
 			assertSame(MenuObjectInfoUtils.getMenuInfo(menuInfo), itemObject.getMenu());
 			// presentation
-			assertSame(itemInfo.getImage(), itemObject.getImage());
+			assertSame(itemInfo.getImage(), itemObject.getImageDescriptor());
 			assertSame(itemInfo.getBounds(), itemObject.getBounds());
 		}
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XWT/model/widgets/menu/MenuTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XWT/model/widgets/menu/MenuTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -221,7 +221,7 @@ public class MenuTest extends XwtModelTest {
 		IMenuInfo menuObject = menuInfo.getAdapter(IMenuInfo.class);
 		assertNotNull(menuObject);
 		assertSame(menuInfo, menuObject.getModel());
-		assertSame(menuInfo.getImage(), menuObject.getImage());
+		assertSame(menuInfo.getImage(), menuObject.getImageDescriptor());
 		assertSame(menuInfo.getBounds(), menuObject.getBounds());
 		assertTrue(menuObject.isHorizontal());
 		{
@@ -249,7 +249,7 @@ public class MenuTest extends XwtModelTest {
 		IMenuInfo menuObject = menuInfo.getAdapter(IMenuInfo.class);
 		assertNotNull(menuObject);
 		assertSame(menuObject, menuObject.getModel());
-		assertSame(menuInfo.getImage(), menuObject.getImage());
+		assertSame(menuInfo.getImage(), menuObject.getImageDescriptor());
 		assertSame(menuInfo.getBounds(), menuObject.getBounds());
 		assertFalse(menuObject.isHorizontal());
 	}
@@ -273,7 +273,7 @@ public class MenuTest extends XwtModelTest {
 		IMenuPopupInfo popupObject = menuInfo.getAdapter(IMenuPopupInfo.class);
 		assertNotNull(popupObject);
 		assertSame(menuInfo, popupObject.getModel());
-		assertSame(menuInfo.getPresentation().getIcon(), popupObject.getImage());
+		assertSame(menuInfo.getPresentation().getIcon(), popupObject.getImageDescriptor());
 		assertEquals(16, popupObject.getBounds().width);
 		assertEquals(16, popupObject.getBounds().height);
 		assertSame(IMenuPolicy.NOOP, popupObject.getPolicy());

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/MenuManagerTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/MenuManagerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -324,7 +324,7 @@ public class MenuManagerTest extends RcpModelTest {
 			IMenuInfo menuObject = MenuObjectInfoUtils.getMenuInfo(menuInfo);
 			assertSame(menuObject, menuObject.getModel());
 			// presentation
-			assertNull(menuObject.getImage());
+			assertNull(menuObject.getImageDescriptor());
 			assertThat(menuObject.getBounds().width).isGreaterThan(400);
 			assertThat(menuObject.getBounds().height).isGreaterThan(18);
 			// access
@@ -419,7 +419,7 @@ public class MenuManagerTest extends RcpModelTest {
 			IMenuInfo menuObject = MenuObjectInfoUtils.getMenuInfo(menuInfo);
 			assertSame(menuObject, menuObject.getModel());
 			// presentation
-			assertNull(menuObject.getImage());
+			assertNull(menuObject.getImageDescriptor());
 			assertThat(menuObject.getBounds().width).isGreaterThan(400);
 			assertThat(menuObject.getBounds().height).isGreaterThan(18);
 			// access
@@ -433,8 +433,8 @@ public class MenuManagerTest extends RcpModelTest {
 				IMenuItemInfo itemObject = items.get(0);
 				assertSame(itemInfo_1, itemObject.getModel());
 				// presentation
-				assertNull(itemObject.getImage());
-				assertSame(itemInfo_1.getImage(), itemObject.getImage());
+				assertNull(itemObject.getImageDescriptor());
+				assertSame(itemInfo_1.getImage(), itemObject.getImageDescriptor());
 				assertSame(itemInfo_1.getBounds(), itemObject.getBounds());
 				assertThat(itemObject.getBounds().width).isGreaterThan(50);
 				assertThat(itemObject.getBounds().height).isGreaterThan(18);
@@ -448,7 +448,7 @@ public class MenuManagerTest extends RcpModelTest {
 			IMenuItemInfo itemObject = MenuObjectInfoUtils.getMenuItemInfo(subMenuInfo);
 			assertSame(subMenuInfo, itemObject.getModel());
 			// presentation
-			assertNull(itemObject.getImage());
+			assertNull(itemObject.getImageDescriptor());
 			assertThat(itemObject.getBounds().width).isGreaterThan(50);
 			assertThat(itemObject.getBounds().height).isGreaterThan(18);
 			// access
@@ -460,7 +460,7 @@ public class MenuManagerTest extends RcpModelTest {
 			IMenuInfo menuObject = MenuObjectInfoUtils.getMenuInfo(subMenuInfo);
 			assertSame(menuObject, menuObject.getModel());
 			// presentation
-			assertNotNull(menuObject.getImage());
+			assertNotNull(menuObject.getImageDescriptor());
 			assertThat(menuObject.getBounds().width).isGreaterThan(50);
 			assertThat(menuObject.getBounds().height).isGreaterThan(18);
 			// access

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/rcp/PageTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/rcp/PageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -104,7 +104,7 @@ public class PageTest extends RcpModelTest {
 			assertSame(manager, popupObject.getModel());
 			assertSame(manager, popupObject.getToolkitModel());
 			// presentation
-			assertNull(popupObject.getImage());
+			assertNull(popupObject.getImageDescriptor());
 			assertThat(popupObject.getBounds().width).isGreaterThan(10);
 			assertThat(popupObject.getBounds().height).isGreaterThan(10);
 			// menu

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/rcp/ViewPartTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/rcp/ViewPartTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -116,7 +116,7 @@ public class ViewPartTest extends RcpModelTest {
 			assertSame(manager, popupObject.getModel());
 			assertSame(manager, popupObject.getToolkitModel());
 			// presentation
-			assertNull(popupObject.getImage());
+			assertNull(popupObject.getImageDescriptor());
 			assertThat(popupObject.getBounds().width).isGreaterThan(10);
 			assertThat(popupObject.getBounds().height).isGreaterThan(10);
 			// menu

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/menu/JMenuBarTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/menu/JMenuBarTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,7 +27,8 @@ import org.eclipse.wb.internal.swing.model.component.menu.JMenuItemInfo;
 import org.eclipse.wb.tests.designer.swing.SwingModelTest;
 
 import org.eclipse.draw2d.geometry.Rectangle;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.swt.graphics.ImageData;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -126,13 +127,13 @@ public class JMenuBarTest extends SwingModelTest {
 		// IMenuInfo
 		IMenuInfo menuObject = MenuObjectInfoUtils.getMenuInfo(barInfo);
 		{
-			Image image = menuObject.getImage();
+			ImageDescriptor image = menuObject.getImageDescriptor();
 			assertNotNull(image);
-			org.eclipse.swt.graphics.Rectangle bounds = image.getBounds();
-			assertThat(bounds.x).isEqualTo(0);
-			assertThat(bounds.y).isEqualTo(0);
-			assertThat(bounds.width).isGreaterThan(40);
-			assertThat(bounds.height).isGreaterThan(20);
+			ImageData imageData = image.getImageData(100);
+			assertThat(imageData.x).isEqualTo(0);
+			assertThat(imageData.y).isEqualTo(0);
+			assertThat(imageData.width).isGreaterThan(40);
+			assertThat(imageData.height).isGreaterThan(20);
 		}
 		{
 			Rectangle bounds = menuObject.getBounds();
@@ -227,7 +228,7 @@ public class JMenuBarTest extends SwingModelTest {
 			// presentation
 			{
 				// no image for "bar"
-				assertNull(menuObject.getImage());
+				assertNull(menuObject.getImageDescriptor());
 				// "bar" has same width as "contentPane"
 				assertEquals(contentPaneInfo.getBounds().width, menuObject.getBounds().width);
 				// items on "bar" are placed horizontally
@@ -322,7 +323,7 @@ public class JMenuBarTest extends SwingModelTest {
 			// model
 			assertSame(newButtonInfo, item.getModel());
 			// presentation
-			assertSame(newButtonInfo.getImage(), item.getImage());
+			assertSame(newButtonInfo.getImage(), item.getImageDescriptor());
 			assertEquals(newButtonInfo.getBounds(), item.getBounds());
 			// no sub-menu
 			assertNull(item.getMenu());

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/menu/JMenuItemTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/menu/JMenuItemTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -64,7 +64,7 @@ public class JMenuItemTest extends SwingModelTest {
 			IMenuItemInfo itemObject = MenuObjectInfoUtils.getMenuItemInfo(itemInfo);
 			assertSame(itemInfo, itemObject.getModel());
 			// presentation
-			assertNull(itemObject.getImage());
+			assertNull(itemObject.getImageDescriptor());
 			assertTrue(itemObject.getBounds().width > 40);
 			assertTrue(itemObject.getBounds().height > 15);
 			// in Swing JMenuItem is just item, without sub-menu

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/menu/JMenuTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/menu/JMenuTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -120,14 +120,13 @@ public class JMenuTest extends SwingModelTest {
 		JMenuInfo menuInfo = getJavaInfoByName("menu");
 		IMenuInfo menuObject = MenuObjectInfoUtils.getMenuInfo(menuInfo);
 		Image asItem = menuInfo.getImage();
-		Image asMenu = menuObject.getImage();
 		// initially images exist
 		assertFalse(asItem.isDisposed());
-		assertFalse(asMenu.isDisposed());
+		assertNotNull(menuObject.getImageDescriptor());
 		// dispose model
 		disposeLastModel();
 		assertTrue(asItem.isDisposed());
-		assertTrue(asMenu.isDisposed());
+		assertNull(menuObject.getImageDescriptor());
 	}
 
 	/**
@@ -223,7 +222,7 @@ public class JMenuTest extends SwingModelTest {
 			itemObject = MenuObjectInfoUtils.getMenuItemInfo(menuInfo);
 			assertSame(menuInfo, itemObject.getModel());
 			// presentation
-			assertNull(itemObject.getImage());
+			assertNull(itemObject.getImageDescriptor());
 			assertEquals(menuInfo.getBounds(), itemObject.getBounds());
 			// menu
 			assertSame(MenuObjectInfoUtils.getMenuInfo(menuInfo), itemObject.getMenu());
@@ -234,7 +233,7 @@ public class JMenuTest extends SwingModelTest {
 			menuObject = MenuObjectInfoUtils.getMenuInfo(menuInfo);
 			assertSame(menuObject, menuObject.getModel());
 			// presentation
-			assertNotNull(menuObject.getImage());
+			assertNotNull(menuObject.getImageDescriptor());
 			assertTrue(menuObject.getBounds().width > 50);
 			assertTrue(menuObject.getBounds().height > 2 * 15);
 			assertFalse(menuObject.isHorizontal());
@@ -285,7 +284,7 @@ public class JMenuTest extends SwingModelTest {
 			menuObject = MenuObjectInfoUtils.getMenuInfo(menuInfo);
 			assertSame(menuObject, menuObject.getModel());
 			// presentation
-			assertNotNull(menuObject.getImage());
+			assertNotNull(menuObject.getImageDescriptor());
 			{
 				Rectangle bounds = menuObject.getBounds();
 				assertThat(bounds.width > 50);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/menu/JPopupMenuTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/menu/JPopupMenuTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,6 +21,7 @@ import org.eclipse.wb.internal.core.model.menu.IMenuPopupInfo;
 import org.eclipse.wb.internal.core.model.menu.MenuObjectInfoUtils;
 import org.eclipse.wb.internal.core.model.variable.VariableSupport;
 import org.eclipse.wb.internal.core.model.variable.VoidInvocationVariableSupport;
+import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 import org.eclipse.wb.internal.swing.model.component.menu.JMenuItemInfo;
@@ -102,7 +103,7 @@ public class JPopupMenuTest extends SwingModelTest {
 			IMenuPopupInfo popupObject = MenuObjectInfoUtils.getMenuPopupInfo(popupInfo);
 			assertSame(popupInfo, popupObject.getModel());
 			// presentation
-			assertSame(popupInfo.getDescription().getIcon(), popupObject.getImage());
+			assertSame(popupInfo.getDescription().getIcon(), ReflectionUtils.getFieldObject(popupObject.getImageDescriptor(), "originalImage"));
 			assertEquals(new Rectangle(0, 0, 16, 16), popupObject.getBounds());
 			// no policy
 			assertSame(IMenuPolicy.NOOP, popupObject.getPolicy());
@@ -112,7 +113,7 @@ public class JPopupMenuTest extends SwingModelTest {
 			IMenuInfo menuObject = MenuObjectInfoUtils.getMenuPopupInfo(popupInfo).getMenu();
 			assertSame(menuObject, menuObject.getModel());
 			// presentation
-			assertNotNull(menuObject.getImage());
+			assertNotNull(menuObject.getImageDescriptor());
 			assertThat(menuObject.getBounds().width).isGreaterThan(50);
 			assertThat(menuObject.getBounds().height).isGreaterThanOrEqualTo(40);
 			// items
@@ -188,7 +189,7 @@ public class JPopupMenuTest extends SwingModelTest {
 			IMenuInfo menuObject = popupObject.getMenu();
 			assertSame(menuObject, menuObject.getModel());
 			// presentation
-			assertNotNull(menuObject.getImage());
+			assertNotNull(menuObject.getImageDescriptor());
 			{
 				Rectangle bounds = menuObject.getBounds();
 				assertThat(bounds.width > 50);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/AbstractMenuObjectTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/AbstractMenuObjectTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,7 @@ import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.tests.designer.tests.DesignerTestCase;
 
 import org.eclipse.draw2d.geometry.Rectangle;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -51,7 +51,7 @@ public class AbstractMenuObjectTest extends DesignerTestCase {
 			}
 
 			@Override
-			public Image getImage() {
+			public ImageDescriptor getImageDescriptor() {
 				throw new NotImplementedException();
 			}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuItemTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuItemTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -185,7 +185,7 @@ public class MenuItemTest extends RcpModelTest {
 			assertSame(itemInfo, itemObject.getModel());
 			assertSame(MenuObjectInfoUtils.getMenuInfo(menuInfo), itemObject.getMenu());
 			// presentation
-			assertSame(itemInfo.getImage(), itemObject.getImage());
+			assertSame(itemInfo.getImage(), itemObject.getImageDescriptor());
 			assertSame(itemInfo.getBounds(), itemObject.getBounds());
 		}
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,6 +26,7 @@ import org.eclipse.wb.internal.core.model.menu.IMenuPopupInfo;
 import org.eclipse.wb.internal.core.model.menu.MenuObjectInfoUtils;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
+import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 import org.eclipse.wb.internal.swt.model.widgets.menu.MenuInfo;
@@ -213,7 +214,7 @@ public class MenuTest extends RcpModelTest {
 		IMenuInfo menuObject = menuInfo.getAdapter(IMenuInfo.class);
 		assertNotNull(menuObject);
 		assertSame(menuInfo, menuObject.getModel());
-		assertSame(menuInfo.getImage(), menuObject.getImage());
+		assertSame(menuInfo.getImage(), menuObject.getImageDescriptor());
 		assertSame(menuInfo.getBounds(), menuObject.getBounds());
 		assertTrue(menuObject.isHorizontal());
 		{
@@ -241,7 +242,7 @@ public class MenuTest extends RcpModelTest {
 		IMenuInfo menuObject = menuInfo.getAdapter(IMenuInfo.class);
 		assertNotNull(menuObject);
 		assertSame(menuObject, menuObject.getModel());
-		assertSame(menuInfo.getImage(), menuObject.getImage());
+		assertSame(menuInfo.getImage(), ReflectionUtils.getFieldObject(menuObject.getImageDescriptor(), "originalImage"));
 		assertSame(menuInfo.getBounds(), menuObject.getBounds());
 		assertFalse(menuObject.isHorizontal());
 	}
@@ -269,7 +270,7 @@ public class MenuTest extends RcpModelTest {
 		IMenuPopupInfo popupObject = menuInfo.getAdapter(IMenuPopupInfo.class);
 		assertNotNull(popupObject);
 		assertSame(menuInfo, popupObject.getModel());
-		assertSame(menuInfo.getPresentation().getIcon(), popupObject.getImage());
+		assertSame(menuInfo.getPresentation().getIcon(), ReflectionUtils.getFieldObject(popupObject.getImageDescriptor(), "originalImage"));
 		assertEquals(16, popupObject.getBounds().width);
 		assertEquals(16, popupObject.getBounds().height);
 		assertSame(menuObject, popupObject.getMenu());

--- a/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/widgets/menu/MenuInfo.java
+++ b/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/widgets/menu/MenuInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -41,11 +41,14 @@ import org.eclipse.wb.internal.xwt.model.widgets.WidgetInfo;
 import org.eclipse.wb.internal.xwt.model.widgets.XwtLiveManager;
 
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.widgets.Menu;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Model for {@link Menu}.
@@ -268,17 +271,14 @@ public final class MenuInfo extends WidgetInfo implements IAdaptable {
 		// Presentation
 		//
 		////////////////////////////////////////////////////////////////////////////
-		public Image getImage() {
-			return ExecutionUtils.runObjectLog(new RunnableObjectEx<Image>() {
-				public Image runObject() throws Exception {
-					return getPresentation().getIcon();
-				}
-			}, getDescription().getIcon());
+		public ImageDescriptor getImageDescriptor() {
+			Image image = ExecutionUtils.runObjectLog(() -> getPresentation().getIcon(), getDescription().getIcon());
+			return image == null ? null : ImageDescriptor.createFromImage(image);
 		}
 
 		public Rectangle getBounds() {
-			Image image = getImage();
-			return new Rectangle(0, 0, image.getBounds().width, image.getBounds().height);
+			ImageData imageData = getImageDescriptor().getImageData(100);
+			return new Rectangle(0, 0, imageData.width, imageData.height);
 		}
 
 		////////////////////////////////////////////////////////////////////////////
@@ -324,8 +324,8 @@ public final class MenuInfo extends WidgetInfo implements IAdaptable {
 		// Presentation
 		//
 		////////////////////////////////////////////////////////////////////////////
-		public Image getImage() {
-			return m_this.getImage();
+		public ImageDescriptor getImageDescriptor() {
+			return Optional.ofNullable(m_this.getImage()).map(ImageDescriptor::createFromImage).orElse(null);
 		}
 
 		public Rectangle getBounds() {

--- a/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/widgets/menu/MenuItemInfo.java
+++ b/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/widgets/menu/MenuItemInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -44,12 +44,13 @@ import org.eclipse.wb.internal.xwt.model.widgets.ItemInfo;
 import org.eclipse.wb.internal.xwt.model.widgets.XwtLiveManager;
 
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Model for {@link MenuItem}.
@@ -307,8 +308,8 @@ public final class MenuItemInfo extends ItemInfo implements IAdaptable {
 		// Presentation
 		//
 		////////////////////////////////////////////////////////////////////////////
-		public Image getImage() {
-			return m_this.getImage();
+		public ImageDescriptor getImageDescriptor() {
+			return Optional.ofNullable(m_this.getImage()).map(ImageDescriptor::createFromImage).orElse(null);
 		}
 
 		public Rectangle getBounds() {


### PR DESCRIPTION
The image stored in the IMenuObjectInfo instances are used for the presentation. We should switch to ImageDescriptors, to avoid "Widget is disposed" exceptions when closing the editor.

The getImage() method has been renamed to getImageDescriptor(). Where necessary, we use ImageDescriptor.createFromImage() to convert images to the correct type. Those images are slowly going to be transformed in ImageDescriptors in upcoming changes.

When drawing those components, a temporary Image instance is created.