### PR TITLE
Fix: Category not expanded when clicking on it.

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
@@ -459,23 +459,25 @@ public final class PaletteComposite extends Composite {
 					repaint();
 				}
 			});
-			addMouseMoveListener(event -> {
-				if (m_mouseDown) {
-					Point p = new Point(event.x, event.y);
-					// update moving
-					if (!m_moving && m_downPoint.getDistance(p) > 4) {
-						m_moving = true;
-					}
-					// show feedback
-					if (m_moving) {
-						move_showFeedback(p);
-					}
-				} else {
-					m_mouseOnTitle = getTitleRectangle().contains(event.x, event.y);
-					repaint();
-				}
-			});
 			addMouseMotionListener(new MouseMotionListener.Stub() {
+				@Override
+				public void mouseMoved(MouseEvent event) {
+					if (m_mouseDown) {
+						Point p = new Point(event.x, event.y);
+						// update moving
+						if (!m_moving && m_downPoint.getDistance(p) > 4) {
+							m_moving = true;
+						}
+						// show feedback
+						if (m_moving) {
+							move_showFeedback(p);
+						}
+					} else {
+						m_mouseOnTitle = getTitleRectangle().contains(event.x, event.y);
+						repaint();
+					}
+				}
+
 				@Override
 				public void mouseExited(MouseEvent e) {
 					m_mouseOnTitle = false;


### PR DESCRIPTION
We have to use addMouseMotionListener() instead of addMouseMoveListener() to contribute the logic for reacting to mouse movement.
Former is contributed by the composite, latter by the figure. This error is an oversight after switching to the GEF mouse listener. Amends bac42ded3a2a3229e5d63159f5ee192b10100048