### PR TITLE
Remove internal usage of the SwtResourceManager

### DIFF
--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/ObserveElementsWizardPage.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/ObserveElementsWizardPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,6 +20,7 @@ import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
 
+import org.eclipse.jface.resource.FontDescriptor;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
@@ -96,7 +97,9 @@ public class ObserveElementsWizardPage extends WizardPage {
 		// create value bold label
 		Label valueLabel = new Label(titleComposite, SWT.NONE);
 		GridDataFactory.create(valueLabel).fillH().grabH();
-		UiUtils.setBoldFont(valueLabel);
+		valueLabel.setFont(FontDescriptor.createFrom(valueLabel.getFont()) //
+				.setStyle(SWT.BOLD) //
+				.createFont(null));
 		valueLabel.setText(ExecutionUtils.runObjectLog(new RunnableObjectEx<String>() {
 			@Override
 			public String runObject() throws Exception {

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/UiUtils.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/UiUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,6 @@ package org.eclipse.wb.internal.core.databinding.ui;
 import org.eclipse.wb.internal.core.databinding.Messages;
 import org.eclipse.wb.internal.core.databinding.model.IObserveInfo;
 import org.eclipse.wb.internal.core.utils.check.Assert;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.IJavaElement;
@@ -31,7 +30,6 @@ import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.SashForm;
 import org.eclipse.swt.widgets.Event;
-import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Table;
@@ -122,18 +120,6 @@ public final class UiUtils {
 		Assert.isLegal(weights.length == 2);
 		settings.put(key + ".x", weights[0]);
 		settings.put(key + ".y", weights[1]);
-	}
-
-	////////////////////////////////////////////////////////////////////////////
-	//
-	// Label
-	//
-	////////////////////////////////////////////////////////////////////////////
-	/**
-	 * Sets to label bold version of it font.
-	 */
-	public static void setBoldFont(Label label) {
-		label.setFont(SwtResourceManager.getBoldFont(label.getFont()));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/editor/contentproviders/LabelUiContentProvider.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/editor/contentproviders/LabelUiContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,10 +10,10 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.databinding.ui.editor.contentproviders;
 
-import org.eclipse.wb.internal.core.databinding.ui.UiUtils;
 import org.eclipse.wb.internal.core.databinding.ui.editor.UiContentProviderAdapter;
 import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 
+import org.eclipse.jface.resource.FontDescriptor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
@@ -59,7 +59,9 @@ public final class LabelUiContentProvider extends UiContentProviderAdapter {
 		// create value bold label
 		Label valueLabel = new Label(parent, SWT.NONE);
 		GridDataFactory.create(valueLabel).fillH().grabH().spanH(columns - 1);
-		UiUtils.setBoldFont(valueLabel);
+		valueLabel.setFont(FontDescriptor.createFrom(valueLabel.getFont()) //
+				.setStyle(SWT.BOLD) //
+				.createFont(null));
 		valueLabel.setText(m_value);
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/errors/MultipleConstructorsComposite.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/errors/MultipleConstructorsComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,13 +26,13 @@ import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 import org.eclipse.wb.internal.core.utils.jdt.core.CodeUtils;
 import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.ui.JavaElementLabelProvider;
+import org.eclipse.jface.resource.FontDescriptor;
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.DoubleClickEvent;
 import org.eclipse.jface.viewers.IDoubleClickListener;
@@ -74,14 +74,14 @@ public final class MultipleConstructorsComposite extends Composite {
 			GridLayoutFactory.create(titleComposite).columns(2).margins(10);
 			{
 				Label label = new Label(titleComposite, SWT.NONE);
-				label.setImage(SwtResourceManager.getImage(SWT.ICON_INFORMATION));
+				label.setImage(parent.getDisplay().getSystemImage(SWT.ICON_INFORMATION));
 			}
 			{
 				m_titleLabel = new Label(titleComposite, SWT.NONE);
-				m_titleLabel.setFont(SwtResourceManager.getFont(
-						getFont().getFontData()[0].getName(),
-						14,
-						SWT.BOLD));
+				m_titleLabel.setFont(FontDescriptor.createFrom(getFont()) //
+						.setHeight(14) //
+						.setStyle(SWT.BOLD) //
+						.createFont(null));
 			}
 		}
 		// Browser

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/errors/NoEntryPointComposite.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/errors/NoEntryPointComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,13 +28,13 @@ import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 import org.eclipse.wb.internal.core.utils.jdt.core.CodeUtils;
 import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.ui.JavaElementLabelProvider;
+import org.eclipse.jface.resource.FontDescriptor;
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.DoubleClickEvent;
 import org.eclipse.jface.viewers.IDoubleClickListener;
@@ -78,14 +78,14 @@ public final class NoEntryPointComposite extends Composite {
 			GridLayoutFactory.create(titleComposite).columns(2).margins(10);
 			{
 				Label label = new Label(titleComposite, SWT.NONE);
-				label.setImage(SwtResourceManager.getImage(SWT.ICON_INFORMATION));
+				label.setImage(parent.getDisplay().getSystemImage(SWT.ICON_INFORMATION));
 			}
 			{
 				m_titleLabel = new Label(titleComposite, SWT.NONE);
-				m_titleLabel.setFont(SwtResourceManager.getFont(
-						getFont().getFontData()[0].getName(),
-						14,
-						SWT.BOLD));
+				m_titleLabel.setFont(FontDescriptor.createFrom(getFont()) //
+						.setHeight(14) //
+						.setStyle(SWT.BOLD) //
+						.createFont(null));
 			}
 		}
 		// Browser

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/multi/VisitedLinesHighlighter.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/multi/VisitedLinesHighlighter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,7 +20,6 @@ import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.preferences.IPreferenceConstants;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jface.preference.IPreferenceStore;
@@ -101,7 +100,7 @@ public class VisitedLinesHighlighter implements IPainter, LineBackgroundListener
 		m_shouldHighlight = preferences.getBoolean(IPreferenceConstants.P_HIGHLIGHT_VISITED);
 		RGB rgb =
 				PreferenceConverter.getColor(preferences, IPreferenceConstants.P_HIGHLIGHT_VISITED_COLOR);
-		m_color = SwtResourceManager.getColor(rgb);
+		m_color = new Color(rgb);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/hierarchy/ComponentClassPropertyEditor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/hierarchy/ComponentClassPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,12 +18,12 @@ import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.model.property.editor.TextDisplayPropertyEditor;
 import org.eclipse.wb.internal.core.model.property.table.IPropertyTooltipSite;
 import org.eclipse.wb.internal.core.model.property.table.PropertyTooltipProvider;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.ui.ISharedImages;
 import org.eclipse.jdt.ui.JavaUI;
+import org.eclipse.jface.resource.FontDescriptor;
 import org.eclipse.jface.viewers.DoubleClickEvent;
 import org.eclipse.jface.viewers.IDoubleClickListener;
 import org.eclipse.jface.viewers.IFontProvider;
@@ -221,7 +221,7 @@ public final class ComponentClassPropertyEditor extends TextDisplayPropertyEdito
 	//
 	////////////////////////////////////////////////////////////////////////////
 	private class ComponentClassLabelProvider extends LabelProvider implements IFontProvider {
-		private final Tree m_tree;
+		private final Font m_treeFont;
 
 		////////////////////////////////////////////////////////////////////////////
 		//
@@ -229,7 +229,9 @@ public final class ComponentClassPropertyEditor extends TextDisplayPropertyEdito
 		//
 		////////////////////////////////////////////////////////////////////////////
 		public ComponentClassLabelProvider(final Tree tree) {
-			m_tree = tree;
+			m_treeFont = FontDescriptor.createFrom(tree.getFont())
+					.setStyle(SWT.BOLD)
+					.createFont(null);
 		}
 
 		////////////////////////////////////////////////////////////////////////////
@@ -257,7 +259,7 @@ public final class ComponentClassPropertyEditor extends TextDisplayPropertyEdito
 		public Font getFont(Object element) {
 			Class<?> clazz = (Class<?>) element;
 			if (clazz == m_componentClass) {
-				return SwtResourceManager.getBoldFont(m_tree.getFont());
+				return m_treeFont;
 			}
 			return null;
 		}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/live/AbstractLiveManager.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/live/AbstractLiveManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,11 +33,11 @@ import org.eclipse.wb.internal.core.utils.exception.DesignerExceptionUtils;
 import org.eclipse.wb.internal.core.utils.state.EditorState;
 import org.eclipse.wb.internal.core.utils.state.GlobalState;
 import org.eclipse.wb.internal.core.utils.ui.DrawUtils;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 
@@ -203,7 +203,7 @@ public abstract class AbstractLiveManager {
 		Image image = new Image(null, width, height);
 		GC gc = new GC(image);
 		try {
-			gc.setBackground(SwtResourceManager.getColor(255, 220, 220));
+			gc.setBackground(new Color(255, 220, 220));
 			gc.fillRectangle(0, 0, width, height);
 			String text = ModelMessages.AbstractLiveManager_errorMessage;
 			DrawUtils.drawTextWrap(gc, text, 0, 0, width, height);

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/utils/AbstractLiveManager.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/utils/AbstractLiveManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,13 +21,13 @@ import org.eclipse.wb.internal.core.utils.reflect.ClassMap;
 import org.eclipse.wb.internal.core.utils.state.EditorState;
 import org.eclipse.wb.internal.core.utils.state.GlobalState;
 import org.eclipse.wb.internal.core.utils.ui.DrawUtils;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 import org.eclipse.wb.internal.core.xml.Messages;
 import org.eclipse.wb.internal.core.xml.model.AbstractComponentInfo;
 import org.eclipse.wb.internal.core.xml.model.EditorContext;
 import org.eclipse.wb.internal.core.xml.model.XmlObjectInfo;
 
 import org.eclipse.jdt.core.dom.Statement;
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 
@@ -157,7 +157,7 @@ public abstract class AbstractLiveManager {
 		Image image = new Image(null, width, height);
 		GC gc = new GC(image);
 		try {
-			gc.setBackground(SwtResourceManager.getColor(255, 220, 220));
+			gc.setBackground(new Color(255, 220, 220));
 			gc.fillRectangle(0, 0, width, height);
 			String text = Messages.AbstractLiveManager_errorMessage;
 			DrawUtils.drawTextWrap(gc, text, 0, 0, width, height);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/JustifyPaletteTooltipProvider.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/JustifyPaletteTooltipProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,6 @@ package org.eclipse.wb.core.controls.palette;
 
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.border.MarginBorder;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 import org.eclipse.wb.internal.draw2d.CustomTooltipProvider;
 import org.eclipse.wb.internal.draw2d.JustifyLabel;
 import org.eclipse.wb.internal.draw2d.Label;
@@ -20,6 +19,8 @@ import org.eclipse.wb.internal.draw2d.Label;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.jface.resource.FontDescriptor;
+import org.eclipse.swt.SWT;
 
 /**
  * Standard palette tooltip: bold header and multi line details.
@@ -52,7 +53,9 @@ public final class JustifyPaletteTooltipProvider extends CustomTooltipProvider {
 	protected Figure createTooltipFigure(Figure hostFigure) {
 		// header figure
 		Label headerFigure = new Label(m_header);
-		headerFigure.setFont(SwtResourceManager.getBoldFont(headerFigure.getFont()));
+		headerFigure.setFont(FontDescriptor.createFrom(headerFigure.getFont()) //
+				.setStyle(SWT.BOLD) //
+				.createFont(null));
 		// details figure
 		JustifyLabel detailsFigure = new JustifyLabel();
 		detailsFigure.setBorder(new MarginBorder(new Insets(0, 2, 2, 2)));

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/grid/AbstractGridLayoutEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/grid/AbstractGridLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,7 +29,6 @@ import org.eclipse.wb.gef.core.requests.IDropRequest;
 import org.eclipse.wb.gef.core.requests.Request;
 import org.eclipse.wb.gef.graphical.policies.LayoutEditPolicy;
 import org.eclipse.wb.internal.core.DesignerPlugin;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 import org.eclipse.wb.internal.draw2d.SemiTransparentFigure;
 
 import org.eclipse.draw2d.geometry.Point;
@@ -114,10 +113,10 @@ IHeadersProvider {
 	protected GridTarget m_target;
 	private final Figure m_targetFeedback = new SemiTransparentFigure(64);
 	private TextFeedback m_textFeedback;
-	private static final Color m_goodTargetFillColor = SwtResourceManager.getColor(0, 255, 0);
-	private static final Color m_goodTargetBorderColor = SwtResourceManager.getColor(192, 255, 192);
-	private static final Color m_badTargetFillColor = SwtResourceManager.getColor(255, 0, 0);
-	private static final Color m_badTargetBorderColor = SwtResourceManager.getColor(255, 192, 192);
+	private static final Color m_goodTargetFillColor = new Color(0, 255, 0);
+	private static final Color m_goodTargetBorderColor = new Color(192, 255, 192);
+	private static final Color m_badTargetFillColor = new Color(255, 0, 0);
+	private static final Color m_badTargetBorderColor = new Color(255, 192, 192);
 
 	@Override
 	protected final void showLayoutTargetFeedback(Request request) {

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/selection/TopResizeFigure.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/selection/TopResizeFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,15 +12,14 @@ package org.eclipse.wb.core.gef.policy.selection;
 
 import org.eclipse.wb.draw2d.IColorConstants;
 import org.eclipse.wb.draw2d.border.LineBorder;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 import org.eclipse.wb.internal.draw2d.SemiTransparentFigure;
 
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.TextUtilities;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.jface.resource.FontDescriptor;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Font;
 
 import org.apache.commons.lang.StringUtils;
 
@@ -63,8 +62,10 @@ public class TopResizeFigure extends SemiTransparentFigure {
 		super.paintClientArea(graphics);
 		if (!StringUtils.isEmpty(m_sizeText)) {
 			Rectangle area = getClientArea();
-			Font font = SwtResourceManager.getFont("Arial", 16, SWT.NONE);
-			graphics.setFont(font);
+			graphics.setFont(FontDescriptor.createFrom(graphics.getFont()) //
+					.setHeight(16) //
+					.setStyle(SWT.NONE) //
+					.createFont(null));
 			Dimension textExtent = TextUtilities.INSTANCE.getTextExtents(m_sizeText, graphics.getFont());
 			int x = area.x + (area.width - textExtent.width) / 2;
 			int y = area.y + (area.height - textExtent.height) / 2;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/errors/ExceptionComposite.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/errors/ExceptionComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,7 +23,6 @@ import org.eclipse.wb.internal.core.editor.errors.report2.ZipFileErrorReport;
 import org.eclipse.wb.internal.core.utils.exception.DesignerExceptionUtils;
 import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.swt.SWT;
@@ -73,7 +72,7 @@ public abstract class ExceptionComposite extends Composite {
 			{
 				Label label = new Label(titleComposite, SWT.NONE);
 				GridDataFactory.create(label).alignVM();
-				label.setImage(SwtResourceManager.getImage(SWT.ICON_ERROR));
+				label.setImage(parent.getDisplay().getSystemImage(SWT.ICON_ERROR));
 			}
 			{
 				Link label = new Link(titleComposite, SWT.WRAP | SWT.NO_FOCUS);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/errors/WarningComposite.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/errors/WarningComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,9 +19,9 @@ import org.eclipse.wb.internal.core.editor.Messages;
 import org.eclipse.wb.internal.core.utils.exception.DesignerExceptionUtils;
 import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 
 import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.jface.resource.FontDescriptor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
@@ -62,12 +62,14 @@ public abstract class WarningComposite extends Composite {
 			GridLayoutFactory.create(titleComposite).columns(2).margins(10);
 			{
 				Label label = new Label(titleComposite, SWT.NONE);
-				label.setImage(SwtResourceManager.getImage(SWT.ICON_WARNING));
+				label.setImage(parent.getDisplay().getSystemImage(SWT.ICON_WARNING));
 			}
 			{
 				m_titleLabel = new Label(titleComposite, SWT.NONE);
-				m_titleLabel.setFont(
-						SwtResourceManager.getFont(getFont().getFontData()[0].getName(), 14, SWT.BOLD));
+				m_titleLabel.setFont(FontDescriptor.createFrom(getFont()) //
+						.setHeight(14) //
+						.setStyle(SWT.BOLD) //
+						.createFont(null));
 			}
 		}
 		{

--- a/org.eclipse.wb.rcp.databinding.emf/src/org/eclipse/wb/internal/rcp/databinding/emf/model/bindables/EObjectBindableInfo.java
+++ b/org.eclipse.wb.rcp.databinding.emf/src/org/eclipse/wb/internal/rcp/databinding/emf/model/bindables/EObjectBindableInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,6 @@ import org.eclipse.wb.internal.core.databinding.model.reference.FragmentReferenc
 import org.eclipse.wb.internal.core.databinding.parser.IModelResolver;
 import org.eclipse.wb.internal.core.databinding.ui.ObserveType;
 import org.eclipse.wb.internal.core.databinding.utils.CoreUtils;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 import org.eclipse.wb.internal.rcp.databinding.emf.model.EmfObserveTypeContainer;
 import org.eclipse.wb.internal.rcp.databinding.emf.model.bindables.PropertiesSupport.PropertyInfo;
 import org.eclipse.wb.internal.rcp.databinding.model.BindableInfo;
@@ -26,6 +25,7 @@ import org.eclipse.wb.internal.rcp.databinding.model.beans.direct.DirectFieldMod
 import org.eclipse.wb.internal.rcp.databinding.model.beans.direct.DirectObservableInfo;
 
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.eclipse.jface.viewers.IDecoration;
 
 import org.apache.commons.lang.StringUtils;
 
@@ -54,7 +54,7 @@ public final class EObjectBindableInfo extends BindableInfo {
 			PropertiesSupport propertiesSupport,
 			IModelResolver resolver) throws Exception {
 		super(objectType, new FragmentReferenceProvider(fragment));
-		setBindingDecoration(SwtResourceManager.TOP_RIGHT);
+		setBindingDecoration(IDecoration.TOP_RIGHT);
 		m_fragment = fragment;
 		m_propertiesSupport = propertiesSupport;
 		m_presentation = new EObjectObservePresentation(this);

--- a/org.eclipse.wb.rcp.databinding.xwt/src/org/eclipse/wb/internal/rcp/databinding/xwt/model/beans/XmlElementBeanBindableInfo.java
+++ b/org.eclipse.wb.rcp.databinding.xwt/src/org/eclipse/wb/internal/rcp/databinding/xwt/model/beans/XmlElementBeanBindableInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,10 +11,11 @@
 package org.eclipse.wb.internal.rcp.databinding.xwt.model.beans;
 
 import org.eclipse.wb.internal.core.databinding.model.reference.IReferenceProvider;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 import org.eclipse.wb.internal.core.xml.model.XmlObjectInfo;
 import org.eclipse.wb.internal.rcp.databinding.model.beans.bindables.BeanBindableInfo;
 import org.eclipse.wb.internal.rcp.databinding.model.beans.bindables.BeanSupport;
+
+import org.eclipse.jface.viewers.IDecoration;
 
 /**
  *
@@ -36,7 +37,7 @@ public class XmlElementBeanBindableInfo extends BeanBindableInfo {
 			boolean dataContext) throws Exception {
 		super(beanSupport, null, objectType, referenceProvider, objectInfo);
 		m_dataContext = dataContext;
-		setBindingDecoration(SwtResourceManager.TOP_RIGHT);
+		setBindingDecoration(IDecoration.TOP_RIGHT);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.rcp.databinding.xwt/src/org/eclipse/wb/internal/rcp/databinding/xwt/ui/property/BindingProperty.java
+++ b/org.eclipse.wb.rcp.databinding.xwt/src/org/eclipse/wb/internal/rcp/databinding/xwt/ui/property/BindingProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -38,6 +38,6 @@ public class BindingProperty extends AbstractBindingProperty {
 	@Override
 	public String getText() throws Exception {
 		int column = m_isTarget ? 2 : 1;
-		return BindingLabelProvider.INSTANCE.getColumnText(m_binding, column);
+		return BindingLabelProvider.getText(m_binding, column);
 	}
 }

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/FieldBeanBindableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/FieldBeanBindableInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,6 @@ import org.eclipse.wb.internal.core.databinding.model.reference.IReferenceProvid
 import org.eclipse.wb.internal.core.databinding.model.reference.StringReferenceProvider;
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
 import org.eclipse.wb.internal.core.utils.ast.AstNodeUtils;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 import org.eclipse.wb.internal.rcp.databinding.DatabindingsProvider;
 import org.eclipse.wb.internal.rcp.databinding.model.AbstractBindingInfo;
 import org.eclipse.wb.internal.rcp.databinding.model.beans.BeansObserveTypeContainer;
@@ -27,6 +26,7 @@ import org.eclipse.wb.internal.rcp.databinding.model.widgets.bindables.JavaInfoR
 
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.eclipse.jface.viewers.IDecoration;
 
 import java.beans.PropertyDescriptor;
 
@@ -58,7 +58,7 @@ public final class FieldBeanBindableInfo extends BeanBindableInfo {
 			IReferenceProvider referenceProvider,
 			JavaInfo javaInfo) throws Exception {
 		super(beanSupport, null, objectType, referenceProvider, javaInfo);
-		setBindingDecoration(SwtResourceManager.TOP_RIGHT);
+		setBindingDecoration(IDecoration.TOP_RIGHT);
 		m_hostJavaInfo = fragment == null ? javaInfo : null;
 		m_fragment = fragment;
 		m_children = Lists.newArrayList();

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/LocalVariableBindableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/LocalVariableBindableInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,10 +11,10 @@
 package org.eclipse.wb.internal.rcp.databinding.model.beans.bindables;
 
 import org.eclipse.wb.internal.core.databinding.model.reference.FragmentReferenceProvider;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 import org.eclipse.wb.internal.rcp.databinding.Activator;
 
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.eclipse.jface.viewers.IDecoration;
 
 /**
  * Model for {@code initDataBindings()} local variables <code>Java Beans</code> objects.
@@ -41,7 +41,7 @@ public class LocalVariableBindableInfo extends BeanBindableInfo {
 						new FragmentReferenceProvider(fragment),
 						null,
 						Activator.getImage("localvariable_obj.gif")));
-		setBindingDecoration(SwtResourceManager.TOP_RIGHT);
+		setBindingDecoration(IDecoration.TOP_RIGHT);
 		m_fragment = fragment;
 	}
 

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/MethodBeanBindableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/MethodBeanBindableInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,8 +15,9 @@ import org.eclipse.wb.internal.core.databinding.model.IObservePresentation;
 import org.eclipse.wb.internal.core.databinding.model.presentation.SimpleObservePresentation;
 import org.eclipse.wb.internal.core.databinding.model.reference.IReferenceProvider;
 import org.eclipse.wb.internal.core.databinding.model.reference.StringReferenceProvider;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 import org.eclipse.wb.internal.rcp.databinding.ui.providers.TypeImageProvider;
+
+import org.eclipse.jface.viewers.IDecoration;
 
 /**
  * Model for method based <code>Java Beans</code> objects.
@@ -45,7 +46,7 @@ public final class MethodBeanBindableInfo extends BeanBindableInfo {
 		super(beanSupport, parent, objectType, referenceProvider, createPresentation(
 				referenceProvider,
 				presentationReferenceProvider));
-		setBindingDecoration(SwtResourceManager.TOP_RIGHT);
+		setBindingDecoration(IDecoration.TOP_RIGHT);
 	}
 
 	private static IObservePresentation createPresentation(IReferenceProvider referenceProvider,

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/PropertyBindableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/PropertyBindableInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,10 +16,10 @@ import org.eclipse.wb.internal.core.databinding.model.IObservePresentation;
 import org.eclipse.wb.internal.core.databinding.model.presentation.SimpleObservePresentation;
 import org.eclipse.wb.internal.core.databinding.model.reference.IReferenceProvider;
 import org.eclipse.wb.internal.core.databinding.model.reference.StringReferenceProvider;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 import org.eclipse.wb.internal.rcp.databinding.model.IObservableFactory;
 import org.eclipse.wb.internal.rcp.databinding.ui.providers.TypeImageProvider;
 
+import org.eclipse.jface.viewers.IDecoration;
 import org.eclipse.swt.graphics.Image;
 
 /**
@@ -40,7 +40,7 @@ public abstract class PropertyBindableInfo extends BeanBindableInfo implements I
 			IReferenceProvider referenceProvider,
 			IObservePresentation presentation) {
 		super(beanSupport, parent, objectType, referenceProvider, presentation);
-		setBindingDecoration(SwtResourceManager.TOP_LEFT);
+		setBindingDecoration(IDecoration.TOP_LEFT);
 	}
 
 	public PropertyBindableInfo(BeanSupport beanSupport,

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/bindables/WidgetPropertyBindableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/bindables/WidgetPropertyBindableInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,11 +18,11 @@ import org.eclipse.wb.internal.core.databinding.model.reference.IReferenceProvid
 import org.eclipse.wb.internal.core.databinding.model.reference.StringReferenceProvider;
 import org.eclipse.wb.internal.core.databinding.ui.ObserveType;
 import org.eclipse.wb.internal.core.databinding.ui.decorate.IObserveDecorator;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 import org.eclipse.wb.internal.rcp.databinding.model.BindableInfo;
 import org.eclipse.wb.internal.rcp.databinding.model.IObservableFactory;
 import org.eclipse.wb.internal.rcp.databinding.ui.providers.TypeImageProvider;
 
+import org.eclipse.jface.viewers.IDecoration;
 import org.eclipse.swt.graphics.Image;
 
 import java.util.Collections;
@@ -50,7 +50,7 @@ public final class WidgetPropertyBindableInfo extends BindableInfo implements IO
 			IObservePresentation presentation,
 			IObserveDecorator decorator) {
 		super(objectType, referenceProvider);
-		setBindingDecoration(SwtResourceManager.TOP_LEFT);
+		setBindingDecoration(IDecoration.TOP_LEFT);
 		m_observableFactory = observableFactory;
 		m_presentation = presentation;
 		m_decorator = decorator;

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/property/BindingProperty.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/property/BindingProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -38,6 +38,6 @@ public class BindingProperty extends AbstractBindingProperty {
 	@Override
 	public String getText() throws Exception {
 		int column = m_isTarget ? 2 : 1;
-		return BindingLabelProvider.INSTANCE.getColumnText(m_binding, column);
+		return BindingLabelProvider.getText(m_binding, column);
 	}
 }

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/property/BindingsProperty.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/property/BindingsProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -112,8 +112,8 @@ public class BindingsProperty extends AbstractBindingsProperty {
 		BindingAction action = new BindingAction(m_context, binding);
 		action.setText(observeProperty.getPresentation().getText()
 				+ ": "
-				+ BindingLabelProvider.INSTANCE.getColumnText(binding, isTarget ? 2 : 1));
-		action.setIcon(BindingLabelProvider.INSTANCE.getColumnImage(binding, 0));
+				+ BindingLabelProvider.getText(binding, isTarget ? 2 : 1));
+		action.setImageDescriptor(BindingLabelProvider.getIcon(binding));
 		menu.add(action);
 	}
 }

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/property/InputObserveProperty.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/property/InputObserveProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -51,6 +51,6 @@ public class InputObserveProperty extends SingleObserveBindingProperty {
 	@Override
 	protected String getText() throws Exception {
 		IBindingInfo binding = getBinding();
-		return binding == null ? "" : BindingLabelProvider.INSTANCE.getColumnText(binding, 2);
+		return binding == null ? "" : BindingLabelProvider.getText(binding, 2);
 	}
 }

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/BeanPropertyObserveInfo.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/BeanPropertyObserveInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,6 @@ import org.eclipse.wb.internal.core.databinding.model.presentation.SimpleObserve
 import org.eclipse.wb.internal.core.databinding.model.reference.IReferenceProvider;
 import org.eclipse.wb.internal.core.databinding.ui.ObserveType;
 import org.eclipse.wb.internal.core.databinding.ui.decorate.IObserveDecorator;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 import org.eclipse.wb.internal.swing.databinding.model.ObserveCreationType;
 import org.eclipse.wb.internal.swing.databinding.model.ObserveInfo;
 import org.eclipse.wb.internal.swing.databinding.model.generic.IGenericType;
@@ -24,6 +23,7 @@ import org.eclipse.wb.internal.swing.databinding.model.properties.BeanPropertyIn
 import org.eclipse.wb.internal.swing.databinding.model.properties.PropertyInfo;
 import org.eclipse.wb.internal.swing.databinding.ui.providers.TypeImageProvider;
 
+import org.eclipse.jface.viewers.IDecoration;
 import org.eclipse.swt.graphics.Image;
 
 /**
@@ -52,7 +52,7 @@ public class BeanPropertyObserveInfo extends BeanObserveInfo implements IObserve
 				parent instanceof BeanPropertyObserveInfo ? parent : null,
 						objectType,
 						referenceProvider);
-		setBindingDecoration(SwtResourceManager.TOP_LEFT);
+		setBindingDecoration(IDecoration.TOP_LEFT);
 		m_creationType =
 				java.util.List.class.isAssignableFrom(getObjectClass())
 				? ObserveCreationType.ListProperty

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/FieldBeanObserveInfo.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/FieldBeanObserveInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,10 +13,10 @@ package org.eclipse.wb.internal.swing.databinding.model.beans;
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.databinding.model.IObservePresentation;
 import org.eclipse.wb.internal.core.databinding.model.reference.FragmentReferenceProvider;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 import org.eclipse.wb.internal.swing.databinding.model.generic.IGenericType;
 
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.eclipse.jface.viewers.IDecoration;
 
 /**
  * Model for field based <code>Java Beans</code> objects.
@@ -38,7 +38,7 @@ public final class FieldBeanObserveInfo extends BeanObserveInfo {
 			IGenericType objectType,
 			JavaInfo javaInfo) throws Exception {
 		super(beanSupport, null, objectType, new FragmentReferenceProvider(fragment));
-		setBindingDecoration(SwtResourceManager.TOP_LEFT);
+		setBindingDecoration(IDecoration.TOP_LEFT);
 		m_fragment = fragment;
 		m_presentation =
 				new FieldBeanObservePresentation(this, javaInfo, beanSupport.getBeanImage(

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/LocalVariableObserveInfo.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/LocalVariableObserveInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,11 +13,11 @@ package org.eclipse.wb.internal.swing.databinding.model.beans;
 import org.eclipse.wb.internal.core.databinding.model.IObservePresentation;
 import org.eclipse.wb.internal.core.databinding.model.presentation.SimpleObservePresentation;
 import org.eclipse.wb.internal.core.databinding.model.reference.FragmentReferenceProvider;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 import org.eclipse.wb.internal.swing.databinding.Activator;
 import org.eclipse.wb.internal.swing.databinding.model.generic.IGenericType;
 
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.eclipse.jface.viewers.IDecoration;
 
 /**
  * Model for {@code initDataBindings()} local variables <code>Java Beans</code> objects.
@@ -38,7 +38,7 @@ public final class LocalVariableObserveInfo extends BeanObserveInfo {
 			VariableDeclarationFragment fragment,
 			IGenericType objectType) throws Exception {
 		super(beanSupport, null, objectType, new FragmentReferenceProvider(fragment));
-		setBindingDecoration(SwtResourceManager.TOP_LEFT);
+		setBindingDecoration(IDecoration.TOP_LEFT);
 		m_fragment = fragment;
 		m_presentation =
 				new SimpleObservePresentation(null, null, Activator.getImage("localvariable_obj.gif")) {

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/ObjectPropertyObserveInfo.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/ObjectPropertyObserveInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,13 +17,14 @@ import org.eclipse.wb.internal.core.databinding.model.presentation.SimpleObserve
 import org.eclipse.wb.internal.core.databinding.model.reference.StringReferenceProvider;
 import org.eclipse.wb.internal.core.databinding.ui.ObserveType;
 import org.eclipse.wb.internal.core.databinding.ui.decorate.IObserveDecorator;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 import org.eclipse.wb.internal.swing.databinding.model.ObserveCreationType;
 import org.eclipse.wb.internal.swing.databinding.model.ObserveInfo;
 import org.eclipse.wb.internal.swing.databinding.model.generic.IGenericType;
 import org.eclipse.wb.internal.swing.databinding.model.properties.ObjectPropertyInfo;
 import org.eclipse.wb.internal.swing.databinding.model.properties.PropertyInfo;
 import org.eclipse.wb.internal.swing.databinding.ui.providers.TypeImageProvider;
+
+import org.eclipse.jface.viewers.IDecoration;
 
 import java.util.Collections;
 import java.util.List;
@@ -45,7 +46,7 @@ public final class ObjectPropertyObserveInfo extends ObserveInfo implements IObs
 	////////////////////////////////////////////////////////////////////////////
 	public ObjectPropertyObserveInfo(IGenericType objectType) {
 		super(objectType, StringReferenceProvider.EMPTY);
-		setBindingDecoration(SwtResourceManager.TOP_LEFT);
+		setBindingDecoration(IDecoration.TOP_LEFT);
 		m_creationType =
 				java.util.List.class.isAssignableFrom(getObjectClass())
 				? ObserveCreationType.ListSelfProperty

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/PropertiesObserveInfo.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/PropertiesObserveInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,12 +14,13 @@ import org.eclipse.wb.internal.core.databinding.model.reference.IReferenceProvid
 import org.eclipse.wb.internal.core.databinding.ui.decorate.IObserveDecorator;
 import org.eclipse.wb.internal.core.databinding.ui.editor.IUiContentProvider;
 import org.eclipse.wb.internal.core.databinding.ui.editor.contentproviders.SeparatorUiContentProvider;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 import org.eclipse.wb.internal.swing.databinding.model.ObserveInfo;
 import org.eclipse.wb.internal.swing.databinding.model.generic.IGenericType;
 import org.eclipse.wb.internal.swing.databinding.model.properties.BeanPropertyInfo;
 import org.eclipse.wb.internal.swing.databinding.model.properties.PropertyInfo;
 import org.eclipse.wb.internal.swing.databinding.ui.contentproviders.PropertiesUiContentProvider;
+
+import org.eclipse.jface.viewers.IDecoration;
 
 import org.apache.commons.lang.ArrayUtils;
 
@@ -47,7 +48,7 @@ public final class PropertiesObserveInfo extends BeanPropertyObserveInfo {
 			IObserveDecorator decorator,
 			String[] properties) throws Exception {
 		super(beanSupport, parent, text, objectType, referenceProvider, decorator);
-		setBindingDecoration(SwtResourceManager.TOP_LEFT);
+		setBindingDecoration(IDecoration.TOP_LEFT);
 		m_properties = properties;
 	}
 

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/VirtualObserveInfo.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/VirtualObserveInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,11 +15,12 @@ import com.google.common.collect.ImmutableList;
 import org.eclipse.wb.internal.core.databinding.model.IObservePresentation;
 import org.eclipse.wb.internal.core.databinding.model.presentation.SimpleObservePresentation;
 import org.eclipse.wb.internal.core.databinding.model.reference.StringReferenceProvider;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 import org.eclipse.wb.internal.swing.databinding.Activator;
 import org.eclipse.wb.internal.swing.databinding.model.ObserveCreationType;
 import org.eclipse.wb.internal.swing.databinding.model.ObserveInfo;
 import org.eclipse.wb.internal.swing.databinding.model.generic.ClassGenericType;
+
+import org.eclipse.jface.viewers.IDecoration;
 
 /**
  * @author lobas_av
@@ -35,7 +36,7 @@ public final class VirtualObserveInfo extends BeanObserveInfo {
 	////////////////////////////////////////////////////////////////////////////
 	public VirtualObserveInfo() {
 		super(null, null, ClassGenericType.LIST_CLASS, StringReferenceProvider.EMPTY);
-		setBindingDecoration(SwtResourceManager.TOP_LEFT);
+		setBindingDecoration(IDecoration.TOP_LEFT);
 		m_presentation =
 				new SimpleObservePresentation("[Virtual]", "[Virtual]", Activator.getImage("virtual.png"));
 		setProperties(ImmutableList.<ObserveInfo>of(new ObjectPropertyObserveInfo(getObjectType())));

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/contentproviders/el/ElPropertyUiConfiguration.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/contentproviders/el/ElPropertyUiConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,10 +10,9 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.databinding.ui.contentproviders.el;
 
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
-
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
+import org.eclipse.ui.PlatformUI;
 
 /**
  * Configuration for {@link ElPropertyUiContentProvider}.
@@ -24,11 +23,11 @@ import org.eclipse.swt.graphics.Color;
 public class ElPropertyUiConfiguration {
 	private String m_title;
 	private int m_rows = 4;
-	private Color m_stringsColor = SwtResourceManager.getColor(42, 0, 255);
-	private Color m_keywordsColor = SwtResourceManager.getColor(127, 0, 85);
-	private Color m_numbersColor = SwtResourceManager.getColor(SWT.COLOR_BLACK);
-	private Color m_operatorsColor = SwtResourceManager.getColor(0, 57, 29);
-	private Color m_propertiesColor = SwtResourceManager.getColor(130, 0, 0);
+	private Color m_stringsColor = new Color(42, 0, 255);
+	private Color m_keywordsColor = new Color(127, 0, 85);
+	private Color m_numbersColor = PlatformUI.getWorkbench().getDisplay().getSystemColor(SWT.COLOR_BLACK);
+	private Color m_operatorsColor = new Color(0, 57, 29);
+	private Color m_propertiesColor = new Color(130, 0, 0);
 
 	////////////////////////////////////////////////////////////////////////////
 	//

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/contentproviders/el/KeywordsRule.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/contentproviders/el/KeywordsRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,8 +10,7 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.databinding.ui.contentproviders.el;
 
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
-
+import org.eclipse.jface.resource.FontDescriptor;
 import org.eclipse.jface.text.TextAttribute;
 import org.eclipse.jface.text.rules.ICharacterScanner;
 import org.eclipse.jface.text.rules.IRule;
@@ -49,7 +48,9 @@ public class KeywordsRule implements IRule {
 				new Token(new TextAttribute(configuration.getKeywordsColor(),
 						null,
 						SWT.NORMAL,
-						SwtResourceManager.getBoldFont(sourceViewer.getTextWidget().getFont())));
+						FontDescriptor.createFrom(sourceViewer.getTextWidget().getFont()) //
+								.setStyle(SWT.BOLD) //
+								.createFont(null)));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/property/BindingProperty.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/property/BindingProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -38,6 +38,6 @@ public class BindingProperty extends AbstractBindingProperty {
 	@Override
 	public String getText() throws Exception {
 		int column = m_isTarget ? 2 : 1;
-		return BindingLabelProvider.INSTANCE.getColumnText(m_binding, column);
+		return BindingLabelProvider.getText(m_binding, column);
 	}
 }

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/property/BindingsProperty.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/property/BindingsProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -128,8 +128,8 @@ public class BindingsProperty extends AbstractBindingsProperty {
 		BindingAction action = new BindingAction(m_context, binding);
 		action.setText(observeProperty.getPresentation().getText()
 				+ ": "
-				+ BindingLabelProvider.INSTANCE.getColumnText(binding, isTarget ? 2 : 1));
-		action.setIcon(BindingLabelProvider.INSTANCE.getColumnImage(binding, 0));
+				+ BindingLabelProvider.getText(binding, isTarget ? 2 : 1));
+		action.setImageDescriptor(BindingLabelProvider.getIcon(binding));
 		menu.add(action);
 	}
 }

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/property/JComboBoxSelfObserveProperty.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/property/JComboBoxSelfObserveProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -57,6 +57,6 @@ public class JComboBoxSelfObserveProperty extends SingleObserveBindingProperty {
 			return "";
 		}
 		int column = binding.getTargetProperty() == m_observeProperty ? 2 : 1;
-		return BindingLabelProvider.INSTANCE.getColumnText(binding, column);
+		return BindingLabelProvider.getText(binding, column);
 	}
 }

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/providers/BindingLabelProvider.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/providers/BindingLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,6 @@
 package org.eclipse.wb.internal.swing.databinding.ui.providers;
 
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.swing.databinding.Activator;
 import org.eclipse.wb.internal.swing.databinding.model.bindings.AutoBindingInfo;
 import org.eclipse.wb.internal.swing.databinding.model.bindings.BindingInfo;
@@ -22,6 +21,10 @@ import org.eclipse.wb.internal.swing.databinding.model.bindings.JListBindingInfo
 import org.eclipse.wb.internal.swing.databinding.model.bindings.JTableBindingInfo;
 import org.eclipse.wb.internal.swing.databinding.model.bindings.VirtualBindingInfo;
 
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.resource.LocalResourceManager;
+import org.eclipse.jface.resource.ResourceManager;
 import org.eclipse.jface.viewers.IColorProvider;
 import org.eclipse.jface.viewers.ITableLabelProvider;
 import org.eclipse.jface.viewers.LabelProvider;
@@ -40,86 +43,100 @@ public final class BindingLabelProvider extends LabelProvider
 implements
 ITableLabelProvider,
 IColorProvider {
-	private static final Image AUTO_BINDING_IMAGE = Activator.getImage("autobinding2.png");
-	private static final Image JLIST_BINDING_IMAGE = Activator.getImage("JList.gif");
-	private static final Image JLIST_DETAIL_BINDING_IMAGE = Activator.getImage("JListDetail2.png");
-	private static final Image JCOMBO_BOX_BINDING_IMAGE = Activator.getImage("JComboBox.gif");
-	private static final Image JTABLE_BINDING_IMAGE = Activator.getImage("JTable.gif");
-	private static final Image JTABLE_COLUMN_BINDING_IMAGE =
-			Activator.getImage("JTableColumnBinding.png");
-	public static final BindingLabelProvider INSTANCE = new BindingLabelProvider();
+	private static final ImageDescriptor AUTO_BINDING_IMAGE = Activator.getImageDescriptor("autobinding2.png");
+	private static final ImageDescriptor JLIST_BINDING_IMAGE = Activator.getImageDescriptor("JList.gif");
+	private static final ImageDescriptor JLIST_DETAIL_BINDING_IMAGE = Activator.getImageDescriptor("JListDetail2.png");
+	private static final ImageDescriptor JCOMBO_BOX_BINDING_IMAGE = Activator.getImageDescriptor("JComboBox.gif");
+	private static final ImageDescriptor JTABLE_BINDING_IMAGE = Activator.getImageDescriptor("JTable.gif");
+	private static final ImageDescriptor JTABLE_COLUMN_BINDING_IMAGE = Activator.getImageDescriptor("JTableColumnBinding.png");
+	private final ResourceManager m_resourceManager = new LocalResourceManager(JFaceResources.getResources());
+
+	@Override
+	public void dispose() {
+		super.dispose();
+		m_resourceManager.dispose();
+	}
 
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// ITableLabelProvider
 	//
 	////////////////////////////////////////////////////////////////////////////
+	@Override
 	public String getColumnText(final Object element, final int column) {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<String>() {
-			public String runObject() throws Exception {
-				BindingInfo binding = (BindingInfo) element;
-				switch (column) {
-				case 1 :
-					// target
-					return binding.getTargetPresentationText(true);
-				case 2 :
-					// model
-					return binding.getModelPresentationText(true);
-				case 3 :
-					// strategy
-					if (binding instanceof AutoBindingInfo) {
-						AutoBindingInfo autoBinding = (AutoBindingInfo) binding;
-						return autoBinding.getStrategyInfo().getStrategyValue();
-					}
-					return null;
-				case 4 :
-					// binding
-				{
-					String variable = binding.getVariableIdentifier();
-					if (variable != null) {
-						String name = binding.getName();
-						if (StringUtils.isEmpty(name)) {
-							return variable;
-						}
-						return variable + " - " + name;
-					}
-				}
+		return getText(element, column);
+	}
+
+	public static String getText(Object element, int column) {
+		return ExecutionUtils.runObjectLog(() -> {
+			BindingInfo binding = (BindingInfo) element;
+			switch (column) {
+			case 1:
+				// target
+				return binding.getTargetPresentationText(true);
+			case 2:
+				// model
+				return binding.getModelPresentationText(true);
+			case 3:
+				// strategy
+				if (binding instanceof AutoBindingInfo) {
+					AutoBindingInfo autoBinding = (AutoBindingInfo) binding;
+					return autoBinding.getStrategyInfo().getStrategyValue();
 				}
 				return null;
+			case 4:
+			// binding
+			{
+				String variable = binding.getVariableIdentifier();
+				if (variable != null) {
+					String name = binding.getName();
+					if (StringUtils.isEmpty(name)) {
+						return variable;
+					}
+					return variable + " - " + name;
+				}
 			}
+			}
+			return null;
 		}, "<exception, see log>");
 	}
 
+	@Override
 	public Image getColumnImage(Object element, int column) {
 		if (column == 0) {
-			if (element instanceof JListBindingInfo) {
+			return m_resourceManager.createImageWithDefault(getIcon(element));
+		}
+		return null;
+	}
+
+	public static ImageDescriptor getIcon(Object element) {
+		if (element instanceof JListBindingInfo) {
+			return JLIST_BINDING_IMAGE;
+		}
+		if (element instanceof DetailBindingInfo) {
+			return JLIST_DETAIL_BINDING_IMAGE;
+		}
+		if (element instanceof JComboBoxBindingInfo) {
+			return JCOMBO_BOX_BINDING_IMAGE;
+		}
+		if (element instanceof JTableBindingInfo) {
+			return JTABLE_BINDING_IMAGE;
+		}
+		if (element instanceof ColumnBindingInfo) {
+			return JTABLE_COLUMN_BINDING_IMAGE;
+		}
+		if (element instanceof AutoBindingInfo) {
+			return AUTO_BINDING_IMAGE;
+		}
+		if (element instanceof VirtualBindingInfo) {
+			VirtualBindingInfo binding = (VirtualBindingInfo) element;
+			switch (binding.getSwingType()) {
+			case JListBinding :
 				return JLIST_BINDING_IMAGE;
-			}
-			if (element instanceof DetailBindingInfo) {
-				return JLIST_DETAIL_BINDING_IMAGE;
-			}
-			if (element instanceof JComboBoxBindingInfo) {
-				return JCOMBO_BOX_BINDING_IMAGE;
-			}
-			if (element instanceof JTableBindingInfo) {
+			case JTableBinding :
 				return JTABLE_BINDING_IMAGE;
-			}
-			if (element instanceof ColumnBindingInfo) {
-				return JTABLE_COLUMN_BINDING_IMAGE;
-			}
-			if (element instanceof AutoBindingInfo) {
-				return AUTO_BINDING_IMAGE;
-			}
-			if (element instanceof VirtualBindingInfo) {
-				VirtualBindingInfo binding = (VirtualBindingInfo) element;
-				switch (binding.getSwingType()) {
-				case JListBinding :
-					return JLIST_BINDING_IMAGE;
-				case JTableBinding :
-					return JTABLE_BINDING_IMAGE;
-				case JComboBoxBinding :
-					return JCOMBO_BOX_BINDING_IMAGE;
-				}
+			case JComboBoxBinding :
+				return JCOMBO_BOX_BINDING_IMAGE;
 			}
 		}
 		return null;
@@ -130,6 +147,7 @@ IColorProvider {
 	// IColorProvider
 	//
 	////////////////////////////////////////////////////////////////////////////
+	@Override
 	public Color getForeground(Object element) {
 		if (element instanceof VirtualBindingInfo) {
 			return Display.getCurrent().getSystemColor(SWT.COLOR_DARK_GRAY);
@@ -137,6 +155,7 @@ IColorProvider {
 		return null;
 	}
 
+	@Override
 	public Color getBackground(Object element) {
 		return null;
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/support/ContainerSupportTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/support/ContainerSupportTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,6 @@
 package org.eclipse.wb.tests.designer.swt.support;
 
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 import org.eclipse.wb.internal.swt.support.ContainerSupport;
 import org.eclipse.wb.internal.swt.support.ControlSupport;
 import org.eclipse.wb.tests.designer.Expectations;
@@ -19,6 +18,7 @@ import org.eclipse.wb.tests.designer.Expectations.IntValue;
 
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
 
@@ -155,11 +155,11 @@ public class ContainerSupportTest extends AbstractSupportTest {
 	@Test
 	public void test_setShellImage() throws Exception {
 		Object shell = ContainerSupport.createShell();
+		Image rcpImage = ImageDescriptor.createFromFile(Object.class, "/javax/swing/plaf/basic/icons/JavaCup16.png")
+				.createImage();
 		try {
 			assertNull(ReflectionUtils.invokeMethod(shell, "getImage()"));
 			//
-			Image rcpImage =
-					SwtResourceManager.getImage(Object.class, "/javax/swing/plaf/basic/icons/JavaCup16.png");
 			ContainerSupport.setShellImage(shell, rcpImage);
 			// check newly set image
 			{
@@ -174,6 +174,7 @@ public class ContainerSupportTest extends AbstractSupportTest {
 				}
 			}
 		} finally {
+			rcpImage.dispose();
 			ControlSupport.dispose(shell);
 		}
 	}

--- a/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/property/editor/color/ColorSupport.java
+++ b/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/property/editor/color/ColorSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,13 +10,13 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.xwt.model.property.editor.color;
 
-import org.eclipse.wb.internal.core.utils.ui.SwtResourceManager;
 import org.eclipse.wb.internal.core.utils.ui.dialogs.color.ColorInfo;
 
 import org.eclipse.e4.xwt.XWTMaps;
 import org.eclipse.e4.xwt.utils.NamedColorsUtil;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
+import org.eclipse.ui.PlatformUI;
 
 import org.apache.commons.lang.StringUtils;
 
@@ -47,7 +47,7 @@ public class ColorSupport {
 				Color color;
 				{
 					int id = XWTMaps.getColor(name);
-					color = SwtResourceManager.getColor(id);
+					color = PlatformUI.getWorkbench().getDisplay().getSystemColor(id);
 				}
 				// create ColorInfo
 				{


### PR DESCRIPTION
Colors don't need to be explicitly disposed, meaning we can just use the normal constructor to create new instances. For system colors, Display.getSystemColor() is used. Similarly, Display.getSystemImage() is used to get system images.

The FontDescriptor is used to create bold variant of a given font. We don't create fresh Font instances, but rather re-use already existing objects. Because the lifecycle of the instances created of the FontDescriptor is bound to the lifecycle of the original font, we must not dispose them on our own.

Decorated images are created via the DecorationOverlayIcon. We use the constants in IDecoration, to specify the corner to which the decoration is added. Instances of those image descriptors are created via a local resource manager.