### PR TITLE
IObjectPresentation should use ImageDescriptors instead of Images.

### DIFF
--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/presentation/JavaInfoDecorator.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/presentation/JavaInfoDecorator.java
@@ -17,9 +17,10 @@ import org.eclipse.wb.internal.core.databinding.Activator;
 import org.eclipse.wb.internal.core.databinding.model.IBindingInfo;
 import org.eclipse.wb.internal.core.databinding.model.IDatabindingsProvider;
 import org.eclipse.wb.internal.core.databinding.model.IObserveInfo;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 
 import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.viewers.DecorationOverlayIcon;
+import org.eclipse.jface.viewers.IDecoration;
 import org.eclipse.swt.graphics.Image;
 
 import java.util.Iterator;
@@ -48,9 +49,9 @@ public abstract class JavaInfoDecorator {
 		m_provider = provider;
 		objectInfoRoot.addBroadcastListener(new ObjectInfoPresentationDecorateIcon() {
 			@Override
-			public void invoke(ObjectInfo object, Image[] icon) throws Exception {
+			public void invoke(ObjectInfo object, ImageDescriptor[] icon) throws Exception {
 				if (hasDecorate(object)) {
-					icon[0] = SwtResourceManager.decorateImage(icon[0], IMAGE, SwtResourceManager.TOP_RIGHT);
+					icon[0] = new DecorationOverlayIcon(icon[0], IMAGE_DESCRIPTOR, IDecoration.TOP_RIGHT);
 				}
 			}
 		});

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/presentation/JavaInfoObservePresentation.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/presentation/JavaInfoObservePresentation.java
@@ -61,7 +61,6 @@ public class JavaInfoObservePresentation implements IObservePresentation {
 
 	@Override
 	public ImageDescriptor getImageDescriptor() throws Exception {
-		return ExecutionUtils.runObjectLog(
-				() -> ImageDescriptor.createFromImage(ObjectInfo.getImage(m_javaInfo)), null);
+		return ExecutionUtils.runObjectLog(() -> ObjectInfo.getImageDescriptor(m_javaInfo), null);
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/part/nonvisual/BeanFigure.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/part/nonvisual/BeanFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,13 +11,16 @@
 package org.eclipse.wb.internal.core.gef.part.nonvisual;
 
 import org.eclipse.wb.draw2d.Figure;
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.draw2d.Label;
 
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageData;
 
 /**
  * A figure that can display text and image.
@@ -26,7 +29,7 @@ import org.eclipse.swt.graphics.Image;
  * @coverage core.gef.nonvisual
  */
 public class BeanFigure extends Figure {
-	private final Image m_image;
+	private final ImageDescriptor m_imageDescriptor;
 	private final Label m_label = new Label();
 	private final Point m_imageLocation = new Point();
 	private final Dimension m_imageSize;
@@ -36,9 +39,15 @@ public class BeanFigure extends Figure {
 	// Constructor
 	//
 	////////////////////////////////////////////////////////////////////////////
+	@Deprecated
 	public BeanFigure(Image image) {
-		m_image = image;
-		m_imageSize = new Dimension(m_image);
+		this(new ImageImageDescriptor(image));
+	}
+
+	public BeanFigure(ImageDescriptor imageDescriptor) {
+		final ImageData imageData = imageDescriptor.getImageData(100);
+		m_imageDescriptor = imageDescriptor;
+		m_imageSize = new Dimension(imageData.width, imageData.height);
 		add(m_label);
 	}
 
@@ -73,6 +82,8 @@ public class BeanFigure extends Figure {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	protected void paintClientArea(Graphics graphics) {
-		graphics.drawImage(m_image, m_imageLocation);
+		Image image = m_imageDescriptor.createImage();
+		graphics.drawImage(image, m_imageLocation);
+		image.dispose();
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/part/nonvisual/NonVisualBeanEditPart.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/part/nonvisual/NonVisualBeanEditPart.java
@@ -19,7 +19,7 @@ import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.core.model.nonvisual.NonVisualBeanInfo;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * {@link EditPart} for <i>non-visual bean</i> model.
@@ -66,8 +66,8 @@ public final class NonVisualBeanEditPart extends GraphicalEditPart {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	protected Figure createFigure() {
-		Image image = ObjectInfo.getImage(m_beanInfo.getJavaInfo());
-		return new BeanFigure(image);
+		ImageDescriptor imageDescriptor = ObjectInfo.getImageDescriptor(m_beanInfo.getJavaInfo());
+		return new BeanFigure(imageDescriptor);
 	}
 
 	@Override

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/creation/ExposedFieldCreationSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/creation/ExposedFieldCreationSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,13 +20,14 @@ import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
 import org.eclipse.wb.internal.core.model.clipboard.IClipboardImplicitCreationSupport;
 import org.eclipse.wb.internal.core.utils.ast.AstNodeUtils;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.SimpleName;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.viewers.DecorationOverlayIcon;
+import org.eclipse.jface.viewers.IDecoration;
 
 import java.lang.reflect.Field;
 
@@ -92,11 +93,10 @@ IExposedCreationSupport {
 		// icon decorator
 		m_javaInfo.addBroadcastListener(new ObjectInfoPresentationDecorateIcon() {
 			@Override
-			public void invoke(ObjectInfo object, Image[] icon) throws Exception {
+			public void invoke(ObjectInfo object, ImageDescriptor[] icon) throws Exception {
 				if (object == m_javaInfo) {
-					Image decorator = DesignerPlugin.getImage("exposed/decorator.gif");
-					icon[0] =
-							SwtResourceManager.decorateImage(icon[0], decorator, SwtResourceManager.BOTTOM_RIGHT);
+					ImageDescriptor decorator = DesignerPlugin.getImageDescriptor("exposed/decorator.gif");
+					icon[0] = new DecorationOverlayIcon(icon[0], decorator, IDecoration.BOTTOM_RIGHT);
 				}
 			}
 		});

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/creation/ExposedPropertyCreationSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/creation/ExposedPropertyCreationSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,12 +21,13 @@ import org.eclipse.wb.internal.core.model.JavaInfoUtils;
 import org.eclipse.wb.internal.core.model.clipboard.IClipboardImplicitCreationSupport;
 import org.eclipse.wb.internal.core.model.description.MethodDescription;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.MethodInvocation;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.viewers.DecorationOverlayIcon;
+import org.eclipse.jface.viewers.IDecoration;
 
 import java.lang.reflect.Method;
 
@@ -137,11 +138,10 @@ IExposedCreationSupport {
 		// icon decorator
 		m_javaInfo.addBroadcastListener(new ObjectInfoPresentationDecorateIcon() {
 			@Override
-			public void invoke(ObjectInfo object, Image[] icon) throws Exception {
+			public void invoke(ObjectInfo object, ImageDescriptor[] icon) throws Exception {
 				if (object == m_javaInfo) {
-					Image decorator = DesignerPlugin.getImage("exposed/decorator.gif");
-					icon[0] =
-							SwtResourceManager.decorateImage(icon[0], decorator, SwtResourceManager.BOTTOM_RIGHT);
+					ImageDescriptor decorator = DesignerPlugin.getImageDescriptor("exposed/decorator.gif");
+					icon[0] = new DecorationOverlayIcon(icon[0], decorator, IDecoration.BOTTOM_RIGHT);
 				}
 			}
 		});

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/creation/factory/InstanceFactoryContainerInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/creation/factory/InstanceFactoryContainerInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,7 @@ import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.model.presentation.DefaultObjectPresentation;
 import org.eclipse.wb.internal.core.model.presentation.IObjectPresentation;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.util.List;
 
@@ -79,8 +79,8 @@ public final class InstanceFactoryContainerInfo extends ObjectInfo {
 			}
 
 			@Override
-			public Image getIcon() throws Exception {
-				return DesignerPlugin.getImage("components/factory_container.gif");
+			public ImageDescriptor getIcon() throws Exception {
+				return DesignerPlugin.getImageDescriptor("components/factory_container.gif");
 			}
 		};
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/nonvisual/AbstractArrayObjectInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/nonvisual/AbstractArrayObjectInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -31,7 +31,7 @@ import org.eclipse.wb.internal.core.utils.check.Assert;
 
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.Expression;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import org.apache.commons.lang.StringUtils;
 
@@ -85,8 +85,8 @@ public abstract class AbstractArrayObjectInfo extends ItemCollectorObjectInfo {
 			}
 
 			@Override
-			public Image getIcon() throws Exception {
-				return DesignerPlugin.getImage("components/non_visual_beans_container.gif");
+			public ImageDescriptor getIcon() throws Exception {
+				return DesignerPlugin.getImageDescriptor("components/non_visual_beans_container.gif");
 			}
 
 			@Override

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/nonvisual/CollectorObjectInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/nonvisual/CollectorObjectInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 import org.eclipse.wb.internal.core.utils.state.EditorState;
 
 import org.eclipse.draw2d.geometry.Rectangle;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import org.apache.commons.lang.StringUtils;
 
@@ -103,8 +103,8 @@ public abstract class CollectorObjectInfo extends ObjectInfo {
 			}
 
 			@Override
-			public Image getIcon() throws Exception {
-				return DesignerPlugin.getImage("components/non_visual_beans_container.gif");
+			public ImageDescriptor getIcon() throws Exception {
+				return DesignerPlugin.getImageDescriptor("components/non_visual_beans_container.gif");
 			}
 
 			@Override

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/nonvisual/NonVisualBeanContainerInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/nonvisual/NonVisualBeanContainerInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -32,7 +32,7 @@ import org.eclipse.wb.internal.core.utils.ast.AstNodeUtils;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.BodyDeclaration;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * Container for <i>non-visual beans</i>, direct child of root {@link JavaInfo}.
@@ -155,8 +155,8 @@ public final class NonVisualBeanContainerInfo extends ObjectInfo {
 			}
 
 			@Override
-			public Image getIcon() throws Exception {
-				return DesignerPlugin.getImage("components/non_visual_beans_container.gif");
+			public ImageDescriptor getIcon() throws Exception {
+				return DesignerPlugin.getImageDescriptor("components/non_visual_beans_container.gif");
 			}
 		};
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/presentation/DefaultJavaInfoPresentation.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/presentation/DefaultJavaInfoPresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,9 @@ package org.eclipse.wb.internal.core.model.presentation;
 
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.model.creation.factory.AbstractExplicitFactoryCreationSupport;
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
 
 /**
@@ -40,18 +42,18 @@ public class DefaultJavaInfoPresentation extends DefaultObjectPresentation {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() throws Exception {
+	public ImageDescriptor getIcon() throws Exception {
 		// for factory try to get "factory method" specific icon
 		if (m_javaInfo.getCreationSupport() instanceof AbstractExplicitFactoryCreationSupport) {
 			AbstractExplicitFactoryCreationSupport factoryCreationSupport =
 					(AbstractExplicitFactoryCreationSupport) m_javaInfo.getCreationSupport();
 			Image icon = factoryCreationSupport.getDescription().getIcon();
 			if (icon != null) {
-				return icon;
+				return new ImageImageDescriptor(icon);
 			}
 		}
 		// by default use "component type" specific icon
-		return m_javaInfo.getDescription().getIcon();
+		return new ImageImageDescriptor(m_javaInfo.getDescription().getIcon());
 	}
 
 	@Override

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/event/EventsProperty.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/event/EventsProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,12 +23,13 @@ import org.eclipse.wb.internal.core.model.ModelMessages;
 import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.model.property.category.PropertyCategory;
 import org.eclipse.wb.internal.core.model.util.PropertyUtils;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.preference.IPreferenceStore;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.viewers.DecorationOverlayIcon;
+import org.eclipse.jface.viewers.IDecoration;
 
 import java.util.List;
 
@@ -63,13 +64,12 @@ public final class EventsProperty extends AbstractEventProperty {
 	private void installDecoratorListener() {
 		m_javaInfo.addBroadcastListener(new ObjectInfoPresentationDecorateIcon() {
 			@Override
-			public void invoke(ObjectInfo object, Image[] icon) throws Exception {
+			public void invoke(ObjectInfo object, ImageDescriptor[] icon) throws Exception {
 				if (object == m_javaInfo) {
 					IPreferenceStore preferences = m_javaInfo.getDescription().getToolkit().getPreferences();
 					if (preferences.getBoolean(IPreferenceConstants.P_DECORATE_ICON) && isModified()) {
-						Image decorator = DesignerPlugin.getImage("events/decorator.gif");
-						icon[0] =
-								SwtResourceManager.decorateImage(icon[0], decorator, SwtResourceManager.TOP_LEFT);
+						ImageDescriptor decorator = DesignerPlugin.getImageDescriptor("events/decorator.gif");
+						icon[0] = new DecorationOverlayIcon(icon[0], decorator, IDecoration.TOP_LEFT);
 					}
 				}
 			}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/RenameConvertSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/RenameConvertSupport.java
@@ -36,6 +36,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jdt.core.JavaConventions;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IContributionManager;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
@@ -367,8 +368,12 @@ public final class RenameConvertSupport {
 				// icon
 				{
 					Label iconLabel = new Label(container, SWT.NONE);
-					Image icon = ObjectInfo.getImage(javaInfo);
-					iconLabel.setImage(icon);
+					ImageDescriptor imageDescriptor = ObjectInfo.getImageDescriptor(javaInfo);
+					if (imageDescriptor != null ) {
+						Image icon = imageDescriptor.createImage();
+						iconLabel.addDisposeListener(event -> icon.dispose());
+						iconLabel.setImage(icon);
+					}
 				}
 				// text
 				{

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/nls/ui/PropertiesComposite.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/nls/ui/PropertiesComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,6 +29,10 @@ import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
 
 import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.resource.LocalResourceManager;
+import org.eclipse.jface.resource.ResourceManager;
 import org.eclipse.jface.viewers.CheckStateChangedEvent;
 import org.eclipse.jface.viewers.CheckboxTreeViewer;
 import org.eclipse.jface.viewers.ICheckStateListener;
@@ -461,6 +465,14 @@ public final class PropertiesComposite extends Composite {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	private class PropertiesLabelProvider extends LabelProvider {
+		private final ResourceManager m_resourceManager = new LocalResourceManager(JFaceResources.getResources());
+
+		@Override
+		public void dispose() {
+			super.dispose();
+			m_resourceManager.dispose();
+		}
+
 		@Override
 		public String getText(final Object element) {
 			return ExecutionUtils.runObjectLog(new RunnableObjectEx<String>() {
@@ -480,18 +492,19 @@ public final class PropertiesComposite extends Composite {
 
 		@Override
 		public Image getImage(final Object element) {
-			return ExecutionUtils.runObjectLog(new RunnableObjectEx<Image>() {
+			ImageDescriptor imageDescriptor = ExecutionUtils.runObjectLog(new RunnableObjectEx<ImageDescriptor>() {
 				@Override
-				public Image runObject() throws Exception {
+				public ImageDescriptor runObject() throws Exception {
 					if (element instanceof JavaInfo) {
 						JavaInfo component = (JavaInfo) element;
 						return component.getPresentation().getIcon();
 					} else {
 						Assert.instanceOf(StringPropertyInfo.class, element);
-						return DesignerPlugin.getImage("nls/property.gif");
+						return DesignerPlugin.getImageDescriptor("nls/property.gif");
 					}
 				}
 			}, null);
+			return imageDescriptor == null ? null : m_resourceManager.createImage(imageDescriptor);
 		}
 	}
 }

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/XmlObjectPresentation.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/XmlObjectPresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,8 +11,9 @@
 package org.eclipse.wb.internal.core.xml.model;
 
 import org.eclipse.wb.internal.core.model.presentation.DefaultObjectPresentation;
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * Presentation for {@link XmlObjectInfo}.
@@ -39,8 +40,8 @@ public class XmlObjectPresentation extends DefaultObjectPresentation {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() throws Exception {
-		return m_object.getDescription().getIcon();
+	public ImageDescriptor getIcon() throws Exception {
+		return new ImageImageDescriptor(m_object.getDescription().getIcon());
 	}
 
 	@Override

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/property/event/EventsProperty.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/property/event/EventsProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,14 +21,15 @@ import org.eclipse.wb.internal.core.model.property.category.PropertyCategory;
 import org.eclipse.wb.internal.core.model.property.editor.PropertyEditor;
 import org.eclipse.wb.internal.core.model.property.event.IPreferenceConstants;
 import org.eclipse.wb.internal.core.model.util.PropertyUtils;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 import org.eclipse.wb.internal.core.xml.Messages;
 import org.eclipse.wb.internal.core.xml.model.XmlObjectInfo;
 
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.preference.IPreferenceStore;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.viewers.DecorationOverlayIcon;
+import org.eclipse.jface.viewers.IDecoration;
 
 import java.util.List;
 
@@ -66,13 +67,12 @@ public final class EventsProperty extends AbstractEventProperty {
 	private void installDecoratorListener() {
 		m_object.addBroadcastListener(new ObjectInfoPresentationDecorateIcon() {
 			@Override
-			public void invoke(ObjectInfo object, Image[] icon) throws Exception {
+			public void invoke(ObjectInfo object, ImageDescriptor[] icon) throws Exception {
 				if (object == m_object) {
 					IPreferenceStore preferences = m_object.getDescription().getToolkit().getPreferences();
 					if (preferences.getBoolean(IPreferenceConstants.P_DECORATE_ICON) && isModified()) {
-						Image decorator = DesignerPlugin.getImage("events/decorator.gif");
-						icon[0] =
-								SwtResourceManager.decorateImage(icon[0], decorator, SwtResourceManager.TOP_LEFT);
+						ImageDescriptor decorator = DesignerPlugin.getImageDescriptor("events/decorator.gif");
+						icon[0] = new DecorationOverlayIcon(icon[0], decorator, IDecoration.TOP_LEFT);
 					}
 				}
 			}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gefTree/part/ObjectEditPart.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gefTree/part/ObjectEditPart.java
@@ -27,6 +27,7 @@ import org.eclipse.wb.internal.gef.tree.policies.AutoExpandEditPolicy;
 import org.eclipse.wb.internal.gef.tree.policies.SelectionEditPolicy;
 
 import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Event;
@@ -176,9 +177,11 @@ public class ObjectEditPart extends TreeEditPart {
 	}
 
 	private void update0() {
-		Image image = ObjectInfo.getImage(m_object);
+		ImageDescriptor imageDescriptor = ObjectInfo.getImageDescriptor(m_object);
 		String text = ObjectInfo.getText(m_object);
-		if (image != null && !image.isDisposed()) {
+		if (imageDescriptor != null) {
+			Image image = imageDescriptor.createImage();
+			getWidget().addDisposeListener(event -> image.dispose());
 			getWidget().setImage(image);
 		}
 		//Obtain the preference specifying the root object name. If no name is specified then the default is used

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/model/ObjectInfo.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/model/ObjectInfo.java
@@ -29,7 +29,7 @@ import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -690,12 +690,12 @@ public abstract class ObjectInfo implements IObjectInfo {
 	 * @return The decorated image or {@code null} on error.
 	 * @see IObjectPresentation
 	 */
-	public static Image getImage(final ObjectInfo objectInfo) {
+	public static ImageDescriptor getImageDescriptor(final ObjectInfo objectInfo) {
 		return ExecutionUtils.runObjectLog(() -> {
-			Image icon = objectInfo.getPresentation().getIcon();
+			ImageDescriptor icon = objectInfo.getPresentation().getIcon();
 			// decorate
 			{
-				Image[] decoratedIcon = new Image[] { icon };
+				ImageDescriptor[] decoratedIcon = new ImageDescriptor[] { icon };
 				objectInfo.getBroadcast(ObjectInfoPresentationDecorateIcon.class).invoke(objectInfo, decoratedIcon);
 				icon = decoratedIcon[0];
 			}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/model/broadcast/ObjectInfoPresentationDecorateIcon.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/model/broadcast/ObjectInfoPresentationDecorateIcon.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,7 @@ package org.eclipse.wb.core.model.broadcast;
 
 import org.eclipse.wb.core.model.ObjectInfo;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * Listener for {@link ObjectInfo} events.
@@ -27,7 +27,7 @@ public interface ObjectInfoPresentationDecorateIcon {
 	 * @param object
 	 *          the {@link ObjectInfo} to decorate icon.
 	 * @param icon
-	 *          the array with single {@link Image}, listener can replace this image
+	 *          the array with single {@link ImageDescriptor}, listener can replace this image
 	 */
-	void invoke(ObjectInfo object, Image[] icon) throws Exception;
+	void invoke(ObjectInfo object, ImageDescriptor[] icon) throws Exception;
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/presentation/DefaultObjectPresentation.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/presentation/DefaultObjectPresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,7 @@ import org.eclipse.wb.core.model.broadcast.ObjectInfoChildTree;
 import org.eclipse.wb.core.model.broadcast.ObjectInfoChildrenGraphical;
 import org.eclipse.wb.core.model.broadcast.ObjectInfoChildrenTree;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.util.List;
 
@@ -80,7 +80,7 @@ public abstract class DefaultObjectPresentation implements IObjectPresentation {
 	}
 
 	@Override
-	public Image getIcon() throws Exception {
+	public ImageDescriptor getIcon() throws Exception {
 		return null;
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/presentation/IObjectPresentation.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/presentation/IObjectPresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,7 @@ package org.eclipse.wb.internal.core.model.presentation;
 
 import org.eclipse.wb.core.model.ObjectInfo;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.util.List;
 
@@ -37,7 +37,7 @@ public interface IObjectPresentation {
 	/**
 	 * @return the icon to display for user.
 	 */
-	Image getIcon() throws Exception;
+	ImageDescriptor getIcon() throws Exception;
 
 	/**
 	 * @return the list of {@link ObjectInfo} children to display for user in components tree. This

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/ObjectsLabelProvider.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/ObjectsLabelProvider.java
@@ -12,6 +12,10 @@ package org.eclipse.wb.internal.core.model.util;
 
 import org.eclipse.wb.core.model.ObjectInfo;
 
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.resource.LocalResourceManager;
+import org.eclipse.jface.resource.ResourceManager;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.swt.graphics.Image;
 
@@ -22,6 +26,13 @@ import org.eclipse.swt.graphics.Image;
  * @coverage core.model.util
  */
 public final class ObjectsLabelProvider extends LabelProvider {
+	private ResourceManager m_resourceManager = new LocalResourceManager(JFaceResources.getResources());
+
+	@Override
+	public void dispose() {
+		super.dispose();
+		m_resourceManager.dispose();
+	}
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -30,7 +41,8 @@ public final class ObjectsLabelProvider extends LabelProvider {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public Image getImage(final Object element) {
-		return ObjectInfo.getImage((ObjectInfo) element);
+		ImageDescriptor imageDescriptor = ObjectInfo.getImageDescriptor((ObjectInfo) element);
+		return imageDescriptor == null ? null : m_resourceManager.createImage(imageDescriptor);
 	}
 
 	@Override

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanBindablePresentation.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanBindablePresentation.java
@@ -14,6 +14,7 @@ import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.databinding.model.presentation.ObservePresentation;
 import org.eclipse.wb.internal.core.databinding.model.reference.IReferenceProvider;
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
@@ -78,8 +79,7 @@ public final class BeanBindablePresentation extends ObservePresentation {
 		if (m_beanImage == null && m_javaInfo == null) {
 			return null;
 		}
-		Image image = m_beanImage == null ? m_javaInfo.getPresentation().getIcon() : m_beanImage;
-		return image == null ? null : ImageDescriptor.createFromImage(image);
+		return m_beanImage == null ? m_javaInfo.getPresentation().getIcon() : new ImageImageDescriptor(m_beanImage);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/ControlDecorationInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/ControlDecorationInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,6 +24,7 @@ import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 import org.eclipse.wb.internal.swt.support.RectangleSupport;
 
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Control;
@@ -67,9 +68,9 @@ public final class ControlDecorationInfo extends AbstractComponentInfo {
 	private Image m_iconImage;
 	private final IObjectPresentation m_presentation = new DefaultJavaInfoPresentation(this) {
 		@Override
-		public Image getIcon() throws Exception {
+		public ImageDescriptor getIcon() throws Exception {
 			if (m_decorationImage != null && m_iconImage != null) {
-				return m_iconImage;
+				return ImageDescriptor.createFromImage(m_iconImage);
 			}
 			return super.getIcon();
 		}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/FieldEditorSubComponentCreationSupport.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/FieldEditorSubComponentCreationSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,14 +21,15 @@ import org.eclipse.wb.internal.core.model.clipboard.IClipboardImplicitCreationSu
 import org.eclipse.wb.internal.core.model.creation.CreationSupport;
 import org.eclipse.wb.internal.core.model.creation.IImplicitCreationSupport;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jface.preference.StringFieldEditor;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.viewers.DecorationOverlayIcon;
+import org.eclipse.jface.viewers.IDecoration;
 
 import java.lang.reflect.Method;
 
@@ -92,11 +93,10 @@ IImplicitCreationSupport {
 		// icon decorator
 		m_javaInfo.addBroadcastListener(new ObjectInfoPresentationDecorateIcon() {
 			@Override
-			public void invoke(ObjectInfo object, Image[] icon) throws Exception {
+			public void invoke(ObjectInfo object, ImageDescriptor[] icon) throws Exception {
 				if (object == m_javaInfo) {
-					Image decorator = DesignerPlugin.getImage("exposed/decorator.gif");
-					icon[0] =
-							SwtResourceManager.decorateImage(icon[0], decorator, SwtResourceManager.BOTTOM_RIGHT);
+					ImageDescriptor decorator = DesignerPlugin.getImageDescriptor("exposed/decorator.gif");
+					icon[0] = new DecorationOverlayIcon(icon[0], decorator, IDecoration.BOTTOM_RIGHT);
 				}
 			}
 		});

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/ActionContainerInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/ActionContainerInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -34,7 +34,7 @@ import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jface.action.Action;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
@@ -76,8 +76,8 @@ public final class ActionContainerInfo extends ObjectInfo {
 			}
 
 			@Override
-			public Image getIcon() throws Exception {
-				return Activator.getImage("info/Action/container.gif");
+			public ImageDescriptor getIcon() throws Exception {
+				return Activator.getImageDescriptor("info/Action/container.gif");
 			}
 		};
 	}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/ActionContributionItemInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/ActionContributionItemInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,7 +27,7 @@ import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jface.action.ActionContributionItem;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.IContributionManager;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.util.List;
 
@@ -76,7 +76,7 @@ public final class ActionContributionItemInfo extends ContributionItemInfo {
 	////////////////////////////////////////////////////////////////////////////
 	private final IObjectPresentation m_presentation = new DefaultJavaInfoPresentation(this) {
 		@Override
-		public Image getIcon() throws Exception {
+		public ImageDescriptor getIcon() throws Exception {
 			return getAction().getPresentation().getIcon();
 		}
 

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/ActionInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/ActionInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,12 +20,11 @@ import org.eclipse.wb.internal.core.model.presentation.DefaultJavaInfoPresentati
 import org.eclipse.wb.internal.core.model.presentation.IObjectPresentation;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
-import org.eclipse.wb.internal.core.utils.ui.ImageDisposer;
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.rcp.palette.ActionUseEntryInfo;
 
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.swt.graphics.Image;
 
 import java.util.List;
 
@@ -64,17 +63,15 @@ public final class ActionInfo extends JavaInfo {
 	@Override
 	public void refresh_dispose() throws Exception {
 		super.refresh_dispose();
-		// dispose ImageDescriptor image
-		if (m_iconImage != null) {
-			m_iconImage = null;
-		}
+		// dispose ImageDescriptor
+		m_icon = null;
 	}
 
 	@Override
 	protected void refresh_fetch() throws Exception {
 		super.refresh_fetch();
-		// update ImageDescriptor image
-		refreshIconImage();
+		// update ImageDescriptor
+		m_icon = (ImageDescriptor) ReflectionUtils.invokeMethod2(getObject(), "getImageDescriptor");
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -83,18 +80,18 @@ public final class ActionInfo extends JavaInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * The SWT {@link Image} created from {@link ImageDescriptor}, may be <code>null</code>.
+	 * The SWT {@link ImageDescriptor}, may be <code>null</code>.
 	 */
-	private Image m_iconImage;
+	private ImageDescriptor m_icon;
 	private final IObjectPresentation m_presentation = new DefaultJavaInfoPresentation(this) {
 		@Override
-		public Image getIcon() throws Exception {
-			if (m_iconImage != null) {
-				return m_iconImage;
+		public ImageDescriptor getIcon() throws Exception {
+			if (m_icon != null) {
+				return m_icon;
 			}
 			if (getCreationSupport() instanceof IActionIconProvider) {
 				IActionIconProvider iconProvider = (IActionIconProvider) getCreationSupport();
-				return iconProvider.getActionIcon();
+				return new ImageImageDescriptor(iconProvider.getActionIcon());
 			}
 			return super.getIcon();
 		}
@@ -103,17 +100,5 @@ public final class ActionInfo extends JavaInfo {
 	@Override
 	public IObjectPresentation getPresentation() {
 		return m_presentation;
-	}
-
-	/**
-	 * Converts {@link ImageDescriptor} into {@link #m_iconImage}.
-	 */
-	private void refreshIconImage() throws Exception {
-		// if Action has ImageDescriptor, convert it into Image
-		Object imageDescription = ReflectionUtils.invokeMethod2(getObject(), "getImageDescriptor");
-		if (imageDescription != null) {
-			m_iconImage = (Image) ReflectionUtils.invokeMethod2(imageDescription, "createImage");
-			ImageDisposer.add(this, "iconImage", m_iconImage);
-		}
 	}
 }

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/AbstractPartInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/AbstractPartInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ import org.eclipse.wb.internal.swt.support.ControlSupport;
 
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.MethodInvocation;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.ui.IPageLayout;
 
@@ -288,7 +288,7 @@ IPageLayoutTopLevelInfo {
 	////////////////////////////////////////////////////////////////////////////
 	private final IObjectPresentation m_presentation = new DefaultJavaInfoPresentation(this) {
 		@Override
-		public Image getIcon() throws Exception {
+		public ImageDescriptor getIcon() throws Exception {
 			return getPresentationIcon();
 		}
 
@@ -306,7 +306,7 @@ IPageLayoutTopLevelInfo {
 	/**
 	 * @return the icon to show in component tree.
 	 */
-	protected abstract Image getPresentationIcon() throws Exception;
+	protected abstract ImageDescriptor getPresentationIcon() throws Exception;
 
 	/**
 	 * @return the text to show in component tree.

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/EditorAreaInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/EditorAreaInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,8 +17,8 @@ import org.eclipse.wb.internal.rcp.Activator;
 import org.eclipse.wb.internal.swt.support.CoordinateUtils;
 
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.custom.CTabFolder;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.ui.IPageLayout;
@@ -61,8 +61,8 @@ public final class EditorAreaInfo extends ObjectInfo implements IPageLayoutTopLe
 	public IObjectPresentation getPresentation() {
 		return new DefaultObjectPresentation(this) {
 			@Override
-			public Image getIcon() throws Exception {
-				return Activator.getImage("info/perspective/editor.gif");
+			public ImageDescriptor getIcon() throws Exception {
+				return Activator.getImageDescriptor("info/perspective/editor.gif");
 			}
 
 			@Override

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/FolderViewInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/FolderViewInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,12 +19,14 @@ import org.eclipse.wb.internal.core.model.presentation.DefaultJavaInfoPresentati
 import org.eclipse.wb.internal.core.model.presentation.IObjectPresentation;
 import org.eclipse.wb.internal.core.model.variable.VoidInvocationVariableSupport;
 import org.eclipse.wb.internal.core.utils.ast.DomGenerics;
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.rcp.model.rcp.PdeUtils;
 import org.eclipse.wb.internal.rcp.model.rcp.PdeUtils.ViewInfo;
 import org.eclipse.wb.internal.swt.support.CoordinateUtils;
 
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CLabel;
 import org.eclipse.swt.custom.CTabFolder;
@@ -95,7 +97,7 @@ public final class FolderViewInfo extends AbstractComponentInfo implements IRend
 	////////////////////////////////////////////////////////////////////////////
 	private final IObjectPresentation m_presentation = new DefaultJavaInfoPresentation(this) {
 		@Override
-		public Image getIcon() throws Exception {
+		public ImageDescriptor getIcon() throws Exception {
 			return getPresentationIcon();
 		}
 
@@ -113,8 +115,8 @@ public final class FolderViewInfo extends AbstractComponentInfo implements IRend
 	/**
 	 * @return the icon to show in component tree.
 	 */
-	private Image getPresentationIcon() throws Exception {
-		return getViewInfo().getIcon();
+	private ImageDescriptor getPresentationIcon() throws Exception {
+		return new ImageImageDescriptor(getViewInfo().getIcon());
 	}
 
 	/**

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/PageLayoutAddViewInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/PageLayoutAddViewInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,10 +19,12 @@ import org.eclipse.wb.internal.core.model.property.editor.BooleanPropertyEditor;
 import org.eclipse.wb.internal.core.model.variable.VoidInvocationVariableSupport;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.rcp.model.rcp.PdeUtils;
 import org.eclipse.wb.internal.rcp.model.rcp.PdeUtils.ViewInfo;
 
 import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabItem;
@@ -216,8 +218,8 @@ public final class PageLayoutAddViewInfo extends AbstractPartInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected Image getPresentationIcon() {
-		return getViewInfo().getIcon();
+	protected ImageDescriptor getPresentationIcon() {
+		return new ImageImageDescriptor(getViewInfo().getIcon());
 	}
 
 	@Override
@@ -242,7 +244,12 @@ public final class PageLayoutAddViewInfo extends AbstractPartInfo {
 		CTabFolder folder = PageLayoutInfo.createPartFolder(m_page.getPartsComposite());
 		// create CTabItem
 		CTabItem item = new CTabItem(folder, SWT.CLOSE);
-		item.setImage(getPresentationIcon());
+		ImageDescriptor imageDescriptor = getPresentationIcon();
+		if (imageDescriptor != null) {
+			Image image = imageDescriptor.createImage();
+			item.addDisposeListener(event -> image.dispose());
+			item.setImage(image);
+		}
 		item.setText(getViewInfo().getName());
 		// return CTabFolder
 		folder.setSelection(item);

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/PageLayoutCreateFolderInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/PageLayoutCreateFolderInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -31,12 +31,12 @@ import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 import org.eclipse.wb.internal.rcp.Activator;
 
 import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabItem;
 import org.eclipse.swt.events.ControlAdapter;
 import org.eclipse.swt.events.ControlEvent;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -210,8 +210,8 @@ public final class PageLayoutCreateFolderInfo extends AbstractPartInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected Image getPresentationIcon() {
-		return Activator.getImage("info/perspective/folder.gif");
+	protected ImageDescriptor getPresentationIcon() {
+		return Activator.getImageDescriptor("info/perspective/folder.gif");
 	}
 
 	@Override

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/shortcuts/AbstractShortcutContainerInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/shortcuts/AbstractShortcutContainerInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -36,11 +36,11 @@ import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.PaintEvent;
 import org.eclipse.swt.events.PaintListener;
 import org.eclipse.swt.graphics.GC;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.ToolBar;
@@ -108,8 +108,8 @@ public abstract class AbstractShortcutContainerInfo extends ObjectInfo {
 	////////////////////////////////////////////////////////////////////////////
 	private final IObjectPresentation m_presentation = new DefaultObjectPresentation(this) {
 		@Override
-		public Image getIcon() throws Exception {
-			return Activator.getImage("info/perspective/container.gif");
+		public ImageDescriptor getIcon() throws Exception {
+			return Activator.getImageDescriptor("info/perspective/container.gif");
 		}
 
 		@Override

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/shortcuts/AbstractShortcutInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/shortcuts/AbstractShortcutInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,6 +29,7 @@ import org.eclipse.wb.internal.swt.support.RectangleSupport;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
@@ -100,7 +101,7 @@ public abstract class AbstractShortcutInfo extends AbstractComponentInfo impleme
 	////////////////////////////////////////////////////////////////////////////
 	private final IObjectPresentation m_presentation = new DefaultJavaInfoPresentation(this) {
 		@Override
-		public Image getIcon() throws Exception {
+		public ImageDescriptor getIcon() throws Exception {
 			return getPresentationIcon();
 		}
 
@@ -118,7 +119,7 @@ public abstract class AbstractShortcutInfo extends AbstractComponentInfo impleme
 	/**
 	 * @return the icon to show in component tree.
 	 */
-	protected abstract Image getPresentationIcon() throws Exception;
+	protected abstract ImageDescriptor getPresentationIcon() throws Exception;
 
 	/**
 	 * @return the text to show in component tree.
@@ -135,8 +136,13 @@ public abstract class AbstractShortcutInfo extends AbstractComponentInfo impleme
 	@Override
 	public Object render() throws Exception {
 		ToolBar toolBar = m_container.getToolBar();
+		ImageDescriptor imageDescriptor = getPresentationIcon();
 		m_item = new ToolItem(toolBar, SWT.NONE);
-		m_item.setImage(getPresentationIcon());
+		if (imageDescriptor != null) {
+			Image image = imageDescriptor.createImage();
+			m_item.addDisposeListener(event -> image.dispose());
+			m_item.setImage(image);
+		}
 		m_item.setToolTipText(getPresentationText());
 		return m_item;
 	}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/shortcuts/FastViewInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/shortcuts/FastViewInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,12 +10,13 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.rcp.perspective.shortcuts;
 
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.rcp.model.rcp.PdeUtils;
 import org.eclipse.wb.internal.rcp.model.rcp.PdeUtils.ViewInfo;
 import org.eclipse.wb.internal.rcp.model.rcp.perspective.PageLayoutInfo;
 
 import org.eclipse.jdt.core.dom.MethodInvocation;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.ui.IPageLayout;
 
 /**
@@ -42,8 +43,8 @@ public final class FastViewInfo extends AbstractShortcutInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected Image getPresentationIcon() throws Exception {
-		return getViewInfo().getIcon();
+	protected ImageDescriptor getPresentationIcon() throws Exception {
+		return new ImageImageDescriptor(getViewInfo().getIcon());
 	}
 
 	@Override

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/shortcuts/PerspectiveShortcutInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/shortcuts/PerspectiveShortcutInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,12 +10,13 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.rcp.perspective.shortcuts;
 
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.rcp.model.rcp.PdeUtils;
 import org.eclipse.wb.internal.rcp.model.rcp.PdeUtils.PerspectiveInfo;
 import org.eclipse.wb.internal.rcp.model.rcp.perspective.PageLayoutInfo;
 
 import org.eclipse.jdt.core.dom.MethodInvocation;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.ui.IPageLayout;
 
 /**
@@ -42,8 +43,8 @@ public final class PerspectiveShortcutInfo extends AbstractShortcutInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected Image getPresentationIcon() throws Exception {
-		return getPerspectiveInfo().getIcon();
+	protected ImageDescriptor getPresentationIcon() throws Exception {
+		return new ImageImageDescriptor(getPerspectiveInfo().getIcon());
 	}
 
 	@Override

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/shortcuts/ViewShortcutInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/shortcuts/ViewShortcutInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,12 +10,13 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.rcp.perspective.shortcuts;
 
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.rcp.model.rcp.PdeUtils;
 import org.eclipse.wb.internal.rcp.model.rcp.PdeUtils.ViewInfo;
 import org.eclipse.wb.internal.rcp.model.rcp.perspective.PageLayoutInfo;
 
 import org.eclipse.jdt.core.dom.MethodInvocation;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.ui.IPageLayout;
 
 /**
@@ -42,8 +43,8 @@ public final class ViewShortcutInfo extends AbstractShortcutInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected Image getPresentationIcon() throws Exception {
-		return getViewInfo().getIcon();
+	protected ImageDescriptor getPresentationIcon() throws Exception {
+		return new ImageImageDescriptor(getViewInfo().getIcon());
 	}
 
 	@Override

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/AbstractPositionInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/AbstractPositionInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,7 @@ import org.eclipse.wb.internal.core.model.presentation.IObjectPresentation;
 import org.eclipse.wb.internal.rcp.Activator;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * {@link ObjectInfo} that represents empty position in {@link AbstractPositionCompositeInfo}.
@@ -68,8 +68,8 @@ public final class AbstractPositionInfo extends ObjectInfo {
 	public IObjectPresentation getPresentation() {
 		return new DefaultObjectPresentation(this) {
 			@Override
-			public Image getIcon() throws Exception {
-				return Activator.getImage("info/position/element_transparent.png");
+			public ImageDescriptor getIcon() throws Exception {
+				return Activator.getImageDescriptor("info/position/element_transparent.png");
 			}
 
 			@Override

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/ActionUseEntryInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/ActionUseEntryInfo.java
@@ -14,7 +14,6 @@ import org.eclipse.wb.core.editor.palette.model.EntryInfo;
 import org.eclipse.wb.core.editor.palette.model.entry.ToolEntryInfo;
 import org.eclipse.wb.gef.core.tools.Tool;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.rcp.Activator;
 import org.eclipse.wb.internal.rcp.gef.policy.jface.action.ActionDropTool;
 import org.eclipse.wb.internal.rcp.model.jface.action.ActionInfo;
@@ -22,7 +21,6 @@ import org.eclipse.wb.internal.rcp.model.jface.action.ActionInfo;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.IContributionManager;
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.swt.graphics.Image;
 
 import org.apache.commons.lang.ObjectUtils;
 
@@ -35,7 +33,7 @@ import org.apache.commons.lang.ObjectUtils;
  * @coverage rcp.editor.palette
  */
 public final class ActionUseEntryInfo extends ToolEntryInfo {
-	private static final Image ICON = Activator.getImage("info/Action/action.gif");
+	private static final ImageDescriptor ICON = Activator.getImageDescriptor("info/Action/action.gif");
 	private final ActionInfo m_action;
 
 	////////////////////////////////////////////////////////////////////////////
@@ -57,13 +55,7 @@ public final class ActionUseEntryInfo extends ToolEntryInfo {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public ImageDescriptor getIcon() {
-		return ImageDescriptor.createFromImage(ExecutionUtils.runObjectLog(
-			new RunnableObjectEx<Image>() {
-				@Override
-				public Image runObject() throws Exception {
-					return m_action.getPresentation().getIcon();
-				}
-			}, ICON));
+		return ExecutionUtils.runObjectLog(() -> m_action.getPresentation().getIcon(), ICON);
 	}
 
 	@Override

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/FieldBeanObservePresentation.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/FieldBeanObservePresentation.java
@@ -12,6 +12,7 @@ package org.eclipse.wb.internal.swing.databinding.model.beans;
 
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.databinding.model.presentation.ObservePresentation;
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
@@ -50,8 +51,7 @@ public final class FieldBeanObservePresentation extends ObservePresentation {
 		if (m_beanImage == null && m_javaInfo == null) {
 			return null;
 		}
-		Image image = m_beanImage == null ? m_javaInfo.getPresentation().getIcon() : m_beanImage;
-		return image == null ? null : ImageDescriptor.createFromImage(image);
+		return m_beanImage == null ? m_javaInfo.getPresentation().getIcon() : new ImageImageDescriptor(m_beanImage);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/bean/ActionContainerInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/bean/ActionContainerInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,7 +26,7 @@ import org.eclipse.wb.internal.core.model.variable.LazyVariableSupport;
 import org.eclipse.wb.internal.core.model.variable.VariableSupport;
 import org.eclipse.wb.internal.swing.Activator;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.util.Collections;
 import java.util.List;
@@ -151,8 +151,8 @@ public final class ActionContainerInfo extends ObjectInfo {
 			}
 
 			@Override
-			public Image getIcon() throws Exception {
-				return Activator.getImage("info/Action/container.gif");
+			public ImageDescriptor getIcon() throws Exception {
+				return Activator.getImageDescriptor("info/Action/container.gif");
 			}
 		};
 	}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/bean/ActionInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/bean/ActionInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,6 +30,7 @@ import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.palette.ActionUseEntryInfo;
 
 import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
 
 import java.io.IOException;
@@ -96,9 +97,9 @@ public class ActionInfo extends JavaInfo {
 	private Image m_smallIconImage;
 	private final IObjectPresentation m_presentation = new DefaultJavaInfoPresentation(this) {
 		@Override
-		public Image getIcon() throws Exception {
+		public ImageDescriptor getIcon() throws Exception {
 			if (m_smallIconImage != null) {
-				return m_smallIconImage;
+				return ImageDescriptor.createFromImage(m_smallIconImage);
 			}
 			return super.getIcon();
 		}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/bean/ActionJavaInfoParticipator.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/bean/ActionJavaInfoParticipator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,6 @@ import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.broadcast.ObjectEventListener;
 import org.eclipse.wb.internal.core.model.util.ObjectInfoAction;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.core.utils.ui.MenuManagerEx;
 import org.eclipse.wb.internal.swing.Activator;
 import org.eclipse.wb.internal.swing.ToolkitProvider;
@@ -28,7 +27,7 @@ import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.Separator;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.util.List;
 
@@ -159,7 +158,7 @@ public final class ActionJavaInfoParticipator implements IJavaInfoInitialization
 			boolean isFirst) throws Exception {
 		for (final ActionInfo actionInfo : ActionContainerInfo.getActions(root)) {
 			String text = actionInfo.getPresentation().getText();
-			Image image = actionInfo.getPresentation().getIcon();
+			ImageDescriptor image = actionInfo.getPresentation().getIcon();
 			// add action
 			RunnableEx runnable = new RunnableEx() {
 				public void run() throws Exception {
@@ -171,7 +170,7 @@ public final class ActionJavaInfoParticipator implements IJavaInfoInitialization
 			};
 			IAction action =
 					contextMenu_createAction(root, isFirst, text, IAction.AS_RADIO_BUTTON, runnable);
-			action.setImageDescriptor(new ImageImageDescriptor(image));
+			action.setImageDescriptor(image);
 			groupsManager.add(action);
 			// update check state
 			{

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/bean/ButtonGroupContainerInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/bean/ButtonGroupContainerInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,7 +22,7 @@ import org.eclipse.wb.internal.core.model.variable.FieldInitializerVariableSuppo
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.swing.Activator;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.util.Collections;
 import java.util.List;
@@ -133,8 +133,8 @@ public final class ButtonGroupContainerInfo extends ObjectInfo {
 			}
 
 			@Override
-			public Image getIcon() throws Exception {
-				return Activator.getImage("info/ButtonGroup/ButtonGroup_container.gif");
+			public ImageDescriptor getIcon() throws Exception {
+				return Activator.getImageDescriptor("info/ButtonGroup/ButtonGroup_container.gif");
 			}
 		};
 	}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/menu/JPopupMenuInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/menu/JPopupMenuInfo.java
@@ -28,20 +28,19 @@ import org.eclipse.wb.internal.core.model.order.ComponentOrderFirst;
 import org.eclipse.wb.internal.core.utils.IAdaptable;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 import org.eclipse.wb.internal.swing.utils.SwingImageUtils;
 
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 
 import java.awt.Component;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.List;
-import java.util.Optional;
 
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
@@ -239,8 +238,7 @@ public final class JPopupMenuInfo extends ContainerInfo implements IAdaptable {
 		//
 		////////////////////////////////////////////////////////////////////////////
 		public ImageDescriptor getImageDescriptor() {
-			Image image = ExecutionUtils.runObjectLog(() -> getPresentation().getIcon(), getDescription().getIcon());
-			return image == null ? null : ImageDescriptor.createFromImage(image);
+			return ExecutionUtils.runObjectLog(() -> getPresentation().getIcon(), new ImageImageDescriptor(getDescription().getIcon()));
 		}
 
 		public Rectangle getBounds() {

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/palette/ActionUseEntryInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/palette/ActionUseEntryInfo.java
@@ -16,13 +16,11 @@ import org.eclipse.wb.gef.core.requests.ICreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.gef.core.tools.Tool;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.swing.Activator;
 import org.eclipse.wb.internal.swing.model.ModelMessages;
 import org.eclipse.wb.internal.swing.model.bean.ActionInfo;
 
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.swt.graphics.Image;
 
 import org.apache.commons.lang.ObjectUtils;
 
@@ -40,7 +38,7 @@ import javax.swing.JToolBar;
  * @coverage swing.editor.palette
  */
 public final class ActionUseEntryInfo extends ToolEntryInfo {
-	private static final Image ICON = Activator.getImage("info/Action/action.gif");
+	private static final ImageDescriptor ICON = Activator.getImageDescriptor("info/Action/action.gif");
 	private final ActionInfo m_action;
 
 	////////////////////////////////////////////////////////////////////////////
@@ -62,13 +60,7 @@ public final class ActionUseEntryInfo extends ToolEntryInfo {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public ImageDescriptor getIcon() {
-		return ImageDescriptor.createFromImage(ExecutionUtils.runObjectLog(
-			new RunnableObjectEx<Image>() {
-				@Override
-				public Image runObject() throws Exception {
-					return m_action.getPresentation().getIcon();
-				}
-			}, ICON));
+		return ExecutionUtils.runObjectLog(() -> m_action.getPresentation().getIcon(), ICON);
 	}
 
 	@Override

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/jface/resource/RegistryContainerInfo.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/jface/resource/RegistryContainerInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,7 @@ import org.eclipse.wb.internal.swt.Activator;
 import org.eclipse.wb.internal.swt.model.ModelMessages;
 
 import org.eclipse.jdt.core.dom.ASTNode;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.text.MessageFormat;
 import java.util.Collections;
@@ -117,8 +117,8 @@ public final class RegistryContainerInfo extends ObjectInfo {
 			}
 
 			@Override
-			public Image getIcon() throws Exception {
-				return Activator.getImage("components/registry_container.gif");
+			public ImageDescriptor getIcon() throws Exception {
+				return Activator.getImageDescriptor("components/registry_container.gif");
 			}
 		};
 	}

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/WidgetSelectDialog.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/WidgetSelectDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,10 @@ import org.eclipse.wb.internal.core.utils.ui.dialogs.ResizableDialog;
 import org.eclipse.wb.internal.swt.Activator;
 
 import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.resource.LocalResourceManager;
+import org.eclipse.jface.resource.ResourceManager;
 import org.eclipse.jface.viewers.DoubleClickEvent;
 import org.eclipse.jface.viewers.IDoubleClickListener;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
@@ -194,6 +198,14 @@ public class WidgetSelectDialog<C extends IAbstractComponentInfo> extends Resiza
 	//
 	////////////////////////////////////////////////////////////////////////////
 	private class ControlLabelProvider extends LabelProvider implements ITableLabelProvider {
+		private ResourceManager m_resourceManager = new LocalResourceManager(JFaceResources.getResources());
+
+		@Override
+		public void dispose() {
+			super.dispose();
+			m_resourceManager.dispose();
+		}
+
 		@Override
 		@SuppressWarnings("unchecked")
 		public String getColumnText(Object element, int columnIndex) {
@@ -210,7 +222,8 @@ public class WidgetSelectDialog<C extends IAbstractComponentInfo> extends Resiza
 		public Image getColumnImage(Object element, int columnIndex) {
 			C info = (C) element;
 			try {
-				return info.getPresentation().getIcon();
+				ImageDescriptor imageDescriptor = info.getPresentation().getIcon();
+				return imageDescriptor == null ? null : m_resourceManager.createImage(imageDescriptor);
 			} catch (Throwable e) {
 				throw ReflectionUtils.propagate(e);
 			}

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/widgets/StylePresentation.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/widgets/StylePresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,12 +15,10 @@ import com.google.common.collect.Maps;
 import org.eclipse.wb.internal.core.model.presentation.DefaultJavaInfoPresentation;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.reflect.ClassMap;
-import org.eclipse.wb.internal.core.utils.ui.ImageDisposer;
 import org.eclipse.wb.internal.swt.model.ModelMessages;
 import org.eclipse.wb.internal.swt.support.ControlSupport;
 
-import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.widgets.Display;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.widgets.Widget;
 
 import org.osgi.framework.Bundle;
@@ -51,10 +49,10 @@ public abstract class StylePresentation extends DefaultJavaInfoPresentation {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() throws Exception {
+	public ImageDescriptor getIcon() throws Exception {
 		// try to get by style
 		int style = ControlSupport.getStyle(m_javaInfo.getObject());
-		for (Map.Entry<Integer, Image> entry : getImages().entrySet()) {
+		for (Map.Entry<Integer, ImageDescriptor> entry : getImages().entrySet()) {
 			int keyStyle = entry.getKey();
 			if ((style & keyStyle) == keyStyle) {
 				return entry.getValue();
@@ -74,13 +72,13 @@ public abstract class StylePresentation extends DefaultJavaInfoPresentation {
 	// Utils
 	//
 	////////////////////////////////////////////////////////////////////////////
-	private static final ClassMap<Map<Integer, Image>> m_images = ClassMap.create();
+	private static final ClassMap<Map<Integer, ImageDescriptor>> m_images = ClassMap.create();
 
 	/**
 	 * @return the "style to image" map corresponding to this {@link StylePresentation}.
 	 */
-	private Map<Integer, Image> getImages() throws Exception {
-		Map<Integer, Image> images = m_images.get(getClass());
+	private Map<Integer, ImageDescriptor> getImages() throws Exception {
+		Map<Integer, ImageDescriptor> images = m_images.get(getClass());
 		if (images == null) {
 			images = Maps.newHashMap();
 			m_images.put(getClass(), images);
@@ -100,7 +98,7 @@ public abstract class StylePresentation extends DefaultJavaInfoPresentation {
 	 */
 	protected final void addImage(int style, String imagePath) throws Exception {
 		// load image
-		Image image;
+		ImageDescriptor image;
 		{
 			Bundle bundle = m_javaInfo.getDescription().getToolkit().getBundle();
 			URL imageURL = bundle.getEntry(imagePath);
@@ -110,10 +108,9 @@ public abstract class StylePresentation extends DefaultJavaInfoPresentation {
 							ModelMessages.StylePresentation_canNotFindImage,
 							imagePath,
 							bundle.getSymbolicName()));
-			image = new Image(Display.getDefault(), imageURL.openStream());
+			image = ImageDescriptor.createFromURL(imageURL);
 		}
 		// remember image
 		getImages().put(style, image);
-		ImageDisposer.add(getClass(), imagePath, image);
 	}
 }

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/widgets/menu/MenuInfo.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/widgets/menu/MenuInfo.java
@@ -44,6 +44,7 @@ import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.ast.NodeTarget;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.swt.model.widgets.WidgetInfo;
 import org.eclipse.wb.internal.swt.model.widgets.live.SwtLiveManager;
 import org.eclipse.wb.internal.swt.model.widgets.live.menu.MenuLiveManager;
@@ -55,7 +56,6 @@ import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Decorations;
@@ -340,8 +340,7 @@ public final class MenuInfo extends WidgetInfo implements IAdaptable {
 		////////////////////////////////////////////////////////////////////////////
 		@Override
 		public ImageDescriptor getImageDescriptor() {
-			Image image = ExecutionUtils.runObjectLog(() -> getPresentation().getIcon(), getDescription().getIcon());
-			return image == null ? null : ImageDescriptor.createFromImage(image);
+			return ExecutionUtils.runObjectLog(() -> getPresentation().getIcon(), new ImageImageDescriptor(getDescription().getIcon()));
 		}
 
 		@Override

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/model/property/EventsPropertyTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/model/property/EventsPropertyTest.java
@@ -123,18 +123,18 @@ public class EventsPropertyTest extends XwtModelTest {
 		// be default decoration enabled
 		assertNotSame(
 				button_1.getPresentation().getIcon(),
-				ObjectInfo.getImage(button_1));
+				ObjectInfo.getImageDescriptor(button_1));
 		assertSame(
 				button_2.getPresentation().getIcon(),
-				ObjectInfo.getImage(button_2));
+				ObjectInfo.getImageDescriptor(button_2));
 		// disable decoration, no decoration expected
 		TOOLKIT.getPreferences().setValue(IPreferenceConstants.P_DECORATE_ICON, false);
 		assertSame(
 				button_1.getPresentation().getIcon(),
-				ObjectInfo.getImage(button_1));
+				ObjectInfo.getImageDescriptor(button_1));
 		assertSame(
 				button_2.getPresentation().getIcon(),
-				ObjectInfo.getImage(button_2));
+				ObjectInfo.getImageDescriptor(button_2));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/DefaultJavaInfoPresentationTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/DefaultJavaInfoPresentationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@ package org.eclipse.wb.tests.designer.core.model;
 import org.eclipse.wb.internal.core.model.creation.factory.StaticFactoryCreationSupport;
 import org.eclipse.wb.internal.core.model.presentation.DefaultJavaInfoPresentation;
 import org.eclipse.wb.internal.core.model.presentation.IObjectPresentation;
+import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 import org.eclipse.wb.tests.designer.swing.SwingModelTest;
@@ -47,7 +48,7 @@ public class DefaultJavaInfoPresentationTest extends SwingModelTest {
 		// check "button" presentation, icon is from ComponentDescription
 		IObjectPresentation presentation = button.getPresentation();
 		assertInstanceOf(DefaultJavaInfoPresentation.class, presentation);
-		assertSame(button.getDescription().getIcon(), presentation.getIcon());
+		assertSame(button.getDescription().getIcon(), ReflectionUtils.getFieldObject(presentation.getIcon(), "m_Image"));
 		assertEquals("button", presentation.getText());
 	}
 
@@ -87,7 +88,7 @@ public class DefaultJavaInfoPresentationTest extends SwingModelTest {
 		StaticFactoryCreationSupport creationSupport =
 				(StaticFactoryCreationSupport) button.getCreationSupport();
 		IObjectPresentation presentation = button.getPresentation();
-		assertSame(creationSupport.getDescription().getIcon(), presentation.getIcon());
+		assertSame(creationSupport.getDescription().getIcon(), ReflectionUtils.getFieldObject(presentation.getIcon(), "m_Image"));
 		assertEquals("button", presentation.getText());
 	}
 
@@ -128,7 +129,7 @@ public class DefaultJavaInfoPresentationTest extends SwingModelTest {
 		}
 		// ...so use from ComponentDescription
 		IObjectPresentation presentation = button.getPresentation();
-		assertSame(button.getDescription().getIcon(), presentation.getIcon());
+		assertSame(button.getDescription().getIcon(), ReflectionUtils.getFieldObject(presentation.getIcon(), "m_Image"));
 		assertEquals("button", presentation.getText());
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/ExposedFieldCreationSupportTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/ExposedFieldCreationSupportTest.java
@@ -16,6 +16,7 @@ import org.eclipse.wb.internal.core.model.clipboard.JavaInfoMemento;
 import org.eclipse.wb.internal.core.model.creation.ExposedFieldCreationSupport;
 import org.eclipse.wb.internal.core.model.variable.ExposedFieldVariableSupport;
 import org.eclipse.wb.internal.core.model.variable.LocalUniqueVariableSupport;
+import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 import org.eclipse.wb.internal.swing.model.layout.FlowLayoutInfo;
@@ -500,11 +501,11 @@ public class ExposedFieldCreationSupportTest extends SwingModelTest {
 		assertSame(exposedContainer.getDescription(), innerPanel.getDescription());
 		// ...but their icons are different, because (probably) decorator applied
 		assertSame(
-				innerPanel.getPresentation().getIcon(),
-				ObjectInfo.getImage(innerPanel));
+				ReflectionUtils.getFieldObject(innerPanel.getPresentation().getIcon(), "m_Image"),
+				ReflectionUtils.getFieldObject(ObjectInfo.getImageDescriptor(innerPanel), "m_Image"));
 		assertNotSame(
 				exposedContainer.getPresentation().getIcon(),
-				ObjectInfo.getImage(exposedContainer));
+				ObjectInfo.getImageDescriptor(exposedContainer));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/ExposedPropertyCreationSupportTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/ExposedPropertyCreationSupportTest.java
@@ -12,6 +12,7 @@ package org.eclipse.wb.tests.designer.core.model.creation;
 
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.model.creation.ExposedPropertyCreationSupport;
+import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 import org.eclipse.wb.tests.designer.swing.SwingModelTest;
@@ -438,11 +439,11 @@ public class ExposedPropertyCreationSupportTest extends SwingModelTest {
 		assertSame(contentPane.getDescription(), container.getDescription());
 		// ...but their icons are different, because (probably) decorator applied
 		assertSame(
-				container.getPresentation().getIcon(),
-				ObjectInfo.getImage(container));
+				ReflectionUtils.getFieldObject(container.getPresentation().getIcon(), "m_Image"),
+				ReflectionUtils.getFieldObject(ObjectInfo.getImageDescriptor(container), "m_Image"));
 		assertNotSame(
 				contentPane.getPresentation().getIcon(),
-				ObjectInfo.getImage(contentPane));
+				ObjectInfo.getImageDescriptor(contentPane));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/EventsPropertyTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/EventsPropertyTest.java
@@ -2182,18 +2182,18 @@ public class EventsPropertyTest extends SwingModelTest implements IPreferenceCon
 		// be default decoration enabled
 		assertNotSame(
 				button_1.getPresentation().getIcon(),
-				ObjectInfo.getImage(button_1));
+				ObjectInfo.getImageDescriptor(button_1));
 		assertSame(
-				button_2.getPresentation().getIcon(),
-				ObjectInfo.getImage(button_2));
+				ReflectionUtils.getFieldObject(button_2.getPresentation().getIcon(), "m_Image"),
+				ReflectionUtils.getFieldObject(ObjectInfo.getImageDescriptor(button_2), "m_Image"));
 		// disable decoration, no decoration expected
 		panel.getDescription().getToolkit().getPreferences().setValue(P_DECORATE_ICON, false);
 		assertSame(
-				button_1.getPresentation().getIcon(),
-				ObjectInfo.getImage(button_1));
+				ReflectionUtils.getFieldObject(button_1.getPresentation().getIcon(), "m_Image"),
+				ReflectionUtils.getFieldObject(ObjectInfo.getImageDescriptor(button_1), "m_Image"));
 		assertSame(
-				button_2.getPresentation().getIcon(),
-				ObjectInfo.getImage(button_2));
+				ReflectionUtils.getFieldObject(button_2.getPresentation().getIcon(), "m_Image"),
+				ReflectionUtils.getFieldObject(ObjectInfo.getImageDescriptor(button_2), "m_Image"));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/ObjectsLabelProviderTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/ObjectsLabelProviderTest.java
@@ -16,11 +16,12 @@ import org.eclipse.wb.core.model.broadcast.ObjectInfoPresentationDecorateText;
 import org.eclipse.wb.internal.core.model.presentation.DefaultObjectPresentation;
 import org.eclipse.wb.internal.core.model.presentation.IObjectPresentation;
 import org.eclipse.wb.internal.core.model.util.ObjectsLabelProvider;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 import org.eclipse.wb.tests.designer.core.model.TestObjectInfo;
 import org.eclipse.wb.tests.designer.tests.DesignerTestCase;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.viewers.DecorationOverlayIcon;
+import org.eclipse.jface.viewers.IDecoration;
 
 /**
  * Test for {@link ObjectsLabelProvider}.
@@ -28,10 +29,10 @@ import org.eclipse.swt.graphics.Image;
  * @author scheglov_ke
  */
 public class ObjectsLabelProviderTest extends DesignerTestCase {
-	private static final Image DEF_ICON = SwtResourceManager.getImage(
+	private static final ImageDescriptor DEF_ICON = ImageDescriptor.createFromFile(
 			Object.class,
 			"/javax/swing/plaf/basic/icons/JavaCup16.png");
-	private static final Image DOWN_ICON = SwtResourceManager.getImage(
+	private static final ImageDescriptor DOWN_ICON = ImageDescriptor.createFromFile(
 			Object.class,
 			"/javax/swing/plaf/metal/icons/sortDown.png");
 	private static final String DEF_TEXT = "theObject";
@@ -47,7 +48,7 @@ public class ObjectsLabelProviderTest extends DesignerTestCase {
 	public void test_default() throws Exception {
 		TestObjectInfo theObject = new MyObjectInfo();
 		// do checks
-		assertSame(DEF_ICON, ObjectInfo.getImage(theObject));
+		assertSame(DEF_ICON, ObjectInfo.getImageDescriptor(theObject));
 		assertSame(DEF_TEXT, ObjectInfo.getText(theObject));
 	}
 
@@ -58,9 +59,8 @@ public class ObjectsLabelProviderTest extends DesignerTestCase {
 		TestObjectInfo theObject = new MyObjectInfo();
 		theObject.addBroadcastListener(new ObjectInfoPresentationDecorateIcon() {
 			@Override
-			public void invoke(ObjectInfo object, Image[] icon) throws Exception {
-				icon[0] =
-						SwtResourceManager.decorateImage(icon[0], DOWN_ICON, SwtResourceManager.BOTTOM_RIGHT);
+			public void invoke(ObjectInfo object, ImageDescriptor[] icon) throws Exception {
+				icon[0] = new DecorationOverlayIcon(icon[0], DOWN_ICON, IDecoration.BOTTOM_RIGHT);
 			}
 		});
 		theObject.addBroadcastListener(new ObjectInfoPresentationDecorateText() {
@@ -70,7 +70,7 @@ public class ObjectsLabelProviderTest extends DesignerTestCase {
 			}
 		});
 		// do checks
-		assertNotSame(DEF_ICON, ObjectInfo.getImage(theObject));
+		assertNotSame(DEF_ICON, ObjectInfo.getImageDescriptor(theObject));
 		assertEquals("A: " + DEF_TEXT + " :B", ObjectInfo.getText(theObject));
 	}
 
@@ -84,7 +84,7 @@ public class ObjectsLabelProviderTest extends DesignerTestCase {
 		public IObjectPresentation getPresentation() {
 			return new DefaultObjectPresentation(this) {
 				@Override
-				public Image getIcon() throws Exception {
+				public ImageDescriptor getIcon() throws Exception {
 					return DEF_ICON;
 				}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/databinding/rcp/model/beans/BeanBindableTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/databinding/rcp/model/beans/BeanBindableTest.java
@@ -77,7 +77,7 @@ public class BeanBindableTest extends AbstractBindingTest {
 				FieldBeanBindableInfo.class,
 				"m_shell - Shell|m_shell|org.eclipse.swt.widgets.Shell",
 				observes.get(0));
-		assertSame(shell.getPresentation().getIcon(), ReflectionUtils.getFieldObject(observes.get(0).getPresentation().getImageDescriptor(), "originalImage"));
+		assertSame(ReflectionUtils.getFieldObject(shell.getPresentation().getIcon(), "m_Image"), ReflectionUtils.getFieldObject(observes.get(0).getPresentation().getImageDescriptor(), "m_Image"));
 		//
 		assertBindable(
 				FieldBeanBindableInfo.class,
@@ -338,7 +338,7 @@ public class BeanBindableTest extends AbstractBindingTest {
 				FieldBeanBindableInfo.class,
 				"m_shell - Shell|m_shell|org.eclipse.swt.widgets.Shell",
 				observes.get(0));
-		assertSame(shell.getPresentation().getIcon(), ReflectionUtils.getFieldObject(observes.get(0).getPresentation().getImageDescriptor(), "originalImage"));
+		assertSame(ReflectionUtils.getFieldObject(shell.getPresentation().getIcon(), "m_Image"), ReflectionUtils.getFieldObject(observes.get(0).getPresentation().getImageDescriptor(), "m_Image"));
 		//
 		assertBindable(
 				FieldBeanBindableInfo.class,

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/ActionTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/ActionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -205,7 +205,7 @@ public class ActionTest extends RcpModelTest {
 				ComponentDescriptionHelper.getDescription(
 						m_lastEditor,
 						m_lastLoader.loadClass("org.eclipse.jface.action.Action")).getIcon();
-		assertTrue(UiUtils.equals(genericActionIcon, presentation.getIcon()));
+		assertTrue(UiUtils.equals(ImageDescriptor.createFromImage(genericActionIcon), presentation.getIcon()));
 		// add ResourceManager and set ImageDescriptor
 		{
 			ManagerUtils.ensure_ResourceManager(window);
@@ -213,13 +213,12 @@ public class ActionTest extends RcpModelTest {
 					(ClassInstanceCreation) action.getCreationSupport().getNode();
 			Expression imageDescriptionExpression = (Expression) actionCreation.arguments().get(1);
 			m_lastEditor.replaceExpression(imageDescriptionExpression, ImmutableList.of(
-					"org.eclipse.wb.swt.ResourceManager.getImageDescriptor(",
-					"getClass(),",
-					"\"/icons/full/etool16/delete_edit.gif\")"));
+					"org.eclipse.jface.resource.ImageDescriptor.createFromURL(",
+					"org.eclipse.core.runtime.Platform.getBundle(\"org.eclipse.ui\").getResource(\"/icons/full/etool16/delete_edit.png\"))"));
 		}
 		// now icon is got from ImageDescriptor, well at least not default one
 		window.refresh();
-		assertFalse(UiUtils.equals(genericActionIcon, presentation.getIcon()));
+		assertFalse(UiUtils.equals(ImageDescriptor.createFromImage(genericActionIcon), presentation.getIcon()));
 	}
 
 	/**
@@ -253,7 +252,7 @@ public class ActionTest extends RcpModelTest {
 					ComponentDescriptionHelper.getDescription(
 							m_lastEditor,
 							m_lastLoader.loadClass("org.eclipse.jface.action.Action")).getIcon();
-			assertTrue(UiUtils.equals(genericActionIcon, presentation.getIcon()));
+			assertTrue(UiUtils.equals(ImageDescriptor.createFromImage(genericActionIcon), presentation.getIcon()));
 		}
 		// set CreationSupport with IActionIconProvider
 		final Image expectedImage = DesignerPlugin.getImage("test.png");
@@ -271,7 +270,7 @@ public class ActionTest extends RcpModelTest {
 			action.setCreationSupport(creationSupport);
 		}
 		// now "expectedImage"
-		assertSame(expectedImage, presentation.getIcon());
+		assertSame(expectedImage, ReflectionUtils.getFieldObject(presentation.getIcon(), "m_Image"));
 	}
 
 	/**
@@ -654,7 +653,7 @@ public class ActionTest extends RcpModelTest {
 		{
 			IObjectPresentation actionPresentation = action.getPresentation();
 			IObjectPresentation itemPresentation = contributionItem.getPresentation();
-			assertSame(actionPresentation.getIcon(), itemPresentation.getIcon());
+			assertSame(ReflectionUtils.getFieldObject(actionPresentation.getIcon(), "m_Image"), ReflectionUtils.getFieldObject(itemPresentation.getIcon(), "m_Image"));
 			assertEquals(actionPresentation.getText(), itemPresentation.getText());
 		}
 		// delete "contributionItem"
@@ -793,7 +792,7 @@ public class ActionTest extends RcpModelTest {
 		{
 			IObjectPresentation actionPresentation = action.getPresentation();
 			IObjectPresentation itemPresentation = contributionItem.getPresentation();
-			assertSame(actionPresentation.getIcon(), itemPresentation.getIcon());
+			assertSame(ReflectionUtils.getFieldObject(actionPresentation.getIcon(), "m_Image"), ReflectionUtils.getFieldObject(itemPresentation.getIcon(), "m_Image"));
 			assertEquals("(no variable)", itemPresentation.getText());
 		}
 		// refresh(), check "contributionItem"

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/ControlDecorationTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/ControlDecorationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,8 @@ import org.eclipse.wb.internal.core.EnvironmentUtils;
 import org.eclipse.wb.internal.core.model.presentation.IObjectPresentation;
 import org.eclipse.wb.internal.core.model.property.GenericProperty;
 import org.eclipse.wb.internal.core.model.property.Property;
+import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.core.utils.ui.UiUtils;
 import org.eclipse.wb.internal.rcp.model.jface.ControlDecorationInfo;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
@@ -103,7 +105,7 @@ public class ControlDecorationTest extends RcpModelTest {
 		// check presentation
 		{
 			IObjectPresentation presentation = decoration.getPresentation();
-			assertFalse(UiUtils.equals(presentation.getIcon(), decoration.getDescription().getIcon()));
+			assertFalse(UiUtils.equals(presentation.getIcon(), new ImageImageDescriptor(decoration.getDescription().getIcon())));
 		}
 	}
 
@@ -137,7 +139,7 @@ public class ControlDecorationTest extends RcpModelTest {
 		// check presentation
 		{
 			IObjectPresentation presentation = decoration.getPresentation();
-			assertSame(decoration.getDescription().getIcon(), presentation.getIcon());
+			assertSame(decoration.getDescription().getIcon(), ReflectionUtils.getFieldObject(presentation.getIcon(), "m_Image"));
 		}
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/rcp/ActionFactoryTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/rcp/ActionFactoryTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ import org.eclipse.wb.tests.designer.rcp.RcpModelTest;
 
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jface.action.Action;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.ui.actions.ActionFactory;
 
 /**
@@ -163,9 +163,9 @@ public class ActionFactoryTest extends RcpModelTest {
 		// no "imageDescriptor" property for Action, but presentation still has icon
 		assertNull(ReflectionUtils.invokeMethod(action.getObject(), "getImageDescriptor()"));
 		{
-			Image icon = action.getPresentation().getIcon();
+			ImageDescriptor icon = action.getPresentation().getIcon();
 			assertNotNull(icon);
-			assertTrue(UiUtils.equals(Activator.getImage("info/Action/workbench_action.gif"), icon));
+			assertTrue(UiUtils.equals(Activator.getImageDescriptor("info/Action/workbench_action.gif"), icon));
 		}
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/widgets/ToolBarTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/widgets/ToolBarTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -147,7 +147,7 @@ public class ToolBarTest extends RcpModelTest {
 		ToolItemInfo itemDropDown = toolBar.getItems().get(4);
 		ToolItemInfo itemSeparator = toolBar.getItems().get(5);
 		// check icons
-		assertSame(itemDefault.getPresentation().getIcon(), itemPush.getPresentation().getIcon());
+		assertSame(ReflectionUtils.getFieldObject(itemDefault.getPresentation().getIcon(), "m_Image"), ReflectionUtils.getFieldObject(itemPush.getPresentation().getIcon(), "m_Image"));
 		assertNotSame(itemPush.getPresentation().getIcon(), itemRadio.getPresentation().getIcon());
 		assertNotSame(itemPush.getPresentation().getIcon(), itemCheck.getPresentation().getIcon());
 		assertNotSame(itemRadio.getPresentation().getIcon(), itemCheck.getPresentation().getIcon());

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/bean/ActionTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/bean/ActionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -52,7 +52,7 @@ import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import org.assertj.core.api.Assertions;
 
@@ -1588,8 +1588,8 @@ public class ActionTest extends SwingModelTest {
 		ActionInfo action_1 = ActionContainerInfo.getActions(panel).get(0);
 		ActionInfo action_2 = ActionContainerInfo.getActions(panel).get(1);
 		// action_1 has SMALL_ICON, so has not default icon, as action_2
-		Image icon_1 = action_1.getPresentation().getIcon();
-		Image icon_2 = action_2.getPresentation().getIcon();
+		ImageDescriptor icon_1 = action_1.getPresentation().getIcon();
+		ImageDescriptor icon_2 = action_2.getPresentation().getIcon();
 		assertNotSame(action_1.getDescription().getIcon(), icon_1);
 		assertSame(action_2.getDescription().getIcon(), icon_2);
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/menu/JPopupMenuTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/menu/JPopupMenuTest.java
@@ -103,7 +103,7 @@ public class JPopupMenuTest extends SwingModelTest {
 			IMenuPopupInfo popupObject = MenuObjectInfoUtils.getMenuPopupInfo(popupInfo);
 			assertSame(popupInfo, popupObject.getModel());
 			// presentation
-			assertSame(popupInfo.getDescription().getIcon(), ReflectionUtils.getFieldObject(popupObject.getImageDescriptor(), "originalImage"));
+			assertSame(popupInfo.getDescription().getIcon(), ReflectionUtils.getFieldObject(popupObject.getImageDescriptor(), "m_Image"));
 			assertEquals(new Rectangle(0, 0, 16, 16), popupObject.getBounds());
 			// no policy
 			assertSame(IMenuPolicy.NOOP, popupObject.getPolicy());

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuItemTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuItemTest.java
@@ -18,6 +18,7 @@ import org.eclipse.wb.internal.core.model.menu.MenuObjectInfoUtils;
 import org.eclipse.wb.internal.core.model.property.GenericProperty;
 import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.model.property.event.EventsProperty;
+import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 import org.eclipse.wb.internal.swt.model.widgets.menu.MenuInfo;
 import org.eclipse.wb.internal.swt.model.widgets.menu.MenuItemInfo;
@@ -131,8 +132,8 @@ public class MenuItemTest extends RcpModelTest {
 		MenuItemInfo menuItemSeparator = menuItems.get(4);
 		// test icons
 		assertSame(
-				menuItemDefault.getPresentation().getIcon(),
-				menuItemPush.getPresentation().getIcon());
+				ReflectionUtils.getFieldObject(menuItemDefault.getPresentation().getIcon(), "m_Image"),
+				ReflectionUtils.getFieldObject(menuItemPush.getPresentation().getIcon(), "m_Image"));
 		assertNotSame(
 				menuItemDefault.getPresentation().getIcon(),
 				menuItemCheck.getPresentation().getIcon());

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuTest.java
@@ -270,7 +270,7 @@ public class MenuTest extends RcpModelTest {
 		IMenuPopupInfo popupObject = menuInfo.getAdapter(IMenuPopupInfo.class);
 		assertNotNull(popupObject);
 		assertSame(menuInfo, popupObject.getModel());
-		assertSame(menuInfo.getPresentation().getIcon(), ReflectionUtils.getFieldObject(popupObject.getImageDescriptor(), "originalImage"));
+		assertSame(menuInfo.getPresentation().getIcon(), popupObject.getImageDescriptor());
 		assertEquals(16, popupObject.getBounds().width);
 		assertEquals(16, popupObject.getBounds().height);
 		assertSame(menuObject, popupObject.getMenu());

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/widgets/ButtonsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/widgets/ButtonsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.swt.model.widgets;
 
+import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.swt.model.layout.FillLayoutInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ButtonInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ButtonStylePresentation;
@@ -167,7 +168,7 @@ public class ButtonsTest extends RcpModelTest {
 		ButtonInfo buttonCheck = (ButtonInfo) shell.getChildrenControls().get(2);
 		ButtonInfo buttonRadio = (ButtonInfo) shell.getChildrenControls().get(3);
 		// check icons
-		assertSame(buttonDefault.getPresentation().getIcon(), buttonPush.getPresentation().getIcon());
+		assertSame(ReflectionUtils.getFieldObject(buttonDefault.getPresentation().getIcon(), "m_Image"), ReflectionUtils.getFieldObject(buttonPush.getPresentation().getIcon(), "m_Image"));
 		assertNotSame(buttonPush.getPresentation().getIcon(), buttonRadio.getPresentation().getIcon());
 		assertNotSame(buttonPush.getPresentation().getIcon(), buttonCheck.getPresentation().getIcon());
 		assertNotSame(buttonRadio.getPresentation().getIcon(), buttonCheck.getPresentation().getIcon());

--- a/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/widgets/AbstractPositionInfo.java
+++ b/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/widgets/AbstractPositionInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,7 @@ import org.eclipse.wb.internal.core.model.presentation.DefaultObjectPresentation
 import org.eclipse.wb.internal.core.model.presentation.IObjectPresentation;
 import org.eclipse.wb.internal.rcp.Activator;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * {@link ObjectInfo} that represents empty position in {@link AbstractPositionCompositeInfo}.
@@ -60,8 +60,8 @@ public final class AbstractPositionInfo extends ObjectInfo {
 	public IObjectPresentation getPresentation() {
 		return new DefaultObjectPresentation(this) {
 			@Override
-			public Image getIcon() throws Exception {
-				return Activator.getImage("info/position/element_transparent.png");
+			public ImageDescriptor getIcon() throws Exception {
+				return Activator.getImageDescriptor("info/position/element_transparent.png");
 			}
 
 			public String getText() throws Exception {

--- a/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/widgets/StylePresentation.java
+++ b/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/widgets/StylePresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,8 +13,10 @@ package org.eclipse.wb.internal.xwt.model.widgets;
 import com.google.common.collect.Maps;
 
 import org.eclipse.wb.internal.core.utils.check.Assert;
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.core.xml.model.XmlObjectPresentation;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Widget;
@@ -49,13 +51,13 @@ public abstract class StylePresentation extends XmlObjectPresentation {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getIcon() throws Exception {
+	public ImageDescriptor getIcon() throws Exception {
 		// try to get by style
 		int style = m_widget.getStyle();
 		for (Map.Entry<Integer, Image> entry : getImages().entrySet()) {
 			int keyStyle = entry.getKey();
 			if ((style & keyStyle) == keyStyle) {
-				return entry.getValue();
+				return new ImageImageDescriptor(entry.getValue());
 			}
 		}
 		// use default

--- a/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/widgets/menu/MenuInfo.java
+++ b/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/widgets/menu/MenuInfo.java
@@ -24,6 +24,7 @@ import org.eclipse.wb.internal.core.model.presentation.IObjectPresentation;
 import org.eclipse.wb.internal.core.utils.IAdaptable;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.core.xml.model.EditorContext;
 import org.eclipse.wb.internal.core.xml.model.XmlMenuMenuObject;
 import org.eclipse.wb.internal.core.xml.model.XmlObjectInfo;
@@ -43,7 +44,6 @@ import org.eclipse.wb.internal.xwt.model.widgets.XwtLiveManager;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.widgets.Menu;
 
@@ -272,8 +272,7 @@ public final class MenuInfo extends WidgetInfo implements IAdaptable {
 		//
 		////////////////////////////////////////////////////////////////////////////
 		public ImageDescriptor getImageDescriptor() {
-			Image image = ExecutionUtils.runObjectLog(() -> getPresentation().getIcon(), getDescription().getIcon());
-			return image == null ? null : ImageDescriptor.createFromImage(image);
+			return ExecutionUtils.runObjectLog(() -> getPresentation().getIcon(), new ImageImageDescriptor(getDescription().getIcon()));
 		}
 
 		public Rectangle getBounds() {


### PR DESCRIPTION
Changes the return type of getIcon() from Image to ImageDescriptor.

Where necessary, temporary instances of those images are created on-demand. Already existing images are converted to ImageDescriptors using the ImageImageDescriptor utility class.

Give how closely related those classes are, this change also changes the signature of ObjectInfoPresentationDecorateIcon to use ImageDescriptors as well.