### PR TITLE
Remove obsolete Image constructor for ComponentPresentation

### DIFF
--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/description/ComponentPresentationHelper.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/description/ComponentPresentationHelper.java
@@ -36,7 +36,6 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.swt.graphics.Image;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -166,19 +165,14 @@ public final class ComponentPresentationHelper {
 		return image;
 	}
 
-	private static Image getComponentImage(Bundle bundle, String componentClassName, String creationId)
+	private static ImageDescriptor getComponentImage(Bundle bundle, String componentClassName, String creationId)
 			throws Exception {
 		String iconPath = "/wbp-meta/" + getImageName(componentClassName, creationId);
 		for (String ext : DescriptionHelper.ICON_EXTS) {
 			String iconName = iconPath + ext;
 			URL entry = bundle.getEntry(iconName);
 			if (entry != null) {
-				InputStream stream = entry.openStream();
-				try {
-					return new Image(null, stream);
-				} finally {
-					stream.close();
-				}
+				return ImageDescriptor.createFromURL(entry);
 			}
 		}
 		// not found
@@ -639,7 +633,7 @@ public final class ComponentPresentationHelper {
 			String desc = parseHelper.getDescription(creationId);
 			String name = parseHelper.getName(componentClassName, creationId);
 			String key = getKey(componentClassName, creationId);
-			Image icon = getComponentImage(bundle, componentClassName, creationId);
+			ImageDescriptor icon = getComponentImage(bundle, componentClassName, creationId);
 			if (icon == null) {
 				// no image -- no presentation ;)
 				return;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/description/ComponentPresentation.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/description/ComponentPresentation.java
@@ -10,10 +10,7 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description;
 
-import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
-
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 
 import java.io.ByteArrayInputStream;
@@ -47,15 +44,6 @@ public final class ComponentPresentation {
 		m_name = name;
 		m_description = description;
 		m_iconBytes = iconBytes;
-	}
-
-	@Deprecated
-	public ComponentPresentation(String key,
-			String toolkitId,
-			String name,
-			String description,
-			Image icon) {
-		this(key, toolkitId, name, description, new ImageImageDescriptor(icon));
 	}
 
 	public ComponentPresentation(String key,


### PR DESCRIPTION
The ComponentPresentation already uses ImageDescriptors internally, in order to store an image representation. The Image instance in this constructor is converted into an ImageDescriptor using the ImageImageDescriptor wrapper.
This constructor is only called inside the ComponentPresentationHelper, where we can directly switch to using ImageDescriptors as well, rendering this additional step obsolete.