### PR TITLE
Adjust wait time for event loop to stabilize unit test

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/forms/table/TableWrapLayoutGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/forms/table/TableWrapLayoutGefTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -80,7 +80,7 @@ public class TableWrapLayoutGefTest extends RcpGefTest {
 		ControlInfo button = composite.getChildrenControls().get(1);
 		// select "button"
 		canvas.select(button);
-		waitEventLoop(0);
+		waitEventLoop(10);
 		// delete
 		{
 			IAction deleteAction = getDeleteAction();

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/layouts/grid/GridLayoutGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/layouts/grid/GridLayoutGefTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -100,7 +100,7 @@ public class GridLayoutGefTest extends RcpGefTest {
 		ControlInfo button = getJavaInfoByName("button");
 		// select "button"
 		canvas.select(button);
-		waitEventLoop(0);
+		waitEventLoop(10);
 		// delete
 		{
 			IAction deleteAction = getDeleteAction();


### PR DESCRIPTION
The wait time for one of the TableWrapLayoutGefTest has been increased to 10ms, in order to ensure that the internal state of the properties table has been updated by the time the component is deleted.

Given that all of those operations normally happen synchronously, this shouldn't be a problem during normal usage, but something that only happens during tests, because they also run in the UI thread and thus SWT updates are only executed when explicitly requested.

To summarize the problem: The button was deleted from the data model, but not from the table. When the table was redrawn, it tried to load the button properties from the model and failed, because nothing was found.