### PR TITLE
Cleanup internal Image wrapper in ComponentEntryInfo & friends

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/core/editor/palette/model/entry/ComponentEntryInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/core/editor/palette/model/entry/ComponentEntryInfo.java
@@ -51,7 +51,6 @@ import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.window.Window;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Shell;
 
 import org.apache.commons.lang.StringUtils;
@@ -75,7 +74,7 @@ public final class ComponentEntryInfo extends ToolEntryInfo {
 	private String m_className;
 	private String m_creationId;
 	private String m_enabledScript;
-	private Image m_icon;
+	private ImageDescriptor m_icon;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -88,7 +87,7 @@ public final class ComponentEntryInfo extends ToolEntryInfo {
 	public ComponentEntryInfo(CategoryInfo categoryInfo, IConfigurationElement element)
 			throws Exception {
 		this(categoryInfo, AttributesProviders.get(element));
-		m_icon = ExternalFactoriesHelper.getImage(element, "icon");
+		m_icon = ExternalFactoriesHelper.getImageDescriptor(element, "icon");
 		addLibraries(element);
 	}
 
@@ -313,7 +312,7 @@ public final class ComponentEntryInfo extends ToolEntryInfo {
 		if (m_icon == null) {
 			return DEFAULT_ICON;
 		}
-		return ImageDescriptor.createFromImage(m_icon);
+		return m_icon;
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/model/entry/FactoryEntryInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/model/entry/FactoryEntryInfo.java
@@ -26,7 +26,6 @@ import org.eclipse.wb.internal.core.model.description.helpers.FactoryDescription
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.jdt.core.ProjectUtils;
 import org.eclipse.wb.internal.core.utils.state.EditorWarning;
-import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 
 import org.eclipse.jface.resource.ImageDescriptor;
 
@@ -182,7 +181,7 @@ public abstract class FactoryEntryInfo extends ToolEntryInfo {
 			if (m_methodDescription.getIcon() != null) {
 				m_icon = m_methodDescription.getIcon();
 			} else {
-				m_icon = new ImageImageDescriptor(m_presentation.getIcon());
+				m_icon = m_presentation.getIcon();
 			}
 			// update entry name
 			{

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/MorphingSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/MorphingSupport.java
@@ -36,7 +36,6 @@ import org.eclipse.wb.internal.core.utils.ast.AstNodeUtils;
 import org.eclipse.wb.internal.core.utils.ast.StatementTarget;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.core.utils.state.EditorState;
-import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.dom.ASTNode;
@@ -116,7 +115,7 @@ public abstract class MorphingSupport<T extends JavaInfo> extends AbstractMorphi
 	protected ImageDescriptor getTargetImageDescriptor(MorphingTargetDescription target)
 			throws Exception {
 		ComponentPresentation presentation = getComponentPresentation(target);
-		return new ImageImageDescriptor(presentation.getIcon());
+		return presentation.getIcon();
 	}
 
 	private ComponentPresentation getComponentPresentation(MorphingTargetDescription target)

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/editor/palette/model/ComponentEntryInfo.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/editor/palette/model/ComponentEntryInfo.java
@@ -41,7 +41,6 @@ import org.eclipse.wb.internal.core.xml.model.utils.XmlObjectUtils;
 
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Shell;
 
 import org.apache.commons.lang.StringUtils;
@@ -63,7 +62,7 @@ public final class ComponentEntryInfo extends ToolEntryInfo {
 	private String m_className;
 	private String m_creationId;
 	private String m_enabledScript;
-	private Image m_icon;
+	private ImageDescriptor m_icon;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -76,7 +75,7 @@ public final class ComponentEntryInfo extends ToolEntryInfo {
 	public ComponentEntryInfo(CategoryInfo categoryInfo, IConfigurationElement element)
 			throws Exception {
 		this(categoryInfo, AttributesProviders.get(element));
-		m_icon = ExternalFactoriesHelper.getImage(element, "icon");
+		m_icon = ExternalFactoriesHelper.getImageDescriptor(element, "icon");
 		addLibraries(element);
 	}
 
@@ -301,7 +300,7 @@ public final class ComponentEntryInfo extends ToolEntryInfo {
 		if (m_icon == null) {
 			return DEFAULT_ICON;
 		}
-		return ImageDescriptor.createFromImage(m_icon);
+		return m_icon;
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/utils/MorphingSupport.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/utils/MorphingSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,6 @@ import org.eclipse.wb.internal.core.model.description.ComponentPresentation;
 import org.eclipse.wb.internal.core.model.description.MorphingTargetDescription;
 import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.model.util.AbstractMorphingSupport;
-import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.core.xml.model.EditorContext;
 import org.eclipse.wb.internal.core.xml.model.XmlObjectInfo;
 import org.eclipse.wb.internal.core.xml.model.creation.CreationSupport;
@@ -94,7 +93,7 @@ public abstract class MorphingSupport<T extends XmlObjectInfo> extends AbstractM
 	protected ImageDescriptor getTargetImageDescriptor(MorphingTargetDescription target)
 			throws Exception {
 		ComponentPresentation presentation = getComponentPresentation(target);
-		return new ImageImageDescriptor(presentation.getIcon());
+		return presentation.getIcon();
 	}
 
 	private ComponentPresentation getComponentPresentation(MorphingTargetDescription target)

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/description/ComponentPresentation.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/description/ComponentPresentation.java
@@ -10,8 +10,11 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description;
 
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
+
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageData;
 
 import java.io.ByteArrayInputStream;
 
@@ -27,7 +30,7 @@ public final class ComponentPresentation {
 	private final String m_name;
 	private final String m_description;
 	private byte[] m_iconBytes;
-	private Image m_icon;
+	private ImageDescriptor m_icon;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -46,20 +49,20 @@ public final class ComponentPresentation {
 		m_iconBytes = iconBytes;
 	}
 
-	public ComponentPresentation(String key,
-			String toolkitId,
-			String name,
-			String description,
-			ImageDescriptor icon) {
-		this(key, toolkitId, name, description, icon == null ? null : icon.createImage());
-	}
-
 	@Deprecated
 	public ComponentPresentation(String key,
 			String toolkitId,
 			String name,
 			String description,
 			Image icon) {
+		this(key, toolkitId, name, description, new ImageImageDescriptor(icon));
+	}
+
+	public ComponentPresentation(String key,
+			String toolkitId,
+			String name,
+			String description,
+			ImageDescriptor icon) {
 		m_key = key;
 		m_toolkitId = toolkitId;
 		m_name = name;
@@ -88,10 +91,11 @@ public final class ComponentPresentation {
 		return m_description;
 	}
 
-	public Image getIcon() {
+	public ImageDescriptor getIcon() {
 		if (m_icon == null) {
 			if (m_iconBytes != null) {
-				m_icon = new Image(null, new ByteArrayInputStream(m_iconBytes));
+				ImageData imageData = new ImageData(new ByteArrayInputStream(m_iconBytes));
+				m_icon = ImageDescriptor.createFromImageDataProvider(zoom -> zoom == 100 ? imageData : null);
 			}
 		}
 		return m_icon;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/external/ExternalFactoriesHelper.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/external/ExternalFactoriesHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,7 +23,6 @@ import org.eclipse.core.runtime.IExtensionPoint;
 import org.eclipse.core.runtime.IRegistryChangeListener;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.swt.graphics.Image;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.ObjectUtils;
@@ -373,19 +372,6 @@ public class ExternalFactoriesHelper {
 	// Images access
 	//
 	////////////////////////////////////////////////////////////////////////////
-	/**
-	 * @return the {@link Image} from extension {@link Bundle} with path in given
-	 *         attribute. May be <code>null</code> if no value for attribute.
-	 */
-	public static Image getImage(IConfigurationElement element, String attribute) {
-		String path = element.getAttribute(attribute);
-		if (path != null) {
-			Bundle bundle = getExtensionBundle(element);
-			BundleResourceProvider resourceProvider = BundleResourceProvider.get(bundle);
-			return resourceProvider.getImage(path);
-		}
-		return null;
-	}
 
 	/**
 	 * @return the {@link getImageDescriptor} from extension {@link Bundle} with

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/ui/ImageUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/ui/ImageUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@ package org.eclipse.wb.internal.core.utils.ui;
 
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
@@ -41,10 +42,26 @@ import javax.imageio.ImageIO;
 public final class ImageUtils {
 	/**
 	 * @return the PNG bytes of SWT {@link Image}.
+	 * @deprecated Use {@link #getBytesPNG(ImageDescriptor)} instead.
 	 */
+	@Deprecated
 	public static byte[] getBytesPNG(Image image) throws IOException {
+		return getBytesPNG(image.getImageData());
+	}
+
+	/**
+	 * @return the PNG bytes of SWT {@link ImageDescriptor}.
+	 */
+	public static byte[] getBytesPNG(ImageDescriptor image) throws IOException {
+		return getBytesPNG(image.getImageData(100));
+	}
+
+	/**
+	 * @return the PNG bytes of SWT {@link ImageData}.
+	 */
+	private static byte[] getBytesPNG(ImageData imageData) throws IOException {
 		ImageLoader imageLoader = new ImageLoader();
-		imageLoader.data = new ImageData[]{image.getImageData()};
+		imageLoader.data = new ImageData[] { imageData };
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		imageLoader.save(baos, SWT.IMAGE_PNG);
 		return baos.toByteArray();

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/palette/ComponentEntryInfoTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/palette/ComponentEntryInfoTest.java
@@ -896,10 +896,10 @@ public class ComponentEntryInfoTest extends AbstractPaletteTest {
 				assertEquals(
 						"test1 test2 <p attr=\"val\">test3</p> test4 test5",
 						presentation.getDescription());
-				Image icon = presentation.getIcon();
+				ImageDescriptor icon = presentation.getIcon();
 				assertNotNull(icon);
-				assertEquals(image.getBounds().width, 11);
-				assertEquals(image.getBounds().height, 29);
+				assertEquals(icon.getImageData(100).width, 11);
+				assertEquals(icon.getImageData(100).height, 29);
 			} finally {
 				testBundle.uninstall();
 			}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/palette/ComponentEntryInfoTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/palette/ComponentEntryInfoTest.java
@@ -1035,10 +1035,10 @@ public class ComponentEntryInfoTest extends AbstractPaletteTest {
 				assertEquals(
 						"test1 test2 <p attr=\"val\">test3</p> test4 test5",
 						presentation.getDescription());
-				Image icon = presentation.getIcon();
+				ImageDescriptor icon = presentation.getIcon();
 				assertNotNull(icon);
-				assertEquals(image.getBounds().width, 11);
-				assertEquals(image.getBounds().height, 29);
+				assertEquals(icon.getImageData(100).width, 11);
+				assertEquals(icon.getImageData(100).height, 29);
 			} finally {
 				testBundle.uninstall();
 			}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/ExternalFactoriesHelperTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/ExternalFactoriesHelperTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -424,54 +424,6 @@ public class ExternalFactoriesHelperTest extends DesignerTestCase {
 			ExternalFactoriesHelper.getRequiredBundle(id);
 		} catch (IllegalArgumentException e) {
 			assertThat(e.getMessage()).contains(id);
-		}
-	}
-
-	////////////////////////////////////////////////////////////////////////////
-	//
-	// getImage()
-	//
-	////////////////////////////////////////////////////////////////////////////
-	/**
-	 * Test for {@link ExternalFactoriesHelper#getImage(IConfigurationElement, String)}.
-	 */
-	public void test_getImage_noSuchAttribute() throws Exception {
-		TestBundle testBundle = new TestBundle();
-		try {
-			testBundle.addExtension(POINT_ID, "<testObject/>");
-			testBundle.install();
-			// work with Bundle
-			{
-				IConfigurationElement element =
-						ExternalFactoriesHelper.getElements(POINT_ID, "testObject").get(0);
-				Image image = ExternalFactoriesHelper.getImage(element, "noAttribute");
-				assertNull(image);
-			}
-		} finally {
-			testBundle.dispose();
-		}
-	}
-
-	/**
-	 * Test for {@link ExternalFactoriesHelper#getImage(IConfigurationElement, String)}.
-	 */
-	public void test_getImage_success() throws Exception {
-		TestBundle testBundle = new TestBundle();
-		try {
-			testBundle.addExtension(POINT_ID, "<testObject icon='icons/test.png'/>");
-			testBundle.setFile("icons/test.png", TestUtils.createImagePNG(1, 2));
-			testBundle.install();
-			// work with Bundle
-			{
-				IConfigurationElement element =
-						ExternalFactoriesHelper.getElements(POINT_ID, "testObject").get(0);
-				Image image = ExternalFactoriesHelper.getImage(element, "icon");
-				assertNotNull(image);
-				assertEquals(1, image.getBounds().width);
-				assertEquals(2, image.getBounds().height);
-			}
-		} finally {
-			testBundle.dispose();
 		}
 	}
 


### PR DESCRIPTION
The getImage() method in ExternalFactoriesHelper is no longer used. Instead, we use the logically identical getImageDescriptor().