### PR TITLE
Ensure that DisposeProjectAfter is always called after the test

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/AbstractJavaProjectTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/AbstractJavaProjectTest.java
@@ -114,20 +114,25 @@ public abstract class AbstractJavaProjectTest extends DesignerTestCase {
 				@Override
 				public void evaluate() throws Throwable {
 					List<Throwable> errors = new ArrayList<>();
+					if (description.getAnnotation(DisposeProjectBefore.class) != null) {
+						waitEventLoop(10);
+						do_projectDispose();
+						waitEventLoop(10);
+					}
 					try {
-						if (description.getAnnotation(DisposeProjectBefore.class) != null) {
-							do_projectDispose();
-						}
 						base.evaluate();
+					} catch (Throwable t) {
+						errors.add(t);
+					} finally {
 						if (description.getAnnotation(DisposeProjectAfter.class) != null) {
-							waitEventLoop(0);
+							waitEventLoop(10);
 							do_projectDispose();
+							waitEventLoop(10);
 						}
 						if (description.getAnnotation(WaitForAutoBuildAfter.class) != null) {
 							waitForAutoBuild();
 						}
-					} catch (Throwable t) {
-						errors.add(t);
+
 					}
 					MultipleFailureException.assertEmpty(errors);
 				}


### PR DESCRIPTION
If the test happens to fail due to an internal error, the cleanup task is never executed. This is resolved by puttin it in the finally block. Futhermore, we wait 10ms before and after disposing the project to ensure that the Eclipse had enough time to properly delete the project..