### PR TITLE
Cleanup tear-down methods to stabilize test cases

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/AbstractJavaProjectTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/AbstractJavaProjectTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -148,7 +148,6 @@ public abstract class AbstractJavaProjectTest extends DesignerTestCase {
 		if (m_testProject == null) {
 			m_testProject = new TestProject();
 			m_project = m_testProject.getProject();
-			m_project.refreshLocal(IResource.DEPTH_INFINITE, null);
 			m_javaProject = m_testProject.getJavaProject();
 		}
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/DesignerEditorTestCase.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/DesignerEditorTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -86,18 +86,21 @@ public abstract class DesignerEditorTestCase extends AbstractJavaInfoRelatedTest
 	@Override
 	@After
 	public void tearDown() throws Exception {
-		System.clearProperty(DesignerPalette.FLAG_NO_PALETTE);
-		waitEventLoop(0);
-		TestUtils.closeAllEditors();
-		waitEventLoop(0);
-		// check for exceptions
-		{
-			removeExceptionsListener();
-			assertNoLoggedExceptions();
+		try {
+			System.clearProperty(DesignerPalette.FLAG_NO_PALETTE);
+			waitEventLoop(0);
+			TestUtils.closeAllEditors();
+			waitEventLoop(0);
+			// check for exceptions
+			{
+				removeExceptionsListener();
+				assertNoLoggedExceptions();
+			}
+		} finally {
+			// continue
+			waitEventLoop(0);
+			super.tearDown();
 		}
-		// continue
-		waitEventLoop(0);
-		super.tearDown();
 	}
 
 	////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The refresh call was added as part of the JUnit4 migration in an attempt
to stabilize some of the failing test cases. In return, this seems to
have destabilized previously stable tests, instead.
We also need to ensure that resources are ALWAYS deleted once a test
finishes, even if the test itself has failed. Otherwise those files may
leak into the next test.