### PR TITLE
Add MVEL bundle to the project classloader

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/parser/AbstractParseFactory.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/parser/AbstractParseFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -80,7 +80,9 @@ import org.eclipse.jdt.core.dom.SuperMethodInvocation;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 
 import org.apache.commons.lang.StringUtils;
+import org.mvel2.MVEL;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 import java.lang.reflect.Constructor;
 import java.net.URL;
@@ -766,6 +768,11 @@ public abstract class AbstractParseFactory implements IParseFactory {
 		parentClassLoader.add(
 				new BundleClassLoader("org.eclipse.wb.core.java"),
 				List.of("net.bytebuddy.", "org.eclipse.wb.internal.core.model.creation"));;
+				// add class loader for MVEL2 (issue 533)
+				// MVEL is internally using this class-loader to construct an
+				// instance of Accessor, even though it was executed from within
+				// a different class-loader.
+				parentClassLoader.add(FrameworkUtil.getBundle(MVEL.class));
 				// add class loaders for "classLoader-bundle" contributions
 				List<IConfigurationElement> toolkitElements =
 						DescriptionHelper.getToolkitElements(getToolkitId());

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/reflect/CompositeClassLoader.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/reflect/CompositeClassLoader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,10 +15,14 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.wiring.BundleCapability;
+import org.osgi.framework.wiring.BundleWiring;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Set;
@@ -46,6 +50,23 @@ public class CompositeClassLoader extends ClassLoader {
 	 */
 	public List<ClassLoader> getClassLoaders() {
 		return m_classLoaders;
+	}
+
+	/**
+	 * Adds new {@link BundleClassLoader} into composition. The classloader is
+	 * created using the given {@link Bundle}. The namespace includes all of the
+	 * bundles exported packages.
+	 *
+	 * @param bundle An OSGi {@link Bundle}
+	 */
+	public void add(Bundle bundle) {
+		ClassLoader classLoader = new BundleClassLoader(bundle);
+		List<String> namespaces = new ArrayList<>();
+		BundleWiring bundleWiring = bundle.adapt(BundleWiring.class);
+		for (BundleCapability bundleCapability : bundleWiring.getCapabilities("osgi.wiring.package")) {
+			namespaces.add((String) bundleCapability.getAttributes().get("osgi.wiring.package"));
+		}
+		add(classLoader, namespaces);
 	}
 
 	/**


### PR DESCRIPTION
This resolves the NoClassDefFoundError thrown by MVEL when trying to parse an expression via ScriptUtils. Internally, MVEL loads a class using our composite classloader which itself is based on the project classloader. This classloader is not the one that called MVEL and doesn't have its classes in its classpath. Simply adding this missing dependency solves this problem.