### PR TITLE
ISurroundTarget should use ImageDescriptor instead of Image.

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/surround/ISurroundTarget.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/surround/ISurroundTarget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,7 @@ import org.eclipse.wb.core.model.AbstractComponentInfo;
 import org.eclipse.wb.core.model.IAbstractComponentInfo;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.util.List;
 
@@ -40,7 +40,7 @@ public abstract class ISurroundTarget<C extends IAbstractComponentInfo, T extend
 	/**
 	 * @return the icon to display for user.
 	 */
-	public abstract Image getIcon(AstEditor editor) throws Exception;
+	public abstract ImageDescriptor getIcon(AstEditor editor) throws Exception;
 
 	////////////////////////////////////////////////////////////////////////////
 	//

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/surround/SurroundSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/surround/SurroundSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -166,7 +166,7 @@ public abstract class SurroundSupport<C extends AbstractComponentInfo, T extends
 			m_editor = m_sourceContainer.getEditor();
 			// presentation
 			setText(m_target.getText(m_editor));
-			setIcon(m_target.getIcon(m_editor));
+			setImageDescriptor(m_target.getIcon(m_editor));
 		}
 
 		////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/util/surround/CTabFolderSurroundTarget.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/util/surround/CTabFolderSurroundTarget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,11 +15,12 @@ import org.eclipse.wb.internal.core.model.creation.ConstructorCreationSupport;
 import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper;
 import org.eclipse.wb.internal.core.model.util.surround.ISurroundTarget;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.rcp.model.widgets.CTabFolderInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.custom.CTabFolder;
-import org.eclipse.swt.graphics.Image;
 
 /**
  * {@link ISurroundTarget} that uses {@link CTabFolder} as target container.
@@ -45,8 +46,8 @@ public final class CTabFolderSurroundTarget extends ISurroundTarget<CTabFolderIn
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon(AstEditor editor) throws Exception {
-		return ComponentDescriptionHelper.getDescription(editor, FOLDER_CLASS_NAME).getIcon();
+	public ImageDescriptor getIcon(AstEditor editor) throws Exception {
+		return new ImageImageDescriptor(ComponentDescriptionHelper.getDescription(editor, FOLDER_CLASS_NAME).getIcon());
 	}
 
 	@Override

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/util/surround/SashFormSurroundTarget.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/util/surround/SashFormSurroundTarget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,11 +15,12 @@ import org.eclipse.wb.internal.core.model.creation.ConstructorCreationSupport;
 import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper;
 import org.eclipse.wb.internal.core.model.util.surround.ISurroundTarget;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.rcp.model.widgets.SashFormInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.custom.SashForm;
-import org.eclipse.swt.graphics.Image;
 
 /**
  * {@link ISurroundTarget} that uses {@link SashForm} as target container.
@@ -45,8 +46,8 @@ public final class SashFormSurroundTarget extends ISurroundTarget<SashFormInfo, 
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon(AstEditor editor) throws Exception {
-		return ComponentDescriptionHelper.getDescription(editor, CLASS_NAME).getIcon();
+	public ImageDescriptor getIcon(AstEditor editor) throws Exception {
+		return new ImageImageDescriptor(ComponentDescriptionHelper.getDescription(editor, CLASS_NAME).getIcon());
 	}
 
 	@Override

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/util/surround/ScrolledCompositeSurroundTarget.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/util/surround/ScrolledCompositeSurroundTarget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,13 +15,14 @@ import org.eclipse.wb.internal.core.model.creation.ConstructorCreationSupport;
 import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper;
 import org.eclipse.wb.internal.core.model.util.surround.ISurroundTarget;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.rcp.model.widgets.ScrolledCompositeInfo;
 import org.eclipse.wb.internal.swt.model.util.surround.CompositeSurroundTarget;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.custom.ScrolledComposite;
-import org.eclipse.swt.graphics.Image;
 
 import java.util.List;
 
@@ -52,8 +53,8 @@ ISurroundTarget<ScrolledCompositeInfo, ControlInfo> {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon(AstEditor editor) throws Exception {
-		return ComponentDescriptionHelper.getDescription(editor, CLASS_NAME).getIcon();
+	public ImageDescriptor getIcon(AstEditor editor) throws Exception {
+		return new ImageImageDescriptor(ComponentDescriptionHelper.getDescription(editor, CLASS_NAME).getIcon());
 	}
 
 	@Override

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/util/surround/TabFolderSurroundTarget.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/util/surround/TabFolderSurroundTarget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,10 +15,11 @@ import org.eclipse.wb.internal.core.model.creation.ConstructorCreationSupport;
 import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper;
 import org.eclipse.wb.internal.core.model.util.surround.ISurroundTarget;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.rcp.model.widgets.TabFolderInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.widgets.TabFolder;
 
 /**
@@ -45,8 +46,8 @@ public final class TabFolderSurroundTarget extends ISurroundTarget<TabFolderInfo
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon(AstEditor editor) throws Exception {
-		return ComponentDescriptionHelper.getDescription(editor, FOLDER_CLASS_NAME).getIcon();
+	public ImageDescriptor getIcon(AstEditor editor) throws Exception {
+		return new ImageImageDescriptor(ComponentDescriptionHelper.getDescription(editor, FOLDER_CLASS_NAME).getIcon());
 	}
 
 	@Override

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/util/surround/JPanelSurroundTarget.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/util/surround/JPanelSurroundTarget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,11 +15,12 @@ import org.eclipse.wb.internal.core.model.creation.ConstructorCreationSupport;
 import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper;
 import org.eclipse.wb.internal.core.model.util.surround.ISurroundTarget;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 import org.eclipse.wb.internal.swing.model.layout.FlowLayoutInfo;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import javax.swing.JPanel;
 
@@ -38,8 +39,8 @@ public final class JPanelSurroundTarget extends ISurroundTarget<ContainerInfo, C
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon(AstEditor editor) throws Exception {
-		return ComponentDescriptionHelper.getDescription(editor, CLASS_NAME).getIcon();
+	public ImageDescriptor getIcon(AstEditor editor) throws Exception {
+		return new ImageImageDescriptor(ComponentDescriptionHelper.getDescription(editor, CLASS_NAME).getIcon());
 	}
 
 	@Override

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/util/surround/JPanelWithBorderSurroundTarget.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/util/surround/JPanelWithBorderSurroundTarget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,11 +15,12 @@ import org.eclipse.wb.internal.core.model.creation.ConstructorCreationSupport;
 import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper;
 import org.eclipse.wb.internal.core.model.util.surround.ISurroundTarget;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 import org.eclipse.wb.internal.swing.model.layout.FlowLayoutInfo;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.util.List;
 
@@ -42,8 +43,8 @@ ISurroundTarget<ContainerInfo, ComponentInfo> {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon(AstEditor editor) throws Exception {
-		return ComponentDescriptionHelper.getDescription(editor, CLASS_NAME).getIcon();
+	public ImageDescriptor getIcon(AstEditor editor) throws Exception {
+		return new ImageImageDescriptor(ComponentDescriptionHelper.getDescription(editor, CLASS_NAME).getIcon());
 	}
 
 	@Override

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/util/surround/JScrollPaneSurroundTarget.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/util/surround/JScrollPaneSurroundTarget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,12 +15,13 @@ import org.eclipse.wb.internal.core.model.creation.ConstructorCreationSupport;
 import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper;
 import org.eclipse.wb.internal.core.model.util.surround.ISurroundTarget;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 import org.eclipse.wb.internal.swing.model.component.JScrollPaneInfo;
 import org.eclipse.wb.internal.swing.model.layout.FlowLayoutInfo;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.util.List;
 
@@ -43,8 +44,8 @@ ISurroundTarget<JScrollPaneInfo, ComponentInfo> {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon(AstEditor editor) throws Exception {
-		return ComponentDescriptionHelper.getDescription(editor, CLASS_NAME).getIcon();
+	public ImageDescriptor getIcon(AstEditor editor) throws Exception {
+		return new ImageImageDescriptor(ComponentDescriptionHelper.getDescription(editor, CLASS_NAME).getIcon());
 	}
 
 	@Override

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/util/surround/JSplitPaneSurroundTarget.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/util/surround/JSplitPaneSurroundTarget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,10 +15,11 @@ import org.eclipse.wb.internal.core.model.creation.ConstructorCreationSupport;
 import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper;
 import org.eclipse.wb.internal.core.model.util.surround.ISurroundTarget;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.JSplitPaneInfo;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.util.List;
 
@@ -39,8 +40,8 @@ public final class JSplitPaneSurroundTarget extends ISurroundTarget<JSplitPaneIn
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon(AstEditor editor) throws Exception {
-		return ComponentDescriptionHelper.getDescription(editor, CLASS_NAME).getIcon();
+	public ImageDescriptor getIcon(AstEditor editor) throws Exception {
+		return new ImageImageDescriptor(ComponentDescriptionHelper.getDescription(editor, CLASS_NAME).getIcon());
 	}
 
 	@Override

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/util/surround/JTabbedPaneSurroundTarget.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/util/surround/JTabbedPaneSurroundTarget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,10 +15,11 @@ import org.eclipse.wb.internal.core.model.creation.ConstructorCreationSupport;
 import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper;
 import org.eclipse.wb.internal.core.model.util.surround.ISurroundTarget;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.JTabbedPaneInfo;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import javax.swing.JTabbedPane;
 
@@ -39,8 +40,8 @@ ISurroundTarget<JTabbedPaneInfo, ComponentInfo> {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon(AstEditor editor) throws Exception {
-		return ComponentDescriptionHelper.getDescription(editor, CLASS_NAME).getIcon();
+	public ImageDescriptor getIcon(AstEditor editor) throws Exception {
+		return new ImageImageDescriptor(ComponentDescriptionHelper.getDescription(editor, CLASS_NAME).getIcon());
 	}
 
 	@Override

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/util/surround/AbstractCompositeSurroundTarget.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/util/surround/AbstractCompositeSurroundTarget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,12 +15,13 @@ import org.eclipse.wb.internal.core.model.creation.ConstructorCreationSupport;
 import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper;
 import org.eclipse.wb.internal.core.model.util.surround.ISurroundTarget;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.swt.model.layout.LayoutInfo;
 import org.eclipse.wb.internal.swt.model.layout.RowLayoutInfo;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.widgets.Composite;
 
 import java.util.List;
@@ -51,8 +52,8 @@ ISurroundTarget<CompositeInfo, ControlInfo> {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon(AstEditor editor) throws Exception {
-		return ComponentDescriptionHelper.getDescription(editor, m_className).getIcon();
+	public ImageDescriptor getIcon(AstEditor editor) throws Exception {
+		return new ImageImageDescriptor(ComponentDescriptionHelper.getDescription(editor, m_className).getIcon());
 	}
 
 	@Override


### PR DESCRIPTION
The icon in SurroundSupport is already converted into an ImageDescriptor internally. This change is a pre-requisite for changing the signature of the IObjectDescription.

Where necessary, images are converted to objects of type ImageDescriptor using ImageImageDescriptor.