### PR TITLE
Fix potential memory leak by using ImageDescriptors in ImageUtils

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/ui/ImageUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/ui/ImageUtils.java
@@ -34,7 +34,7 @@ import java.io.IOException;
 import javax.imageio.ImageIO;
 
 /**
- * Utilities for {@link Image} operations.
+ * Utilities for {@link ImageDescriptor} operations.
  *
  * @author scheglov_ke
  * @coverage core.ui
@@ -68,14 +68,15 @@ public final class ImageUtils {
 	}
 
 	/**
-	 * @return the SWT {@link Image} for AWT one.
+	 * @return the SWT {@link ImageDescriptor} for AWT one.
 	 */
-	public static Image convertToSWT(final java.awt.Image awtImage) {
+	public static ImageDescriptor convertToSWT(final java.awt.Image awtImage) {
 		return ExecutionUtils.runObject(() -> {
 			BufferedImage bufferedImage = getBufferedImage(awtImage);
 			ByteArrayOutputStream os = new ByteArrayOutputStream();
 			ImageIO.write(bufferedImage, "PNG", os);
-			return new Image(null, new ImageData(new ByteArrayInputStream(os.toByteArray())));
+			return ImageDescriptor.createFromImageDataProvider(
+					zoom -> zoom == 100 ? new ImageData(new ByteArrayInputStream(os.toByteArray())) : null);
 		});
 	}
 
@@ -142,9 +143,9 @@ public final class ImageUtils {
 	}
 
 	/**
-	 * @return the SWT {@link Image} for AWT icon.
+	 * @return the SWT {@link ImageDescriptor} for AWT icon.
 	 */
-	public static Image convertToSWT(javax.swing.Icon icon) {
+	public static ImageDescriptor convertToSWT(javax.swing.Icon icon) {
 		// prepare Swing image from Icon
 		BufferedImage awtImage;
 		{

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanBindablePresentation.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanBindablePresentation.java
@@ -14,10 +14,8 @@ import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.databinding.model.presentation.ObservePresentation;
 import org.eclipse.wb.internal.core.databinding.model.reference.IReferenceProvider;
-import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.swt.graphics.Image;
 
 import org.apache.commons.lang.ClassUtils;
 
@@ -31,7 +29,7 @@ public final class BeanBindablePresentation extends ObservePresentation {
 	private Class<?> m_objectType;
 	private final IReferenceProvider m_presentation;
 	private ObjectInfo m_javaInfo;
-	private Image m_beanImage;
+	private ImageDescriptor m_beanImage;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -41,7 +39,7 @@ public final class BeanBindablePresentation extends ObservePresentation {
 	public BeanBindablePresentation(Class<?> objectType,
 			IReferenceProvider presentation,
 			ObjectInfo javaInfo,
-			Image beanImage) {
+			ImageDescriptor beanImage) {
 		m_objectType = objectType;
 		m_presentation = presentation;
 		m_javaInfo = javaInfo;
@@ -65,7 +63,7 @@ public final class BeanBindablePresentation extends ObservePresentation {
 		m_objectType = objectType;
 	}
 
-	public void setBeanImage(Image beanImage) {
+	public void setBeanImage(ImageDescriptor beanImage) {
 		m_beanImage = beanImage;
 	}
 
@@ -79,7 +77,7 @@ public final class BeanBindablePresentation extends ObservePresentation {
 		if (m_beanImage == null && m_javaInfo == null) {
 			return null;
 		}
-		return m_beanImage == null ? m_javaInfo.getPresentation().getIcon() : new ImageImageDescriptor(m_beanImage);
+		return m_beanImage == null ? m_javaInfo.getPresentation().getIcon() : m_beanImage;
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -36,7 +36,7 @@ import org.eclipse.wb.internal.rcp.databinding.model.widgets.bindables.ViewerObs
 import org.eclipse.wb.internal.rcp.databinding.preferences.IPreferenceConstants;
 import org.eclipse.wb.internal.rcp.databinding.ui.providers.TypeImageProvider;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import org.apache.commons.lang.ClassUtils;
 
@@ -58,7 +58,7 @@ import java.util.Set;
  * @coverage bindings.rcp.model.beans
  */
 public final class BeanSupport {
-	private final Map<Class<?>, Image> m_classToImage = Maps.newHashMap();
+	private final Map<Class<?>, ImageDescriptor> m_classToImage = Maps.newHashMap();
 	private final IModelResolver m_resolver;
 	private final Class<?> m_IObservable;
 	private final Class<?> m_IObservableValue;
@@ -411,15 +411,15 @@ public final class BeanSupport {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * @return {@link Image} represented given bean class.
+	 * @return {@link ImageDescriptor} represented given bean class.
 	 */
-	public Image getBeanImage(Class<?> beanClass, ObjectInfo javaInfo) throws Exception {
+	public ImageDescriptor getBeanImage(Class<?> beanClass, ObjectInfo javaInfo) throws Exception {
 		// check java info
 		if (javaInfo != null) {
 			return null;
 		}
 		// prepare cached image
-		Image beanImage = m_classToImage.get(beanClass);
+		ImageDescriptor beanImage = m_classToImage.get(beanClass);
 		// check load image
 		if (beanImage == null) {
 			try {
@@ -428,15 +428,14 @@ public final class BeanSupport {
 				java.awt.Image awtBeanIcon = beanInfo.getIcon(BeanInfo.ICON_COLOR_16x16);
 				if (awtBeanIcon == null) {
 					// set default
-					beanImage = Activator.getImage("javabean.gif");
+					beanImage = Activator.getImageDescriptor("javabean.gif");
 				} else {
 					// convert to SWT image
-					// FIXME: memory leak
 					beanImage = ImageUtils.convertToSWT(awtBeanIcon);
 				}
 			} catch (Throwable e) {
 				// set default
-				beanImage = Activator.getImage("javabean.gif");
+				beanImage = Activator.getImageDescriptor("javabean.gif");
 			}
 			m_classToImage.put(beanClass, beanImage);
 		}

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/LocalVariableBindableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/LocalVariableBindableInfo.java
@@ -40,7 +40,7 @@ public class LocalVariableBindableInfo extends BeanBindableInfo {
 				new BeanBindablePresentation(objectType,
 						new FragmentReferenceProvider(fragment),
 						null,
-						Activator.getImage("localvariable_obj.gif")));
+						Activator.getImageDescriptor("localvariable_obj.gif")));
 		setBindingDecoration(IDecoration.TOP_RIGHT);
 		m_fragment = fragment;
 	}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/DescriptionProcessor.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/DescriptionProcessor.java
@@ -15,10 +15,7 @@ import org.eclipse.wb.internal.core.model.description.IDescriptionProcessor;
 import org.eclipse.wb.internal.core.model.description.MethodDescription;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
-import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.core.utils.ui.ImageUtils;
-
-import org.eclipse.swt.graphics.Image;
 
 import java.awt.Component;
 import java.beans.BeanInfo;
@@ -57,8 +54,7 @@ public final class DescriptionProcessor implements IDescriptionProcessor {
 	private void configureIconFromBeanInfo() throws Exception {
 		java.awt.Image awtIcon = beanInfo.getIcon(BeanInfo.ICON_COLOR_16x16);
 		if (awtIcon != null) {
-			Image icon = ImageUtils.convertToSWT(awtIcon);
-			componentDescription.setIcon(new ImageImageDescriptor(icon));
+			componentDescription.setIcon(ImageUtils.convertToSWT(awtIcon));
 		}
 	}
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/bean/ActionInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/bean/ActionInfo.java
@@ -31,7 +31,6 @@ import org.eclipse.wb.internal.swing.palette.ActionUseEntryInfo;
 
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.swt.graphics.Image;
 
 import java.io.IOException;
 import java.util.List;
@@ -92,14 +91,14 @@ public class ActionInfo extends JavaInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * The SWT {@link Image} created from {@link Action#SMALL_ICON}, may be <code>null</code>.
+	 * The SWT {@link ImageDescriptor} created from {@link Action#SMALL_ICON}, may be <code>null</code>.
 	 */
-	private Image m_smallIconImage;
+	private ImageDescriptor m_smallIconImage;
 	private final IObjectPresentation m_presentation = new DefaultJavaInfoPresentation(this) {
 		@Override
 		public ImageDescriptor getIcon() throws Exception {
 			if (m_smallIconImage != null) {
-				return ImageDescriptor.createFromImage(m_smallIconImage);
+				return m_smallIconImage;
 			}
 			return super.getIcon();
 		}
@@ -120,8 +119,6 @@ public class ActionInfo extends JavaInfo {
 			javax.swing.Icon smallIcon = (Icon) ((Action) getObject()).getValue(Action.SMALL_ICON);
 			if (smallIcon != null) {
 				m_smallIconImage = ImageUtils.convertToSWT(smallIcon);
-				// schedule SWT image for disposing
-				JavaInfoUtils.getState(this).addDisposableImage(m_smallIconImage);
 			}
 		}
 	}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingImageUtils.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingImageUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -539,7 +539,7 @@ public class SwingImageUtils {
 					return new Image(null, swtImageData);
 				} catch (Throwable e) {
 					// fallback to ImageIO.
-					return ImageUtils.convertToSWT(image);
+					return ImageUtils.convertToSWT(image).createImage();
 				} finally {
 					swtImage.dispose();
 				}

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/DescriptionProcessor.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/DescriptionProcessor.java
@@ -27,10 +27,8 @@ import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.core.utils.state.EditorState;
-import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.core.utils.ui.ImageUtils;
 
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Layout;
 
@@ -304,8 +302,7 @@ public final class DescriptionProcessor implements IDescriptionProcessor {
 			if (beanInfo != null) {
 				java.awt.Image awtIcon = beanInfo.getIcon(BeanInfo.ICON_COLOR_16x16);
 				if (awtIcon != null) {
-					Image icon = ImageUtils.convertToSWT(awtIcon);
-					componentDescription.setIcon(new ImageImageDescriptor(icon));
+					componentDescription.setIcon(ImageUtils.convertToSWT(awtIcon));
 				}
 			}
 		}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/ui/ImageUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/ui/ImageUtilsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,9 @@ import org.eclipse.wb.internal.core.utils.ui.ImageUtils;
 import org.eclipse.wb.tests.designer.TestUtils;
 import org.eclipse.wb.tests.designer.tests.DesignerTestCase;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.Rectangle;
 
 import org.assertj.core.api.Assertions;
@@ -68,14 +70,13 @@ public class ImageUtilsTest extends DesignerTestCase {
 	public void test_convertToSWT_BufferedImage() throws Exception {
 		java.awt.Image awtImage = new BufferedImage(10, 20, BufferedImage.TYPE_INT_ARGB);
 		// do convert
-		Image swtImage = ImageUtils.convertToSWT(awtImage);
+		ImageDescriptor swtImage = ImageUtils.convertToSWT(awtImage);
 		// has same size
 		{
-			Rectangle bounds = swtImage.getBounds();
-			assertEquals(10, bounds.width);
-			assertEquals(20, bounds.height);
+			ImageData imageData = swtImage.getImageData(100);
+			assertEquals(10, imageData.width);
+			assertEquals(20, imageData.height);
 		}
-		swtImage.dispose();
 	}
 
 	/**
@@ -90,13 +91,12 @@ public class ImageUtilsTest extends DesignerTestCase {
 			awtImage = tk.createImage(bytes);
 		}
 		// do convert
-		Image swtImage = ImageUtils.convertToSWT(awtImage);
+		ImageDescriptor swtImage = ImageUtils.convertToSWT(awtImage);
 		// has same size
 		{
-			Rectangle bounds = swtImage.getBounds();
-			assertEquals(10, bounds.width);
-			assertEquals(20, bounds.height);
+			ImageData imageData = swtImage.getImageData(100);
+			assertEquals(10, imageData.width);
+			assertEquals(20, imageData.height);
 		}
-		swtImage.dispose();
 	}
 }


### PR DESCRIPTION
When converting an AWT image to SWT, the utility methods should return an ImageDescriptor instead of an Image. This way the calling method (i.e. our model classes) don't have to worry about disposing the image once no longer needed.