### PR TITLE
Remove singleton pattern from ObjectsLabelProvider

### DIFF
--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/presentation/JavaInfoObservePresentation.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/presentation/JavaInfoObservePresentation.java
@@ -13,7 +13,6 @@ package org.eclipse.wb.internal.core.databinding.model.presentation;
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.databinding.model.IObservePresentation;
-import org.eclipse.wb.internal.core.model.util.ObjectsLabelProvider;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 
 import org.eclipse.jface.resource.ImageDescriptor;
@@ -52,7 +51,7 @@ public class JavaInfoObservePresentation implements IObservePresentation {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public String getText() throws Exception {
-		return ObjectsLabelProvider.INSTANCE.getText(m_javaInfo);
+		return ObjectInfo.getText(m_javaInfo);
 	}
 
 	@Override
@@ -63,6 +62,6 @@ public class JavaInfoObservePresentation implements IObservePresentation {
 	@Override
 	public ImageDescriptor getImageDescriptor() throws Exception {
 		return ExecutionUtils.runObjectLog(
-				() -> ImageDescriptor.createFromImage(ObjectsLabelProvider.INSTANCE.getImage(m_javaInfo)), null);
+				() -> ImageDescriptor.createFromImage(ObjectInfo.getImage(m_javaInfo)), null);
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/model/entry/InstanceFactoryEntryInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/model/entry/InstanceFactoryEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -148,7 +148,7 @@ public final class InstanceFactoryEntryInfo extends FactoryEntryInfo {
 			ElementListSelectionDialog dialog;
 			{
 				Shell shell = DesignerPlugin.getShell();
-				dialog = new ElementListSelectionDialog(shell, ObjectsLabelProvider.INSTANCE);
+				dialog = new ElementListSelectionDialog(shell, new ObjectsLabelProvider());
 				dialog.setTitle(Messages.InstanceFactoryEntryInfo_selectFactoryTitle);
 				dialog.setMessage(Messages.InstanceFactoryEntryInfo_selectFactoryMessage);
 			}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/part/nonvisual/NonVisualBeanEditPart.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/part/nonvisual/NonVisualBeanEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,12 +12,12 @@ package org.eclipse.wb.internal.core.gef.part.nonvisual;
 
 import org.eclipse.wb.core.gef.policy.selection.NonResizableSelectionEditPolicy;
 import org.eclipse.wb.core.model.JavaInfo;
+import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.core.model.nonvisual.NonVisualBeanInfo;
-import org.eclipse.wb.internal.core.model.util.ObjectsLabelProvider;
 
 import org.eclipse.swt.graphics.Image;
 
@@ -66,13 +66,13 @@ public final class NonVisualBeanEditPart extends GraphicalEditPart {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	protected Figure createFigure() {
-		Image image = ObjectsLabelProvider.INSTANCE.getImage(m_beanInfo.getJavaInfo());
+		Image image = ObjectInfo.getImage(m_beanInfo.getJavaInfo());
 		return new BeanFigure(image);
 	}
 
 	@Override
 	protected void refreshVisuals() {
-		String text = ObjectsLabelProvider.INSTANCE.getText(m_beanInfo.getJavaInfo());
+		String text = ObjectInfo.getText(m_beanInfo.getJavaInfo());
 		BeanFigure figure = (BeanFigure) getFigure();
 		figure.update(text, m_beanInfo.getLocation());
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/ObjectPropertyEditor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/ObjectPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -78,7 +78,7 @@ IComplexPropertyEditor {
 	protected String getText(Property property) throws Exception {
 		JavaInfo component = getValueComponent(property);
 		if (component != null) {
-			return ObjectsLabelProvider.INSTANCE.getText(component);
+			return ObjectInfo.getText(component);
 		}
 		// unknown value
 		return null;
@@ -112,7 +112,7 @@ IComplexPropertyEditor {
 			ITreeContentProvider contentProvider = createContentProvider(propertyType);
 			// create dialog
 			selectionDialog =
-					new ElementTreeSelectionDialog(DesignerPlugin.getShell(), ObjectsLabelProvider.INSTANCE,
+					new ElementTreeSelectionDialog(DesignerPlugin.getShell(), new ObjectsLabelProvider(),
 							contentProvider) {
 				@Override
 				public void create() {

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/order/ReorderDialog.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/order/ReorderDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -94,7 +94,7 @@ final class ReorderDialog extends ResizableDialog {
 			}
 		});
 		m_viewer.setContentProvider(new ArrayContentProvider());
-		m_viewer.setLabelProvider(ObjectsLabelProvider.INSTANCE);
+		m_viewer.setLabelProvider(new ObjectsLabelProvider());
 		//
 		TableFactory.modify(m_viewer).headerVisible(true).linesVisible(true);
 		GridDataFactory.create(m_viewer.getControl()).fill().grab().hintC(60, 15);

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/RenameConvertSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/RenameConvertSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -367,13 +367,13 @@ public final class RenameConvertSupport {
 				// icon
 				{
 					Label iconLabel = new Label(container, SWT.NONE);
-					Image icon = ObjectsLabelProvider.INSTANCE.getImage(javaInfo);
+					Image icon = ObjectInfo.getImage(javaInfo);
 					iconLabel.setImage(icon);
 				}
 				// text
 				{
 					Label textLabel = new Label(container, SWT.NONE);
-					String text = ObjectsLabelProvider.INSTANCE.getText(javaInfo);
+					String text = ObjectInfo.getText(javaInfo);
 					textLabel.setText(text);
 				}
 			}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gefTree/part/ObjectEditPart.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gefTree/part/ObjectEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,6 @@ import org.eclipse.wb.core.model.broadcast.ObjectEventListener;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.gef.tree.TreeEditPart;
-import org.eclipse.wb.internal.core.model.util.ObjectsLabelProvider;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
@@ -177,8 +176,8 @@ public class ObjectEditPart extends TreeEditPart {
 	}
 
 	private void update0() {
-		Image image = ObjectsLabelProvider.INSTANCE.getImage(m_object);
-		String text = ObjectsLabelProvider.INSTANCE.getText(m_object);
+		Image image = ObjectInfo.getImage(m_object);
+		String text = ObjectInfo.getText(m_object);
 		if (image != null && !image.isDisposed()) {
 			getWidget().setImage(image);
 		}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/model/ObjectInfo.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/model/ObjectInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,8 @@ import org.eclipse.wb.core.model.broadcast.ObjectEventListener;
 import org.eclipse.wb.core.model.broadcast.ObjectInfoAllProperties;
 import org.eclipse.wb.core.model.broadcast.ObjectInfoChildAddAfter;
 import org.eclipse.wb.core.model.broadcast.ObjectInfoChildAddBefore;
+import org.eclipse.wb.core.model.broadcast.ObjectInfoPresentationDecorateIcon;
+import org.eclipse.wb.core.model.broadcast.ObjectInfoPresentationDecorateText;
 import org.eclipse.wb.internal.core.model.ObjectInfoVisitor;
 import org.eclipse.wb.internal.core.model.presentation.IObjectPresentation;
 import org.eclipse.wb.internal.core.model.property.Property;
@@ -26,6 +28,8 @@ import org.eclipse.wb.internal.core.utils.GenericsUtils;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
+
+import org.eclipse.swt.graphics.Image;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -670,5 +674,55 @@ public abstract class ObjectInfo implements IObjectInfo {
 			arbitraries = ImmutableMap.of();
 		}
 		return arbitraries;
+	}
+
+	////////////////////////////////////////////////////////////////////////////
+	//
+	// Static Access
+	//
+	////////////////////////////////////////////////////////////////////////////
+
+	/**
+	 * Static helper method for calculating the decorated image presentation of the
+	 * given {@link ObjectInfo} instance.
+	 *
+	 * @param objectInfo The {@link ObjectInfo} instance.
+	 * @return The decorated image or {@code null} on error.
+	 * @see IObjectPresentation
+	 */
+	public static Image getImage(final ObjectInfo objectInfo) {
+		return ExecutionUtils.runObjectLog(() -> {
+			Image icon = objectInfo.getPresentation().getIcon();
+			// decorate
+			{
+				Image[] decoratedIcon = new Image[] { icon };
+				objectInfo.getBroadcast(ObjectInfoPresentationDecorateIcon.class).invoke(objectInfo, decoratedIcon);
+				icon = decoratedIcon[0];
+			}
+			// final icon
+			return icon;
+		}, null);
+	}
+
+	/**
+	 * Static helper method for calculating the decorated text presentation of the
+	 * given {@link ObjectInfo} instance.
+	 *
+	 * @param objectInfo The {@link ObjectInfo} instance.
+	 * @return The decorated text or {@code <exception, see log>} on error.
+	 * @see IObjectPresentation
+	 */
+	public static String getText(final ObjectInfo objectInfo) {
+		return ExecutionUtils.runObjectLog(() -> {
+			String text = objectInfo.getPresentation().getText();
+			// decorate
+			{
+				String[] decoratedText = new String[] { text };
+				objectInfo.getBroadcast(ObjectInfoPresentationDecorateText.class).invoke(objectInfo, decoratedText);
+				text = decoratedText[0];
+			}
+			// final text
+			return text;
+		}, "<exception, see log>");
 	}
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/ObjectsLabelProvider.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/ObjectsLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,10 +11,6 @@
 package org.eclipse.wb.internal.core.model.util;
 
 import org.eclipse.wb.core.model.ObjectInfo;
-import org.eclipse.wb.core.model.broadcast.ObjectInfoPresentationDecorateIcon;
-import org.eclipse.wb.core.model.broadcast.ObjectInfoPresentationDecorateText;
-import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.swt.graphics.Image;
@@ -26,15 +22,6 @@ import org.eclipse.swt.graphics.Image;
  * @coverage core.model.util
  */
 public final class ObjectsLabelProvider extends LabelProvider {
-	public static final ObjectsLabelProvider INSTANCE = new ObjectsLabelProvider();
-
-	////////////////////////////////////////////////////////////////////////////
-	//
-	// Constructor
-	//
-	////////////////////////////////////////////////////////////////////////////
-	private ObjectsLabelProvider() {
-	}
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -43,45 +30,11 @@ public final class ObjectsLabelProvider extends LabelProvider {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public Image getImage(final Object element) {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<Image>() {
-			@Override
-			public Image runObject() throws Exception {
-				ObjectInfo objectInfo = (ObjectInfo) element;
-				Image icon = objectInfo.getPresentation().getIcon();
-				// decorate
-				{
-					Image[] decoratedIcon = new Image[]{icon};
-					objectInfo.getBroadcast(ObjectInfoPresentationDecorateIcon.class).invoke(
-							objectInfo,
-							decoratedIcon);
-					icon = decoratedIcon[0];
-				}
-				// final icon
-				return icon;
-			}
-		},
-				null);
+		return ObjectInfo.getImage((ObjectInfo) element);
 	}
 
 	@Override
 	public String getText(final Object element) {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<String>() {
-			@Override
-			public String runObject() throws Exception {
-				ObjectInfo objectInfo = (ObjectInfo) element;
-				String text = objectInfo.getPresentation().getText();
-				// decorate
-				{
-					String[] decoratedText = new String[]{text};
-					objectInfo.getBroadcast(ObjectInfoPresentationDecorateText.class).invoke(
-							objectInfo,
-							decoratedText);
-					text = decoratedText[0];
-				}
-				// final text
-				return text;
-			}
-		},
-				"<exception, see log>");
+		return ObjectInfo.getText((ObjectInfo) element);
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/model/XmlObjectRootProcessorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/model/XmlObjectRootProcessorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.XML.model;
 
-import org.eclipse.wb.internal.core.model.util.ObjectsLabelProvider;
+import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.xml.model.XmlObjectInfo;
 import org.eclipse.wb.internal.core.xml.model.XmlObjectRootProcessor;
 import org.eclipse.wb.tests.designer.XML.model.description.AbstractCoreTest;
@@ -106,7 +106,7 @@ public class XmlObjectRootProcessorTest extends AbstractCoreTest {
 						"<Shell text='Hello!'/>");
 		shell.refresh();
 		//
-		String text = ObjectsLabelProvider.INSTANCE.getText(shell);
+		String text = ObjectInfo.getText(shell);
 		assertEquals("Shell - \"Hello!\"", text);
 	}
 
@@ -121,7 +121,7 @@ public class XmlObjectRootProcessorTest extends AbstractCoreTest {
 						"<Shell/>");
 		shell.refresh();
 		//
-		String text = ObjectsLabelProvider.INSTANCE.getText(shell);
+		String text = ObjectInfo.getText(shell);
 		assertEquals("Shell", text);
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/model/property/EventsPropertyTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/model/property/EventsPropertyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,12 +10,12 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.XML.model.property;
 
+import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.model.description.ToolkitDescription;
 import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.model.property.event.EventsPropertyUtils;
 import org.eclipse.wb.internal.core.model.property.event.IPreferenceConstants;
-import org.eclipse.wb.internal.core.model.util.ObjectsLabelProvider;
 import org.eclipse.wb.internal.core.model.util.PropertyUtils;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.core.xml.model.XmlObjectInfo;
@@ -123,18 +123,18 @@ public class EventsPropertyTest extends XwtModelTest {
 		// be default decoration enabled
 		assertNotSame(
 				button_1.getPresentation().getIcon(),
-				ObjectsLabelProvider.INSTANCE.getImage(button_1));
+				ObjectInfo.getImage(button_1));
 		assertSame(
 				button_2.getPresentation().getIcon(),
-				ObjectsLabelProvider.INSTANCE.getImage(button_2));
+				ObjectInfo.getImage(button_2));
 		// disable decoration, no decoration expected
 		TOOLKIT.getPreferences().setValue(IPreferenceConstants.P_DECORATE_ICON, false);
 		assertSame(
 				button_1.getPresentation().getIcon(),
-				ObjectsLabelProvider.INSTANCE.getImage(button_1));
+				ObjectInfo.getImage(button_1));
 		assertSame(
 				button_2.getPresentation().getIcon(),
-				ObjectsLabelProvider.INSTANCE.getImage(button_2));
+				ObjectInfo.getImage(button_2));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XWT/model/NameSupportTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XWT/model/NameSupportTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,7 @@ package org.eclipse.wb.tests.designer.XWT.model;
 
 import com.google.common.collect.Lists;
 
-import org.eclipse.wb.internal.core.model.util.ObjectsLabelProvider;
+import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.model.variable.NamesManager;
 import org.eclipse.wb.internal.core.model.variable.NamesManager.ComponentNameDescription;
 import org.eclipse.wb.internal.core.xml.model.XmlObjectInfo;
@@ -86,7 +86,7 @@ public class NameSupportTest extends XwtModelTest {
 		}
 		// ...and it is included into presentation text
 		{
-			String text = ObjectsLabelProvider.INSTANCE.getText(button);
+			String text = ObjectInfo.getText(button);
 			assertEquals("Button - button - \"Save\"", text);
 		}
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XWT/model/forms/ExpandableCompositeTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XWT/model/forms/ExpandableCompositeTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,6 @@
 package org.eclipse.wb.tests.designer.XWT.model.forms;
 
 import org.eclipse.wb.core.model.ObjectInfo;
-import org.eclipse.wb.internal.core.model.util.ObjectsLabelProvider;
 import org.eclipse.wb.internal.xwt.model.forms.ExpandableCompositeInfo;
 import org.eclipse.wb.internal.xwt.model.widgets.AbstractPositionInfo;
 import org.eclipse.wb.internal.xwt.model.widgets.ControlInfo;
@@ -94,7 +93,7 @@ public class ExpandableCompositeTest extends XwtModelTest {
 				"  </ExpandableComposite.client>",
 				"</ExpandableComposite>");
 		ControlInfo button = getObjectByName("button");
-		assertEquals("client - Button", ObjectsLabelProvider.INSTANCE.getText(button));
+		assertEquals("client - Button", ObjectInfo.getText(button));
 	}
 
 	/**
@@ -111,7 +110,7 @@ public class ExpandableCompositeTest extends XwtModelTest {
 		// no "real" Control's, but in "tree" we have position placeholder children
 		List<ObjectInfo> children = composite.getPresentation().getChildrenTree();
 		assertThat(children).hasSize(2);
-		assertEquals("textClient", ObjectsLabelProvider.INSTANCE.getText(children.get(0)));
-		assertEquals("client", ObjectsLabelProvider.INSTANCE.getText(children.get(1)));
+		assertEquals("textClient", ObjectInfo.getText(children.get(0)));
+		assertEquals("client", ObjectInfo.getText(children.get(1)));
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XWT/model/jface/TableViewerTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XWT/model/jface/TableViewerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.XWT.model.jface;
 
+import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.model.property.Property;
-import org.eclipse.wb.internal.core.model.util.ObjectsLabelProvider;
 import org.eclipse.wb.internal.xwt.model.jface.TableViewerColumnInfo;
 import org.eclipse.wb.internal.xwt.model.jface.TableViewerInfo;
 import org.eclipse.wb.internal.xwt.model.widgets.TableInfo;
@@ -135,7 +135,7 @@ public class TableViewerTest extends XwtModelTest {
 			callExpressionAccessor_getAdapter_withWrongType(property);
 		}
 		// "text" is text property, so included into presentation
-		assertEquals("TableViewerColumn - \"A\"", ObjectsLabelProvider.INSTANCE.getText(column));
+		assertEquals("TableViewerColumn - \"A\"", ObjectInfo.getText(column));
 		// set "text" and "width"
 		{
 			column.getPropertyByTitle("text").setValue("B");

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XWT/model/widgets/CBannerTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XWT/model/widgets/CBannerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,6 @@
 package org.eclipse.wb.tests.designer.XWT.model.widgets;
 
 import org.eclipse.wb.core.model.ObjectInfo;
-import org.eclipse.wb.internal.core.model.util.ObjectsLabelProvider;
 import org.eclipse.wb.internal.core.utils.GenericsUtils;
 import org.eclipse.wb.internal.xwt.model.widgets.AbstractPositionInfo;
 import org.eclipse.wb.internal.xwt.model.widgets.CBannerInfo;
@@ -103,7 +102,7 @@ public class CBannerTest extends XwtModelTest {
 				"  </CBanner.bottom>",
 				"</CBanner>");
 		ControlInfo button = getObjectByName("button");
-		assertEquals("bottom - Button", ObjectsLabelProvider.INSTANCE.getText(button));
+		assertEquals("bottom - Button", ObjectInfo.getText(button));
 	}
 
 	/**
@@ -116,8 +115,8 @@ public class CBannerTest extends XwtModelTest {
 		List<ObjectInfo> children = banner.getPresentation().getChildrenTree();
 		assertThat(children).hasSize(3);
 		assertThat(GenericsUtils.select(children, AbstractPositionInfo.class)).hasSize(3);
-		assertEquals("left", ObjectsLabelProvider.INSTANCE.getText(children.get(0)));
-		assertEquals("right", ObjectsLabelProvider.INSTANCE.getText(children.get(1)));
-		assertEquals("bottom", ObjectsLabelProvider.INSTANCE.getText(children.get(2)));
+		assertEquals("left", ObjectInfo.getText(children.get(0)));
+		assertEquals("right", ObjectInfo.getText(children.get(1)));
+		assertEquals("bottom", ObjectInfo.getText(children.get(2)));
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XWT/model/widgets/ViewFormTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XWT/model/widgets/ViewFormTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,6 @@ package org.eclipse.wb.tests.designer.XWT.model.widgets;
 
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.model.presentation.IObjectPresentation;
-import org.eclipse.wb.internal.core.model.util.ObjectsLabelProvider;
 import org.eclipse.wb.internal.core.utils.GenericsUtils;
 import org.eclipse.wb.internal.xwt.model.widgets.AbstractPositionInfo;
 import org.eclipse.wb.internal.xwt.model.widgets.CompositeInfo;
@@ -106,7 +105,7 @@ public class ViewFormTest extends XwtModelTest {
 				"  </ViewForm.content>",
 				"</ViewForm>");
 		ControlInfo button = getObjectByName("button");
-		assertEquals("content - Button", ObjectsLabelProvider.INSTANCE.getText(button));
+		assertEquals("content - Button", ObjectInfo.getText(button));
 	}
 
 	/**
@@ -155,19 +154,19 @@ public class ViewFormTest extends XwtModelTest {
 		// index: 0
 		{
 			AbstractPositionInfo position = (AbstractPositionInfo) children.get(0);
-			assertEquals("topLeft", ObjectsLabelProvider.INSTANCE.getText(position));
+			assertEquals("topLeft", ObjectInfo.getText(position));
 		}
 		// index: 1
 		assertSame(button, children.get(1));
 		// index: 2
 		{
 			AbstractPositionInfo position = (AbstractPositionInfo) children.get(2);
-			assertEquals("topRight", ObjectsLabelProvider.INSTANCE.getText(position));
+			assertEquals("topRight", ObjectInfo.getText(position));
 		}
 		// index: 3
 		{
 			AbstractPositionInfo position = (AbstractPositionInfo) children.get(3);
-			assertEquals("content", ObjectsLabelProvider.INSTANCE.getText(position));
+			assertEquals("content", ObjectInfo.getText(position));
 		}
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/JavaInfoTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/JavaInfoTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,7 +20,6 @@ import org.eclipse.wb.internal.core.model.creation.CreationSupport;
 import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.model.property.accessor.FieldAccessor;
 import org.eclipse.wb.internal.core.model.property.accessor.SetterAccessor;
-import org.eclipse.wb.internal.core.model.util.ObjectsLabelProvider;
 import org.eclipse.wb.internal.core.model.util.TemplateUtils;
 import org.eclipse.wb.internal.core.model.variable.FieldInitializerVariableSupport;
 import org.eclipse.wb.internal.core.model.variable.FieldUniqueVariableSupport;
@@ -1419,8 +1418,8 @@ public class JavaInfoTest extends SwingModelTest {
 		ComponentInfo button_1 = panel.getChildrenComponents().get(0);
 		ComponentInfo button_2 = panel.getChildrenComponents().get(1);
 		// do checks
-		assertEquals("(no variable)", ObjectsLabelProvider.INSTANCE.getText(button_1));
-		assertEquals("(no variable) - \"theText\"", ObjectsLabelProvider.INSTANCE.getText(button_2));
+		assertEquals("(no variable)", ObjectInfo.getText(button_1));
+		assertEquals("(no variable) - \"theText\"", ObjectInfo.getText(button_2));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/ExposedFieldCreationSupportTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/ExposedFieldCreationSupportTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,10 +10,10 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.model.creation;
 
+import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.model.clipboard.IClipboardImplicitCreationSupport;
 import org.eclipse.wb.internal.core.model.clipboard.JavaInfoMemento;
 import org.eclipse.wb.internal.core.model.creation.ExposedFieldCreationSupport;
-import org.eclipse.wb.internal.core.model.util.ObjectsLabelProvider;
 import org.eclipse.wb.internal.core.model.variable.ExposedFieldVariableSupport;
 import org.eclipse.wb.internal.core.model.variable.LocalUniqueVariableSupport;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
@@ -501,10 +501,10 @@ public class ExposedFieldCreationSupportTest extends SwingModelTest {
 		// ...but their icons are different, because (probably) decorator applied
 		assertSame(
 				innerPanel.getPresentation().getIcon(),
-				ObjectsLabelProvider.INSTANCE.getImage(innerPanel));
+				ObjectInfo.getImage(innerPanel));
 		assertNotSame(
 				exposedContainer.getPresentation().getIcon(),
-				ObjectsLabelProvider.INSTANCE.getImage(exposedContainer));
+				ObjectInfo.getImage(exposedContainer));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/ExposedPropertyCreationSupportTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/ExposedPropertyCreationSupportTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.model.creation;
 
+import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.model.creation.ExposedPropertyCreationSupport;
-import org.eclipse.wb.internal.core.model.util.ObjectsLabelProvider;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 import org.eclipse.wb.tests.designer.swing.SwingModelTest;
@@ -439,10 +439,10 @@ public class ExposedPropertyCreationSupportTest extends SwingModelTest {
 		// ...but their icons are different, because (probably) decorator applied
 		assertSame(
 				container.getPresentation().getIcon(),
-				ObjectsLabelProvider.INSTANCE.getImage(container));
+				ObjectInfo.getImage(container));
 		assertNotSame(
 				contentPane.getPresentation().getIcon(),
-				ObjectsLabelProvider.INSTANCE.getImage(contentPane));
+				ObjectInfo.getImage(contentPane));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/EventsPropertyTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/EventsPropertyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@ package org.eclipse.wb.tests.designer.core.model.property;
 
 import org.eclipse.wb.core.editor.IDesignPageSite;
 import org.eclipse.wb.core.model.JavaInfo;
+import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.broadcast.JavaInfoEventOpen;
 import org.eclipse.wb.internal.core.editor.DesignPageSite;
 import org.eclipse.wb.internal.core.model.property.Property;
@@ -21,7 +22,6 @@ import org.eclipse.wb.internal.core.model.property.event.EventsProperty;
 import org.eclipse.wb.internal.core.model.property.event.EventsPropertyUtils;
 import org.eclipse.wb.internal.core.model.property.event.IPreferenceConstants;
 import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
-import org.eclipse.wb.internal.core.model.util.ObjectsLabelProvider;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
@@ -2182,18 +2182,18 @@ public class EventsPropertyTest extends SwingModelTest implements IPreferenceCon
 		// be default decoration enabled
 		assertNotSame(
 				button_1.getPresentation().getIcon(),
-				ObjectsLabelProvider.INSTANCE.getImage(button_1));
+				ObjectInfo.getImage(button_1));
 		assertSame(
 				button_2.getPresentation().getIcon(),
-				ObjectsLabelProvider.INSTANCE.getImage(button_2));
+				ObjectInfo.getImage(button_2));
 		// disable decoration, no decoration expected
 		panel.getDescription().getToolkit().getPreferences().setValue(P_DECORATE_ICON, false);
 		assertSame(
 				button_1.getPresentation().getIcon(),
-				ObjectsLabelProvider.INSTANCE.getImage(button_1));
+				ObjectInfo.getImage(button_1));
 		assertSame(
 				button_2.getPresentation().getIcon(),
-				ObjectsLabelProvider.INSTANCE.getImage(button_2));
+				ObjectInfo.getImage(button_2));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/ObjectsLabelProviderTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/ObjectsLabelProviderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -47,8 +47,8 @@ public class ObjectsLabelProviderTest extends DesignerTestCase {
 	public void test_default() throws Exception {
 		TestObjectInfo theObject = new MyObjectInfo();
 		// do checks
-		assertSame(DEF_ICON, ObjectsLabelProvider.INSTANCE.getImage(theObject));
-		assertSame(DEF_TEXT, ObjectsLabelProvider.INSTANCE.getText(theObject));
+		assertSame(DEF_ICON, ObjectInfo.getImage(theObject));
+		assertSame(DEF_TEXT, ObjectInfo.getText(theObject));
 	}
 
 	/**
@@ -70,8 +70,8 @@ public class ObjectsLabelProviderTest extends DesignerTestCase {
 			}
 		});
 		// do checks
-		assertNotSame(DEF_ICON, ObjectsLabelProvider.INSTANCE.getImage(theObject));
-		assertEquals("A: " + DEF_TEXT + " :B", ObjectsLabelProvider.INSTANCE.getText(theObject));
+		assertNotSame(DEF_ICON, ObjectInfo.getImage(theObject));
+		assertEquals("A: " + DEF_TEXT + " :B", ObjectInfo.getText(theObject));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/widgets/ViewFormTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/widgets/ViewFormTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,6 @@ import org.eclipse.wb.core.model.association.CompoundAssociation;
 import org.eclipse.wb.core.model.association.ConstructorParentAssociation;
 import org.eclipse.wb.core.model.association.InvocationChildAssociation;
 import org.eclipse.wb.internal.core.model.presentation.IObjectPresentation;
-import org.eclipse.wb.internal.core.model.util.ObjectsLabelProvider;
 import org.eclipse.wb.internal.core.utils.GenericsUtils;
 import org.eclipse.wb.internal.rcp.model.widgets.AbstractPositionInfo;
 import org.eclipse.wb.internal.rcp.model.widgets.ViewFormInfo;
@@ -154,7 +153,7 @@ public class ViewFormTest extends RcpModelTest {
 		shell.refresh();
 		ViewFormInfo viewForm = (ViewFormInfo) shell.getChildrenControls().get(0);
 		ControlInfo button = viewForm.getChildrenControls().get(0);
-		assertEquals("setContent - button", ObjectsLabelProvider.INSTANCE.getText(button));
+		assertEquals("setContent - button", ObjectInfo.getText(button));
 	}
 
 	/**
@@ -213,7 +212,7 @@ public class ViewFormTest extends RcpModelTest {
 			assertEquals(3, GenericsUtils.select(children, AbstractPositionInfo.class).size());
 			// prepare "content" position
 			AbstractPositionInfo positionContent = (AbstractPositionInfo) children.get(3);
-			assertEquals("setContent", ObjectsLabelProvider.INSTANCE.getText(positionContent));
+			assertEquals("setContent", ObjectInfo.getText(positionContent));
 			//
 			ControlInfo button = viewForm.getControl("setTopLeft");
 			positionContent.command_MOVE(button);
@@ -257,19 +256,19 @@ public class ViewFormTest extends RcpModelTest {
 		// index: 0
 		{
 			AbstractPositionInfo position = (AbstractPositionInfo) children.get(0);
-			assertEquals("setTopLeft", ObjectsLabelProvider.INSTANCE.getText(position));
+			assertEquals("setTopLeft", ObjectInfo.getText(position));
 		}
 		// index: 1
 		assertSame(button, children.get(1));
 		// index: 2
 		{
 			AbstractPositionInfo position = (AbstractPositionInfo) children.get(2);
-			assertEquals("setTopRight", ObjectsLabelProvider.INSTANCE.getText(position));
+			assertEquals("setTopRight", ObjectInfo.getText(position));
 		}
 		// index: 3
 		{
 			AbstractPositionInfo position = (AbstractPositionInfo) children.get(3);
-			assertEquals("setContent", ObjectsLabelProvider.INSTANCE.getText(position));
+			assertEquals("setContent", ObjectInfo.getText(position));
 		}
 	}
 

--- a/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/property/editor/ObjectPropertyEditor.java
+++ b/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/property/editor/ObjectPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -64,7 +64,7 @@ public final class ObjectPropertyEditor extends TextDialogPropertyEditor {
 	protected String getText(Property property) throws Exception {
 		XmlObjectInfo component = getValueComponent(property);
 		if (component != null) {
-			return ObjectsLabelProvider.INSTANCE.getText(component);
+			return ObjectInfo.getText(component);
 		}
 		// unknown value
 		return null;
@@ -97,7 +97,7 @@ public final class ObjectPropertyEditor extends TextDialogPropertyEditor {
 			ITreeContentProvider contentProvider = createContentProvider(propertyType);
 			// create dialog
 			selectionDialog =
-					new ElementTreeSelectionDialog(DesignerPlugin.getShell(), ObjectsLabelProvider.INSTANCE,
+					new ElementTreeSelectionDialog(DesignerPlugin.getShell(), new ObjectsLabelProvider(),
 							contentProvider) {
 				@Override
 				public void create() {


### PR DESCRIPTION
In order to switch to ImageDescriptors for IObjectPresentation, we first need to remove the singleton pattern from this label provider. We can create images from those descriptors using a resource manager. But if the instance of this provider is static, then those instances are not properly disposed.

The getImage() and getText() methods have been moved to ObjectInfo.