### PR TITLE
IActionIconProvider should use ImageDescriptors instead of Images

### DIFF
--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/ActionInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/ActionInfo.java
@@ -20,7 +20,6 @@ import org.eclipse.wb.internal.core.model.presentation.DefaultJavaInfoPresentati
 import org.eclipse.wb.internal.core.model.presentation.IObjectPresentation;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
-import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.rcp.palette.ActionUseEntryInfo;
 
 import org.eclipse.jface.action.IAction;
@@ -91,7 +90,7 @@ public final class ActionInfo extends JavaInfo {
 			}
 			if (getCreationSupport() instanceof IActionIconProvider) {
 				IActionIconProvider iconProvider = (IActionIconProvider) getCreationSupport();
-				return new ImageImageDescriptor(iconProvider.getActionIcon());
+				return iconProvider.getActionIcon();
 			}
 			return super.getIcon();
 		}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/IActionIconProvider.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/IActionIconProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,7 @@
 package org.eclipse.wb.internal.rcp.model.jface.action;
 
 import org.eclipse.jface.action.Action;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.ui.actions.ActionFactory;
 
 /**
@@ -24,5 +24,5 @@ import org.eclipse.ui.actions.ActionFactory;
  * @coverage rcp.model.jface
  */
 public interface IActionIconProvider {
-	Image getActionIcon();
+	ImageDescriptor getActionIcon();
 }

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/ActionFactoryCreationSupport.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/ActionFactoryCreationSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,7 +29,6 @@ import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.ui.actions.ActionFactory;
 import org.eclipse.ui.actions.ActionFactory.IWorkbenchAction;
@@ -147,10 +146,10 @@ IActionIconProvider {
 	// IActionIconProvider
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public static final Image DEFAULT_ICON = Activator.getImage("info/Action/workbench_action.gif");
+	public static final ImageDescriptor DEFAULT_ICON = Activator.getImageDescriptor("info/Action/workbench_action.gif");
 
 	@Override
-	public Image getActionIcon() {
+	public ImageDescriptor getActionIcon() {
 		return DEFAULT_ICON;
 	}
 

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/ActionFactoryNewEntryInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/ActionFactoryNewEntryInfo.java
@@ -22,7 +22,6 @@ import org.eclipse.wb.internal.rcp.model.jface.action.ActionInfo;
 import org.eclipse.wb.internal.rcp.model.rcp.ActionFactoryCreationSupport;
 
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.actions.ActionFactory;
 import org.eclipse.ui.actions.ActionFactory.IWorkbenchAction;
 
@@ -36,9 +35,9 @@ import java.util.Map;
  * @coverage rcp.editor.palette
  */
 public final class ActionFactoryNewEntryInfo extends ToolEntryInfo {
-	private static final Map<String, Image> m_namedIcons = Maps.newTreeMap();
+	private static final Map<String, ImageDescriptor> m_namedIcons = Maps.newTreeMap();
 	private final String m_name;
-	private final Image m_icon;
+	private final ImageDescriptor m_icon;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -61,10 +60,10 @@ public final class ActionFactoryNewEntryInfo extends ToolEntryInfo {
 			setDescription(action.getDescription());
 			// icon
 			{
-				Image icon = m_namedIcons.get(m_name);
+				ImageDescriptor icon = m_namedIcons.get(m_name);
 				if (icon == null) {
 					if (action.getImageDescriptor() != null) {
-						icon = action.getImageDescriptor().createImage();
+						icon = action.getImageDescriptor();
 					} else {
 						icon = ActionFactoryCreationSupport.DEFAULT_ICON;
 					}
@@ -84,7 +83,7 @@ public final class ActionFactoryNewEntryInfo extends ToolEntryInfo {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public ImageDescriptor getIcon() {
-		return ImageDescriptor.createFromImage(m_icon);
+		return m_icon;
 	}
 
 	@Override

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/ActionTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/ActionTest.java
@@ -255,7 +255,7 @@ public class ActionTest extends RcpModelTest {
 			assertTrue(UiUtils.equals(ImageDescriptor.createFromImage(genericActionIcon), presentation.getIcon()));
 		}
 		// set CreationSupport with IActionIconProvider
-		final Image expectedImage = DesignerPlugin.getImage("test.png");
+		final ImageDescriptor expectedImage = DesignerPlugin.getImageDescriptor("test.png");
 		{
 			CreationSupport creationSupport = new ByteBuddy() //
 					.subclass(CreationSupport.class) //
@@ -270,7 +270,7 @@ public class ActionTest extends RcpModelTest {
 			action.setCreationSupport(creationSupport);
 		}
 		// now "expectedImage"
-		assertSame(expectedImage, ReflectionUtils.getFieldObject(presentation.getIcon(), "m_Image"));
+		assertSame(expectedImage, presentation.getIcon());
 	}
 
 	/**


### PR DESCRIPTION
This stops the unnecessary wrapping from Images using the ImageImageDescriptor.