### PR TITLE
Cleanup internal Image wrapping in CreationDescription & friends

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/model/entry/FactoryEntryInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/model/entry/FactoryEntryInfo.java
@@ -26,9 +26,9 @@ import org.eclipse.wb.internal.core.model.description.helpers.FactoryDescription
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.jdt.core.ProjectUtils;
 import org.eclipse.wb.internal.core.utils.state.EditorWarning;
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.swt.graphics.Image;
 
 import org.apache.commons.lang.StringUtils;
 
@@ -41,7 +41,7 @@ import org.apache.commons.lang.StringUtils;
 public abstract class FactoryEntryInfo extends ToolEntryInfo {
 	protected String m_factoryClassName;
 	protected String m_methodSignature;
-	private Image m_icon;
+	private ImageDescriptor m_icon;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -182,7 +182,7 @@ public abstract class FactoryEntryInfo extends ToolEntryInfo {
 			if (m_methodDescription.getIcon() != null) {
 				m_icon = m_methodDescription.getIcon();
 			} else {
-				m_icon = m_presentation.getIcon();
+				m_icon = new ImageImageDescriptor(m_presentation.getIcon());
 			}
 			// update entry name
 			{
@@ -231,7 +231,7 @@ public abstract class FactoryEntryInfo extends ToolEntryInfo {
 
 	@Override
 	public final ImageDescriptor getIcon() {
-		return ImageDescriptor.createFromImage(m_icon);
+		return m_icon;
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/CreationDescription.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/CreationDescription.java
@@ -17,10 +17,8 @@ import com.google.common.collect.Maps;
 import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.core.utils.jdt.core.CodeUtils;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
-import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.swt.graphics.Image;
 
 import org.apache.commons.lang.StringUtils;
 
@@ -73,19 +71,19 @@ public final class CreationDescription extends AbstractDescription {
 	// icon
 	//
 	////////////////////////////////////////////////////////////////////////////
-	private Image m_icon;
+	private ImageDescriptor m_icon;
 
 	/**
 	 * @return the icon of this creation for displaying for user.
 	 */
 	public ImageDescriptor getIcon() {
-		return m_icon != null ? new ImageImageDescriptor(m_icon) : m_componentDescription.getIcon();
+		return m_icon != null ? m_icon : m_componentDescription.getIcon();
 	}
 
 	/**
 	 * Sets the icon of this creation for displaying for user.
 	 */
-	public void setIcon(Image icon) {
+	public void setIcon(ImageDescriptor icon) {
 		m_icon = icon;
 	}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/factory/FactoryMethodDescription.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/factory/FactoryMethodDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,7 @@ import org.eclipse.wb.internal.core.model.description.MethodDescription;
 import org.eclipse.wb.internal.core.utils.StringUtilities;
 
 import org.eclipse.jdt.core.IMethod;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.util.List;
 import java.util.Map;
@@ -87,19 +87,19 @@ public final class FactoryMethodDescription extends MethodDescription {
 	// Icon
 	//
 	////////////////////////////////////////////////////////////////////////////
-	private Image m_icon;
+	private ImageDescriptor m_icon;
 
 	/**
 	 * @return the icon for this factory method.
 	 */
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		return m_icon;
 	}
 
 	/**
 	 * Sets the icon for this factory method.
 	 */
-	public void setIcon(Image icon) {
+	public void setIcon(ImageDescriptor icon) {
 		m_icon = icon;
 	}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/ComponentDescriptionHelper.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/ComponentDescriptionHelper.java
@@ -83,14 +83,12 @@ import org.eclipse.wb.internal.core.utils.reflect.ClassMap;
 import org.eclipse.wb.internal.core.utils.reflect.IntrospectionHelper;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.core.utils.state.EditorState;
-import org.eclipse.wb.internal.core.utils.ui.ImageDisposer;
-import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import org.apache.commons.digester3.AbstractObjectCreationFactory;
 import org.apache.commons.digester3.Digester;
@@ -499,13 +497,9 @@ public final class ComponentDescriptionHelper {
 		if (currentClass != null) {
 			// check current Class
 			if (componentDescription.getIcon() == null) {
-				Image icon = DescriptionHelper.getIconImage(context, currentClass);
+				ImageDescriptor icon = DescriptionHelper.getIcon(context, currentClass);
 				if (icon != null) {
-					componentDescription.setIcon(new ImageImageDescriptor(icon));
-					{
-						String name = componentDescription.getComponentClass().getName();
-						ImageDisposer.add(componentDescription, name, icon);
-					}
+					componentDescription.setIcon(icon);
 					return;
 				}
 			}
@@ -764,7 +758,7 @@ public final class ComponentDescriptionHelper {
 				if (id != null) {
 					Class<?> componentClass = componentDescription.getComponentClass();
 					String suffix = "_" + id;
-					creation.setIcon(DescriptionHelper.getIconImage(context, componentClass, suffix));
+					creation.setIcon(DescriptionHelper.getIcon(context, componentClass, suffix));
 				}
 				// OK, configured creation
 				return creation;

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/ComponentPresentationHelper.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/ComponentPresentationHelper.java
@@ -37,7 +37,6 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.swt.graphics.Image;
 
 import org.apache.commons.io.IOUtils;
 import org.osgi.framework.Bundle;
@@ -136,7 +135,7 @@ public final class ComponentPresentationHelper {
 			String name = parseHelper.getName(componentClassName, creationId);
 			String key = getKey(componentClassName, creationId);
 			String toolkitId = getToolkitId(state, resource);
-			Image icon = getComponentImage(componentClass, creationId, context);
+			ImageDescriptor icon = getComponentImage(componentClass, creationId, context);
 			ComponentPresentation presentation =
 					new ComponentPresentation(key, toolkitId, name, desc, icon);
 			if (shouldCacheFast(resource.getBundle())) {
@@ -160,10 +159,10 @@ public final class ComponentPresentationHelper {
 		return false;
 	}
 
-	private static Image getComponentImage(Class<?> clazz, String creationId, ILoadingContext context)
+	private static ImageDescriptor getComponentImage(Class<?> clazz, String creationId, ILoadingContext context)
 			throws Exception {
 		String iconPath = getImageName(clazz.getName(), creationId);
-		Image image = DescriptionHelper.getIconImage(context, iconPath);
+		ImageDescriptor image = DescriptionHelper.getIcon(context, iconPath);
 		if (image == null) {
 			// no image for this type, use super type
 			return getComponentImage(clazz.getSuperclass(), null/*use default id*/, context);

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/DescriptionHelper.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/DescriptionHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,7 +27,7 @@ import org.eclipse.wb.internal.core.utils.external.ExternalFactoriesHelper;
 import org.eclipse.wb.internal.core.utils.state.EditorState;
 
 import org.eclipse.core.runtime.IConfigurationElement;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import org.apache.commons.lang.StringUtils;
 import org.osgi.framework.Bundle;
@@ -120,11 +120,11 @@ public final class DescriptionHelper {
 	public static final String[] ICON_EXTS = new String[]{".png", ".gif"};
 
 	/**
-	 * @return the icon {@link Image} for given component.
+	 * @return the icon {@link ImageDescriptor} for given component.
 	 */
-	public static Image getIconImage(ILoadingContext context, Class<?> componentClass)
+	public static ImageDescriptor getIcon(ILoadingContext context, Class<?> componentClass)
 			throws Exception {
-		return getIconImage(context, componentClass, StringUtils.EMPTY);
+		return getIcon(context, componentClass, StringUtils.EMPTY);
 	}
 
 	/**
@@ -138,12 +138,12 @@ public final class DescriptionHelper {
 	 *          optional suffix, may be empty, but not <code>null</code>. We use it loading
 	 *          creation-specific icons.
 	 *
-	 * @return the icon {@link Image}, or <code>null</code>.
+	 * @return the icon {@link ImageDescriptor}, or <code>null</code>.
 	 */
-	public static Image getIconImage(ILoadingContext context, Class<?> componentClass, String suffix)
+	public static ImageDescriptor getIcon(ILoadingContext context, Class<?> componentClass, String suffix)
 			throws Exception {
 		String iconPath = componentClass.getName().replace('.', '/') + suffix;
-		return getIconImage(context, iconPath);
+		return getIcon(context, iconPath);
 	}
 
 	/**
@@ -154,19 +154,14 @@ public final class DescriptionHelper {
 	 * @param iconPath
 	 *          the path to icon file, without extension.
 	 *
-	 * @return the icon {@link Image}, or <code>null</code>.
+	 * @return the icon {@link ImageDescriptor}, or <code>null</code>.
 	 */
-	public static Image getIconImage(ILoadingContext context, String iconPath) throws Exception {
+	public static ImageDescriptor getIcon(ILoadingContext context, String iconPath) throws Exception {
 		for (String ext : ICON_EXTS) {
 			String iconName = iconPath + ext;
 			ResourceInfo resourceInfo = getResourceInfo0(context, iconName, true);
 			if (resourceInfo != null) {
-				InputStream stream = resourceInfo.getURL().openStream();
-				try {
-					return new Image(null, stream);
-				} finally {
-					stream.close();
-				}
+				return ImageDescriptor.createFromURL(resourceInfo.getURL());
 			}
 		}
 		// not found

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/FactoryDescriptionHelper.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/FactoryDescriptionHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -32,7 +32,6 @@ import org.eclipse.wb.internal.core.utils.reflect.ClassMap;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.core.utils.state.EditorState;
 import org.eclipse.wb.internal.core.utils.state.EditorWarning;
-import org.eclipse.wb.internal.core.utils.ui.ImageDisposer;
 import org.eclipse.wb.internal.core.utils.xml.parser.QAttribute;
 import org.eclipse.wb.internal.core.utils.xml.parser.QHandlerAdapter;
 import org.eclipse.wb.internal.core.utils.xml.parser.QParser;
@@ -45,7 +44,7 @@ import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import org.apache.commons.digester3.Digester;
 import org.apache.commons.digester3.Rule;
@@ -301,18 +300,13 @@ public class FactoryDescriptionHelper {
 		for (Map.Entry<String, FactoryMethodDescription> entry : signaturesMap.entrySet()) {
 			FactoryMethodDescription description = entry.getValue();
 			// prepare icon
-			Image icon;
+			ImageDescriptor icon;
 			{
 				String signature = entry.getKey();
 				String signatureUnix = StringUtils.replaceChars(signature, "(,)", "___");
 				String iconPath = factoryClassName.replace('.', '/') + "." + signatureUnix;
-				icon = DescriptionHelper.getIconImage(context, iconPath);
+				icon = DescriptionHelper.getIcon(context, iconPath);
 				description.setIcon(icon);
-			}
-			// schedule disposing
-			{
-				String name = description.getDeclaringClass().getName() + "." + description.getSignature();
-				ImageDisposer.add(description, name, icon);
 			}
 		}
 		// remember descriptions in cache

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/presentation/DefaultJavaInfoPresentation.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/presentation/DefaultJavaInfoPresentation.java
@@ -12,10 +12,8 @@ package org.eclipse.wb.internal.core.model.presentation;
 
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.model.creation.factory.AbstractExplicitFactoryCreationSupport;
-import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.swt.graphics.Image;
 
 /**
  * Default {@link IObjectPresentation} for {@link JavaInfo}
@@ -47,9 +45,9 @@ public class DefaultJavaInfoPresentation extends DefaultObjectPresentation {
 		if (m_javaInfo.getCreationSupport() instanceof AbstractExplicitFactoryCreationSupport) {
 			AbstractExplicitFactoryCreationSupport factoryCreationSupport =
 					(AbstractExplicitFactoryCreationSupport) m_javaInfo.getCreationSupport();
-			Image icon = factoryCreationSupport.getDescription().getIcon();
+			ImageDescriptor icon = factoryCreationSupport.getDescription().getIcon();
 			if (icon != null) {
-				return new ImageImageDescriptor(icon);
+				return icon;
 			}
 		}
 		// by default use "component type" specific icon

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/description/ComponentDescription.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/description/ComponentDescription.java
@@ -20,11 +20,9 @@ import org.eclipse.wb.internal.core.model.description.IComponentDescription;
 import org.eclipse.wb.internal.core.model.description.MorphingTargetDescription;
 import org.eclipse.wb.internal.core.model.description.ToolkitDescription;
 import org.eclipse.wb.internal.core.utils.StringUtilities;
-import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.core.xml.model.XmlObjectInfo;
 
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.swt.graphics.Image;
 
 import org.apache.commons.lang.StringUtils;
 
@@ -106,17 +104,17 @@ IComponentDescription {
 	// Icon
 	//
 	////////////////////////////////////////////////////////////////////////////
-	private Image m_icon;
+	private ImageDescriptor m_icon;
 
 	@Override
 	public ImageDescriptor getIcon() {
-		return new ImageImageDescriptor(m_icon);
+		return m_icon;
 	}
 
 	/**
 	 * Sets the icon for this component.
 	 */
-	public void setIcon(Image icon) {
+	public void setIcon(ImageDescriptor icon) {
 		m_icon = icon;
 	}
 

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/description/ComponentDescriptionHelper.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/description/ComponentDescriptionHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,7 +23,6 @@ import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.exception.DesignerException;
 import org.eclipse.wb.internal.core.utils.external.ExternalFactoriesHelper;
 import org.eclipse.wb.internal.core.utils.reflect.ClassMap;
-import org.eclipse.wb.internal.core.utils.ui.ImageDisposer;
 import org.eclipse.wb.internal.core.xml.IExceptionConstants;
 import org.eclipse.wb.internal.core.xml.model.EditorContext;
 import org.eclipse.wb.internal.core.xml.model.description.internal.AbstractConfigurableDescription;
@@ -42,7 +41,7 @@ import org.eclipse.wb.internal.core.xml.model.description.rules.PropertyDefaultR
 import org.eclipse.wb.internal.core.xml.model.description.rules.PropertyEditorRule;
 import org.eclipse.wb.internal.core.xml.model.description.rules.PropertyTagRule;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import org.apache.commons.digester3.AbstractObjectCreationFactory;
 import org.apache.commons.digester3.Digester;
@@ -176,13 +175,9 @@ public final class ComponentDescriptionHelper {
 		if (currentClass != null) {
 			// check current Class
 			if (componentDescription.getIcon() == null) {
-				Image icon = DescriptionHelper.getIconImage(context.getLoadingContext(), currentClass);
+				ImageDescriptor icon = DescriptionHelper.getIcon(context.getLoadingContext(), currentClass);
 				if (icon != null) {
 					componentDescription.setIcon(icon);
-					{
-						String name = componentDescription.getComponentClass().getName();
-						ImageDisposer.add(componentDescription, name, icon);
-					}
 					return;
 				}
 			}
@@ -351,7 +346,7 @@ public final class ComponentDescriptionHelper {
 				if (id != null) {
 					Class<?> componentClass = componentDescription.getComponentClass();
 					String suffix = "_" + id;
-					Image icon = getIcon(context, componentClass, suffix);
+					ImageDescriptor icon = getIcon(context, componentClass, suffix);
 					creation.setIcon(icon);
 				}
 				// OK, configured creation
@@ -400,11 +395,11 @@ public final class ComponentDescriptionHelper {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * @return the {@link Image} which is in same place as icon of component, but
+	 * @return the {@link ImageDescriptor} which is in same place as icon of component, but
 	 *         has "suffix" in name.
 	 */
-	public static Image getIcon(EditorContext context, Class<?> componentClass, String suffix) throws Exception {
+	public static ImageDescriptor getIcon(EditorContext context, Class<?> componentClass, String suffix) throws Exception {
 		ILoadingContext loadingContext = context.getLoadingContext();
-		return DescriptionHelper.getIconImage(loadingContext, componentClass, suffix);
+		return DescriptionHelper.getIcon(loadingContext, componentClass, suffix);
 	}
 }

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/description/ComponentPresentationHelper.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/description/ComponentPresentationHelper.java
@@ -131,7 +131,7 @@ public final class ComponentPresentationHelper {
 			String name = parseHelper.getName(componentClassName, creationId);
 			String key = getKey(componentClassName, creationId);
 			String toolkitId = getToolkitId(context, resource);
-			Image icon = getComponentImage(componentClass, creationId, loadingContext);
+			ImageDescriptor icon = getComponentImage(componentClass, creationId, loadingContext);
 			ComponentPresentation presentation =
 					new ComponentPresentation(key, toolkitId, name, desc, icon);
 			if (shouldCacheFast(resource.getBundle())) {
@@ -155,10 +155,10 @@ public final class ComponentPresentationHelper {
 		return false;
 	}
 
-	private static Image getComponentImage(Class<?> clazz, String creationId, ILoadingContext context)
+	private static ImageDescriptor getComponentImage(Class<?> clazz, String creationId, ILoadingContext context)
 			throws Exception {
 		String iconPath = getImageName(clazz.getName(), creationId);
-		Image image = DescriptionHelper.getIconImage(context, iconPath);
+		ImageDescriptor image = DescriptionHelper.getIcon(context, iconPath);
 		if (image == null) {
 			// no image for this type, use super type
 			return getComponentImage(clazz.getSuperclass(), null/*use default id*/, context);

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/description/CreationDescription.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/description/CreationDescription.java
@@ -15,10 +15,8 @@ import com.google.common.collect.Maps;
 
 import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.core.utils.jdt.core.CodeUtils;
-import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.swt.graphics.Image;
 
 import java.util.Collections;
 import java.util.List;
@@ -65,19 +63,19 @@ public final class CreationDescription extends AbstractDescription {
 	// icon
 	//
 	////////////////////////////////////////////////////////////////////////////
-	private Image m_icon;
+	private ImageDescriptor m_icon;
 
 	/**
 	 * @return the icon of this creation for displaying for user.
 	 */
 	public ImageDescriptor getIcon() {
-		return m_icon != null ? new ImageImageDescriptor(m_icon) : m_componentDescription.getIcon();
+		return m_icon != null ? m_icon : m_componentDescription.getIcon();
 	}
 
 	/**
 	 * Sets the icon of this creation for displaying for user.
 	 */
-	public void setIcon(Image icon) {
+	public void setIcon(ImageDescriptor icon) {
 		m_icon = icon;
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/DefaultJavaInfoPresentationTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/DefaultJavaInfoPresentationTest.java
@@ -13,7 +13,6 @@ package org.eclipse.wb.tests.designer.core.model;
 import org.eclipse.wb.internal.core.model.creation.factory.StaticFactoryCreationSupport;
 import org.eclipse.wb.internal.core.model.presentation.DefaultJavaInfoPresentation;
 import org.eclipse.wb.internal.core.model.presentation.IObjectPresentation;
-import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 import org.eclipse.wb.tests.designer.swing.SwingModelTest;
@@ -88,7 +87,7 @@ public class DefaultJavaInfoPresentationTest extends SwingModelTest {
 		StaticFactoryCreationSupport creationSupport =
 				(StaticFactoryCreationSupport) button.getCreationSupport();
 		IObjectPresentation presentation = button.getPresentation();
-		assertSame(creationSupport.getDescription().getIcon(), ReflectionUtils.getFieldObject(presentation.getIcon(), "m_Image"));
+		assertSame(creationSupport.getDescription().getIcon(), presentation.getIcon());
 		assertEquals("button", presentation.getText());
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/ExposedFieldCreationSupportTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/ExposedFieldCreationSupportTest.java
@@ -501,8 +501,8 @@ public class ExposedFieldCreationSupportTest extends SwingModelTest {
 		assertSame(exposedContainer.getDescription(), innerPanel.getDescription());
 		// ...but their icons are different, because (probably) decorator applied
 		assertSame(
-				ReflectionUtils.getFieldObject(innerPanel.getPresentation().getIcon(), "m_Image"),
-				ReflectionUtils.getFieldObject(ObjectInfo.getImageDescriptor(innerPanel), "m_Image"));
+				innerPanel.getPresentation().getIcon(),
+				ObjectInfo.getImageDescriptor(innerPanel));
 		assertNotSame(
 				exposedContainer.getPresentation().getIcon(),
 				ObjectInfo.getImageDescriptor(exposedContainer));

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/ExposedPropertyCreationSupportTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/ExposedPropertyCreationSupportTest.java
@@ -439,8 +439,8 @@ public class ExposedPropertyCreationSupportTest extends SwingModelTest {
 		assertSame(contentPane.getDescription(), container.getDescription());
 		// ...but their icons are different, because (probably) decorator applied
 		assertSame(
-				ReflectionUtils.getFieldObject(container.getPresentation().getIcon(), "m_Image"),
-				ReflectionUtils.getFieldObject(ObjectInfo.getImageDescriptor(container), "m_Image"));
+				container.getPresentation().getIcon(),
+				ObjectInfo.getImageDescriptor(container));
 		assertNotSame(
 				contentPane.getPresentation().getIcon(),
 				ObjectInfo.getImageDescriptor(contentPane));

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/FactoryDescriptionHelperTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/FactoryDescriptionHelperTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -31,7 +31,7 @@ import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -1017,7 +1017,7 @@ public class FactoryDescriptionHelperTest extends SwingModelTest {
 			assertNull(factoryDescription.getIcon());
 		}
 		// check "createButton(java.lang.String)"
-		Image factoryMethodIcon;
+		ImageDescriptor factoryMethodIcon;
 		{
 			FactoryMethodDescription factoryDescription =
 					getDescription("test.StaticFactory", "createButton(java.lang.String)", true);
@@ -1027,8 +1027,7 @@ public class FactoryDescriptionHelperTest extends SwingModelTest {
 			// icon
 			factoryMethodIcon = factoryDescription.getIcon();
 			assertNotNull(factoryMethodIcon);
-			assertFalse(factoryMethodIcon.isDisposed());
-			assertTrue(UiUtils.equals(factoryMethodIcon, Activator.getImage("test.png")));
+			assertTrue(UiUtils.equals(factoryMethodIcon, Activator.getImageDescriptor("test.png")));
 		}
 		// here we checked for disposing icon, but now it is disposed when description GC'ed, so skip this
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/description/CreationDescriptionTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/description/CreationDescriptionTest.java
@@ -18,7 +18,8 @@ import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.tests.designer.tests.DesignerTestCase;
 
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageData;
+import org.eclipse.swt.graphics.PaletteData;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.MapEntry.entry;
@@ -37,8 +38,10 @@ import javax.swing.JButton;
  * @author scheglov_ke
  */
 public class CreationDescriptionTest extends DesignerTestCase {
-	private static final Image TYPE_ICON = new Image(null, 1, 1);
-	private static final Image CREATION_ICON = new Image(null, 1, 1);
+	private static final ImageDescriptor TYPE_ICON = ImageDescriptor
+			.createFromImageDataProvider(zoom -> new ImageData(1, 1, 32, new PaletteData(0, 0, 0)));
+	private static final ImageDescriptor CREATION_ICON = ImageDescriptor
+			.createFromImageDataProvider(zoom -> new ImageData(1, 1, 32, new PaletteData(0, 0, 0)));
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -111,13 +114,13 @@ public class CreationDescriptionTest extends DesignerTestCase {
 		{
 			component = mock(ComponentDescription.class);
 			when(component.getComponentClass()).thenReturn((Class) JButton.class);
-			when(component.getIcon()).thenReturn(ImageDescriptor.createFromImage(TYPE_ICON));
+			when(component.getIcon()).thenReturn(TYPE_ICON);
 			when(component.getDescription()).thenReturn("type description");
 		}
 		// prepare creation
 		CreationDescription creation = new CreationDescription(component, "myId", "myName");
 		// check icon/description
-		assertSame(TYPE_ICON, ReflectionUtils.getFieldObject(creation.getIcon(), "originalImage"));
+		assertSame(TYPE_ICON, creation.getIcon());
 		assertEquals("type description", creation.getDescription());
 		// check generation
 		assertNull(creation.getSource());
@@ -145,7 +148,7 @@ public class CreationDescriptionTest extends DesignerTestCase {
 		CreationDescription creation = new CreationDescription(component, "myId", "myName");
 		// check icon
 		creation.setIcon(CREATION_ICON);
-		assertSame(CREATION_ICON, ReflectionUtils.getFieldObject(creation.getIcon(), "m_Image"));
+		assertSame(CREATION_ICON, creation.getIcon());
 		// check description
 		creation.setDescription("creation description");
 		assertEquals("creation description", creation.getDescription());

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/EventsPropertyTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/EventsPropertyTest.java
@@ -2184,16 +2184,16 @@ public class EventsPropertyTest extends SwingModelTest implements IPreferenceCon
 				button_1.getPresentation().getIcon(),
 				ObjectInfo.getImageDescriptor(button_1));
 		assertSame(
-				ReflectionUtils.getFieldObject(button_2.getPresentation().getIcon(), "m_Image"),
-				ReflectionUtils.getFieldObject(ObjectInfo.getImageDescriptor(button_2), "m_Image"));
+				button_2.getPresentation().getIcon(),
+				ObjectInfo.getImageDescriptor(button_2));
 		// disable decoration, no decoration expected
 		panel.getDescription().getToolkit().getPreferences().setValue(P_DECORATE_ICON, false);
 		assertSame(
-				ReflectionUtils.getFieldObject(button_1.getPresentation().getIcon(), "m_Image"),
-				ReflectionUtils.getFieldObject(ObjectInfo.getImageDescriptor(button_1), "m_Image"));
+				button_1.getPresentation().getIcon(),
+				ObjectInfo.getImageDescriptor(button_1));
 		assertSame(
-				ReflectionUtils.getFieldObject(button_2.getPresentation().getIcon(), "m_Image"),
-				ReflectionUtils.getFieldObject(ObjectInfo.getImageDescriptor(button_2), "m_Image"));
+				button_2.getPresentation().getIcon(),
+				ObjectInfo.getImageDescriptor(button_2));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/databinding/rcp/model/beans/BeanBindableTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/databinding/rcp/model/beans/BeanBindableTest.java
@@ -13,7 +13,6 @@ package org.eclipse.wb.tests.designer.databinding.rcp.model.beans;
 import org.eclipse.wb.internal.core.databinding.model.IObserveInfo;
 import org.eclipse.wb.internal.core.databinding.model.IObserveInfo.ChildrenContext;
 import org.eclipse.wb.internal.core.databinding.ui.ObserveType;
-import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.rcp.databinding.DatabindingsProvider;
 import org.eclipse.wb.internal.rcp.databinding.model.BindableInfo;
 import org.eclipse.wb.internal.rcp.databinding.model.beans.BeansObserveTypeContainer;
@@ -77,7 +76,7 @@ public class BeanBindableTest extends AbstractBindingTest {
 				FieldBeanBindableInfo.class,
 				"m_shell - Shell|m_shell|org.eclipse.swt.widgets.Shell",
 				observes.get(0));
-		assertSame(ReflectionUtils.getFieldObject(shell.getPresentation().getIcon(), "m_Image"), ReflectionUtils.getFieldObject(observes.get(0).getPresentation().getImageDescriptor(), "m_Image"));
+		assertSame(shell.getPresentation().getIcon(), observes.get(0).getPresentation().getImageDescriptor());
 		//
 		assertBindable(
 				FieldBeanBindableInfo.class,
@@ -338,7 +337,7 @@ public class BeanBindableTest extends AbstractBindingTest {
 				FieldBeanBindableInfo.class,
 				"m_shell - Shell|m_shell|org.eclipse.swt.widgets.Shell",
 				observes.get(0));
-		assertSame(ReflectionUtils.getFieldObject(shell.getPresentation().getIcon(), "m_Image"), ReflectionUtils.getFieldObject(observes.get(0).getPresentation().getImageDescriptor(), "m_Image"));
+		assertSame(shell.getPresentation().getIcon(), observes.get(0).getPresentation().getImageDescriptor());
 		//
 		assertBindable(
 				FieldBeanBindableInfo.class,

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/ActionTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/ActionTest.java
@@ -652,7 +652,7 @@ public class ActionTest extends RcpModelTest {
 		{
 			IObjectPresentation actionPresentation = action.getPresentation();
 			IObjectPresentation itemPresentation = contributionItem.getPresentation();
-			assertSame(ReflectionUtils.getFieldObject(actionPresentation.getIcon(), "m_Image"), ReflectionUtils.getFieldObject(itemPresentation.getIcon(), "m_Image"));
+			assertSame(actionPresentation.getIcon(), itemPresentation.getIcon());
 			assertEquals(actionPresentation.getText(), itemPresentation.getText());
 		}
 		// delete "contributionItem"
@@ -791,7 +791,7 @@ public class ActionTest extends RcpModelTest {
 		{
 			IObjectPresentation actionPresentation = action.getPresentation();
 			IObjectPresentation itemPresentation = contributionItem.getPresentation();
-			assertSame(ReflectionUtils.getFieldObject(actionPresentation.getIcon(), "m_Image"), ReflectionUtils.getFieldObject(itemPresentation.getIcon(), "m_Image"));
+			assertSame(actionPresentation.getIcon(), itemPresentation.getIcon());
 			assertEquals("(no variable)", itemPresentation.getText());
 		}
 		// refresh(), check "contributionItem"

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/widgets/ToolBarTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/widgets/ToolBarTest.java
@@ -147,7 +147,7 @@ public class ToolBarTest extends RcpModelTest {
 		ToolItemInfo itemDropDown = toolBar.getItems().get(4);
 		ToolItemInfo itemSeparator = toolBar.getItems().get(5);
 		// check icons
-		assertSame(ReflectionUtils.getFieldObject(itemDefault.getPresentation().getIcon(), "m_Image"), ReflectionUtils.getFieldObject(itemPush.getPresentation().getIcon(), "m_Image"));
+		assertSame(itemDefault.getPresentation().getIcon(), itemPush.getPresentation().getIcon());
 		assertNotSame(itemPush.getPresentation().getIcon(), itemRadio.getPresentation().getIcon());
 		assertNotSame(itemPush.getPresentation().getIcon(), itemCheck.getPresentation().getIcon());
 		assertNotSame(itemRadio.getPresentation().getIcon(), itemCheck.getPresentation().getIcon());

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuItemTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuItemTest.java
@@ -132,8 +132,8 @@ public class MenuItemTest extends RcpModelTest {
 		MenuItemInfo menuItemSeparator = menuItems.get(4);
 		// test icons
 		assertSame(
-				ReflectionUtils.getFieldObject(menuItemDefault.getPresentation().getIcon(), "m_Image"),
-				ReflectionUtils.getFieldObject(menuItemPush.getPresentation().getIcon(), "m_Image"));
+				menuItemDefault.getPresentation().getIcon(),
+				menuItemPush.getPresentation().getIcon());
 		assertNotSame(
 				menuItemDefault.getPresentation().getIcon(),
 				menuItemCheck.getPresentation().getIcon());

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/widgets/ButtonsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/widgets/ButtonsTest.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.swt.model.widgets;
 
-import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.swt.model.layout.FillLayoutInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ButtonInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ButtonStylePresentation;
@@ -168,7 +167,7 @@ public class ButtonsTest extends RcpModelTest {
 		ButtonInfo buttonCheck = (ButtonInfo) shell.getChildrenControls().get(2);
 		ButtonInfo buttonRadio = (ButtonInfo) shell.getChildrenControls().get(3);
 		// check icons
-		assertSame(ReflectionUtils.getFieldObject(buttonDefault.getPresentation().getIcon(), "m_Image"), ReflectionUtils.getFieldObject(buttonPush.getPresentation().getIcon(), "m_Image"));
+		assertSame(buttonDefault.getPresentation().getIcon(), buttonPush.getPresentation().getIcon());
 		assertNotSame(buttonPush.getPresentation().getIcon(), buttonRadio.getPresentation().getIcon());
 		assertNotSame(buttonPush.getPresentation().getIcon(), buttonCheck.getPresentation().getIcon());
 		assertNotSame(buttonRadio.getPresentation().getIcon(), buttonCheck.getPresentation().getIcon());

--- a/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/layout/AbsoluteLayoutInfo.java
+++ b/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/layout/AbsoluteLayoutInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -72,7 +72,7 @@ IAbsoluteLayoutInfo<ControlInfo> {
 			throws Exception {
 		super(context, new ComponentDescription(null), creationSupport);
 		getDescription().setToolkit(RcpToolkitDescription.INSTANCE);
-		getDescription().setIcon(Activator.getImage("info/layout/absolute/layout.gif"));
+		getDescription().setIcon(Activator.getImageDescriptor("info/layout/absolute/layout.gif"));
 		addSupport_autoSize();
 		addSupport_propertyBounds();
 		addSupport_contextMenu();


### PR DESCRIPTION
Quite often, we still store icons as raw images and then wrap them as ImageDescriptors when needed. Which can be avoid by directly storing them as those descriptors.