### PR TITLE
Replace icon wrapping for View/Shortcut info with pure image descriptors

### DIFF
--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/CategoriesAndViewsDialog.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/CategoriesAndViewsDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,6 +26,9 @@ import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.InputDialog;
 import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.resource.LocalResourceManager;
+import org.eclipse.jface.resource.ResourceManager;
 import org.eclipse.jface.viewers.DoubleClickEvent;
 import org.eclipse.jface.viewers.IDoubleClickListener;
 import org.eclipse.jface.viewers.IElementComparer;
@@ -487,6 +490,14 @@ public class CategoriesAndViewsDialog extends ResizableDialog {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	private class ViewsLabelProvider extends LabelProvider {
+		private final ResourceManager m_resourceManager = new LocalResourceManager(JFaceResources.getResources());
+
+		@Override
+		public void dispose() {
+			super.dispose();
+			m_resourceManager.dispose();
+		}
+
 		@Override
 		public String getText(Object element) {
 			if (element == OTHER_CATEGORY) {
@@ -513,7 +524,7 @@ public class CategoriesAndViewsDialog extends ResizableDialog {
 				return DesignerPlugin.getImage("folder_open.gif");
 			}
 			if (pluginElement.getName().equals("view")) {
-				return PdeUtils.getElementIcon(pluginElement, "icon", null);
+				return m_resourceManager.createImageWithDefault(PdeUtils.getElementIcon(pluginElement, "icon", null));
 			}
 			return null;
 		}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/FolderViewInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/FolderViewInfo.java
@@ -19,7 +19,6 @@ import org.eclipse.wb.internal.core.model.presentation.DefaultJavaInfoPresentati
 import org.eclipse.wb.internal.core.model.presentation.IObjectPresentation;
 import org.eclipse.wb.internal.core.model.variable.VoidInvocationVariableSupport;
 import org.eclipse.wb.internal.core.utils.ast.DomGenerics;
-import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.rcp.model.rcp.PdeUtils;
 import org.eclipse.wb.internal.rcp.model.rcp.PdeUtils.ViewInfo;
 import org.eclipse.wb.internal.swt.support.CoordinateUtils;
@@ -116,7 +115,7 @@ public final class FolderViewInfo extends AbstractComponentInfo implements IRend
 	 * @return the icon to show in component tree.
 	 */
 	private ImageDescriptor getPresentationIcon() throws Exception {
-		return new ImageImageDescriptor(getViewInfo().getIcon());
+		return getViewInfo().getIcon();
 	}
 
 	/**
@@ -145,8 +144,12 @@ public final class FolderViewInfo extends AbstractComponentInfo implements IRend
 		CTabFolder folder = m_container.getFolder();
 		Composite viewsComposite = m_container.getViewsComposite();
 		// prepare presentation
-		Image icon = getViewInfo().getIcon();
+		ImageDescriptor iconDescriptor = getViewInfo().getIcon();
+		Image icon = iconDescriptor == null ? null : iconDescriptor.createImage();
 		String name = getViewInfo().getName();
+		if (icon != null) {
+			folder.addDisposeListener(event -> icon.dispose());
+		}
 		// create item for view
 		{
 			CTabItem item = new CTabItem(folder, SWT.CLOSE);

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/PageLayoutAddViewInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/PageLayoutAddViewInfo.java
@@ -19,7 +19,6 @@ import org.eclipse.wb.internal.core.model.property.editor.BooleanPropertyEditor;
 import org.eclipse.wb.internal.core.model.variable.VoidInvocationVariableSupport;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.rcp.model.rcp.PdeUtils;
 import org.eclipse.wb.internal.rcp.model.rcp.PdeUtils.ViewInfo;
 
@@ -219,7 +218,7 @@ public final class PageLayoutAddViewInfo extends AbstractPartInfo {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	protected ImageDescriptor getPresentationIcon() {
-		return new ImageImageDescriptor(getViewInfo().getIcon());
+		return getViewInfo().getIcon();
 	}
 
 	@Override

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/shortcuts/FastViewInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/shortcuts/FastViewInfo.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.rcp.perspective.shortcuts;
 
-import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.rcp.model.rcp.PdeUtils;
 import org.eclipse.wb.internal.rcp.model.rcp.PdeUtils.ViewInfo;
 import org.eclipse.wb.internal.rcp.model.rcp.perspective.PageLayoutInfo;
@@ -44,7 +43,7 @@ public final class FastViewInfo extends AbstractShortcutInfo {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	protected ImageDescriptor getPresentationIcon() throws Exception {
-		return new ImageImageDescriptor(getViewInfo().getIcon());
+		return getViewInfo().getIcon();
 	}
 
 	@Override

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/shortcuts/PerspectiveShortcutInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/shortcuts/PerspectiveShortcutInfo.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.rcp.perspective.shortcuts;
 
-import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.rcp.model.rcp.PdeUtils;
 import org.eclipse.wb.internal.rcp.model.rcp.PdeUtils.PerspectiveInfo;
 import org.eclipse.wb.internal.rcp.model.rcp.perspective.PageLayoutInfo;
@@ -44,7 +43,7 @@ public final class PerspectiveShortcutInfo extends AbstractShortcutInfo {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	protected ImageDescriptor getPresentationIcon() throws Exception {
-		return new ImageImageDescriptor(getPerspectiveInfo().getIcon());
+		return getPerspectiveInfo().getIcon();
 	}
 
 	@Override

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/shortcuts/ViewShortcutInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/shortcuts/ViewShortcutInfo.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.rcp.perspective.shortcuts;
 
-import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.rcp.model.rcp.PdeUtils;
 import org.eclipse.wb.internal.rcp.model.rcp.PdeUtils.ViewInfo;
 import org.eclipse.wb.internal.rcp.model.rcp.perspective.PageLayoutInfo;
@@ -44,7 +43,7 @@ public final class ViewShortcutInfo extends AbstractShortcutInfo {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	protected ImageDescriptor getPresentationIcon() throws Exception {
-		return new ImageImageDescriptor(getViewInfo().getIcon());
+		return getViewInfo().getIcon();
 	}
 
 	@Override

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/PerspectivePerspectiveDropEntryInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/PerspectivePerspectiveDropEntryInfo.java
@@ -47,7 +47,7 @@ public final class PerspectivePerspectiveDropEntryInfo extends ToolEntryInfo {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public ImageDescriptor getIcon() {
-		return ImageDescriptor.createFromImage(m_perspective.getIcon());
+		return m_perspective.getIcon();
 	}
 
 	@Override

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/PerspectiveViewDropEntryInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/PerspectiveViewDropEntryInfo.java
@@ -47,7 +47,7 @@ public final class PerspectiveViewDropEntryInfo extends ToolEntryInfo {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public ImageDescriptor getIcon() {
-		return ImageDescriptor.createFromImage(m_view.getIcon());
+		return m_view.getIcon();
 	}
 
 	@Override

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/rcp/PdeUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/rcp/PdeUtilsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -776,8 +776,8 @@ public class PdeUtilsTest extends AbstractPdeTest {
 		// icon exists and is not default
 		assertNotNull(viewInfo.getIcon());
 		assertNotSame(Activator.getImage("info/perspective/view.gif"), viewInfo.getIcon());
-		assertEquals(10, viewInfo.getIcon().getBounds().width);
-		assertEquals(20, viewInfo.getIcon().getBounds().height);
+		assertEquals(10, viewInfo.getIcon().getImageData(100).width);
+		assertEquals(20, viewInfo.getIcon().getImageData(100).height);
 		// toString()
 		assertEquals("(id_1, C_1, null, name 1)", viewInfo.toString());
 	}


### PR DESCRIPTION
In order to keep the amount of changes per commit as small as possible, we convert Images to ImageDescriptors using the ImageImageDescriptor wrapper.

Instead of using this wrapper, we can use the descriptors directly.