### PR TITLE
Remove usage of deprecated constructor for Java primitives.

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/CharacterPropertyEditor.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/CharacterPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -74,7 +74,7 @@ public final class CharacterPropertyEditor extends AbstractTextPropertyEditor {
 			return false;
 		}
 		// modify property
-		property.setValue(new Character(text.charAt(0)));
+		property.setValue(Character.valueOf(text.charAt(0)));
 		return true;
 	}
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/binding/editors/SpinnerEditor.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/binding/editors/SpinnerEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -37,7 +37,7 @@ public class SpinnerEditor implements IDataEditor {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public Object getValue() {
-		return new Integer(m_field.getSelection());
+		return Integer.valueOf(m_field.getSelection());
 	}
 
 	@Override

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/binding/editors/controls/ComboSelectionEditor.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/binding/editors/controls/ComboSelectionEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -38,7 +38,7 @@ public final class ComboSelectionEditor implements IDataEditor {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public Object getValue() {
-		return new Integer(m_combo.getSelectionIndex());
+		return Integer.valueOf(m_combo.getSelectionIndex());
 	}
 
 	@Override

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/binding/editors/controls/RadioButtonsEditor.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/binding/editors/controls/RadioButtonsEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -69,10 +69,10 @@ public final class RadioButtonsEditor implements IDataEditor {
 		for (int i = 0; i < m_buttons.length; i++) {
 			Button button = m_buttons[i];
 			if (button.getSelection()) {
-				return new Integer(m_values[i]);
+				return Integer.valueOf(m_values[i]);
 			}
 		}
-		return new Integer(m_values[0]);
+		return Integer.valueOf(m_values[0]);
 	}
 
 	@Override

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/binding/providers/IntegerPreferenceProvider.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/binding/providers/IntegerPreferenceProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,7 +35,7 @@ public final class IntegerPreferenceProvider extends AbstractPreferenceProvider 
 	@Override
 	public Object getValue(boolean def) {
 		int value = def ? m_store.getDefaultInt(m_key) : m_store.getInt(m_key);
-		return new Integer(value);
+		return Integer.valueOf(value);
 	}
 
 	@Override

--- a/org.eclipse.wb.rcp.databinding/resources/1.4/org/eclipse/wb/rcp/databinding/TreeBeanAdvisor.java
+++ b/org.eclipse.wb.rcp.databinding/resources/1.4/org/eclipse/wb/rcp/databinding/TreeBeanAdvisor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -58,11 +58,11 @@ public final class TreeBeanAdvisor extends TreeStructureAdvisor {
 				return Boolean.FALSE;
 			}
 			if (children.getClass().isArray()) {
-				return new Boolean(Array.getLength(children) > 0);
+				return Boolean.valueOf(Array.getLength(children) > 0);
 			}
 			if (children instanceof Collection) {
 				Collection collection = (Collection) children;
-				return new Boolean(!collection.isEmpty());
+				return Boolean.valueOf(!collection.isEmpty());
 			}
 		}
 		return null;

--- a/org.eclipse.wb.rcp/resources/1.4/org/eclipse/wb/swt/SWTResourceManager.java
+++ b/org.eclipse.wb.rcp/resources/1.4/org/eclipse/wb/swt/SWTResourceManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -351,10 +351,10 @@ public class SWTResourceManager {
 					Object logFont = FontData.class.getField("data").get(fontData); //$NON-NLS-1$
 					if (logFont != null && logFontClass != null) {
 						if (strikeout) {
-							logFontClass.getField("lfStrikeOut").set(logFont, new Byte((byte) 1)); //$NON-NLS-1$
+							logFontClass.getField("lfStrikeOut").set(logFont, Byte.valueOf((byte) 1)); //$NON-NLS-1$
 						}
 						if (underline) {
-							logFontClass.getField("lfUnderline").set(logFont, new Byte((byte) 1)); //$NON-NLS-1$
+							logFontClass.getField("lfUnderline").set(logFont, Byte.valueOf((byte) 1)); //$NON-NLS-1$
 						}
 					}
 				} catch (Throwable e) {
@@ -415,7 +415,7 @@ public class SWTResourceManager {
 	 * @return Cursor The system cursor matching the specific ID
 	 */
 	public static Cursor getCursor(int id) {
-		Integer key = new Integer(id);
+		Integer key = Integer.valueOf(id);
 		Cursor cursor = (Cursor) m_idToCursorMap.get(key);
 		if (cursor == null) {
 			cursor = new Cursor(Display.getDefault(), id);

--- a/org.eclipse.wb.rcp/resources/1.5/org/eclipse/wb/swt/DoubleFieldEditor.java
+++ b/org.eclipse.wb.rcp/resources/1.5/org/eclipse/wb/swt/DoubleFieldEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -81,8 +81,8 @@ public class DoubleFieldEditor extends StringFieldEditor {
 	private static String getMessage_invalidRange(double min, double max) {
 		String message = JFaceResources.format("IntegerFieldEditor.errorMessageRange", //$NON-NLS-1$
 			new Object[]{
-					new Double(min),
-					new Double(max)});
+					Double.valueOf(min),
+					Double.valueOf(max)});
 		return replaceInteger_withDouble(message);
 	}
 	private static String replaceInteger_withDouble(String message) {
@@ -140,7 +140,7 @@ public class DoubleFieldEditor extends StringFieldEditor {
 	protected void doStore() {
 		Text text = getTextControl();
 		if (text != null) {
-			Double i = new Double(text.getText());
+			Double i = Double.valueOf(text.getText());
 			getPreferenceStore().setValue(getPreferenceName(), i.doubleValue());
 		}
 	}
@@ -157,7 +157,7 @@ public class DoubleFieldEditor extends StringFieldEditor {
 	 *                if the <code>String</code> does not contain a parsable double
 	 */
 	public double getDoubleValue() throws NumberFormatException {
-		return new Double(getStringValue()).doubleValue();
+		return Double.valueOf(getStringValue()).doubleValue();
 	}
 	/**
 	 * Sets the tool tip text of the label and text control.

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/PreferencesRepairer.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/PreferencesRepairer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -43,7 +43,7 @@ public final class PreferencesRepairer {
 	 * Sets the <code>boolean</code> value.
 	 */
 	public void setValue(String name, boolean value) {
-		save(name, new Boolean(m_preferences.getBoolean(name)));
+		save(name, Boolean.valueOf(m_preferences.getBoolean(name)));
 		m_preferences.setValue(name, value);
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/eval/other/CastTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/eval/other/CastTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -36,42 +36,42 @@ public class CastTest extends AbstractEngineTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_cast_byte() throws Exception {
-		assertEquals(new Byte((byte) 1), evaluateExpression("(byte)1", "byte"));
+		assertEquals(Byte.valueOf((byte) 1), evaluateExpression("(byte)1", "byte"));
 	}
 
 	@Test
 	public void test_cast_short() throws Exception {
-		assertEquals(new Short((short) 1), evaluateExpression("(short)1", "short"));
+		assertEquals(Short.valueOf((short) 1), evaluateExpression("(short)1", "short"));
 	}
 
 	@Test
 	public void test_cast_int() throws Exception {
-		assertEquals(new Integer(1), evaluateExpression("(int)1", "int"));
+		assertEquals(Integer.valueOf(1), evaluateExpression("(int)1", "int"));
 	}
 
 	@Test
 	public void test_cast_long() throws Exception {
-		assertEquals(new Long(1L), evaluateExpression("(long)1", "long"));
+		assertEquals(Long.valueOf(1L), evaluateExpression("(long)1", "long"));
 	}
 
 	@Test
 	public void test_cast_float() throws Exception {
-		assertEquals(new Float(1.2f), evaluateExpression("(float)1.2f", "float"));
+		assertEquals(Float.valueOf(1.2f), evaluateExpression("(float)1.2f", "float"));
 	}
 
 	@Test
 	public void test_cast_float2() throws Exception {
-		assertEquals(new Float(1.2f), evaluateExpression("(float)1.2", "float"));
+		assertEquals(Float.valueOf(1.2f), evaluateExpression("(float)1.2", "float"));
 	}
 
 	@Test
 	public void test_cast_float3() throws Exception {
-		assertEquals(new Float(1.2f), evaluateExpression("(float)1.2d", "double"));
+		assertEquals(Float.valueOf(1.2f), evaluateExpression("(float)1.2d", "double"));
 	}
 
 	@Test
 	public void test_cast_double() throws Exception {
-		assertEquals(new Double(1.2d), evaluateExpression("(double)1.2d", "double"));
+		assertEquals(Double.valueOf(1.2d), evaluateExpression("(double)1.2d", "double"));
 	}
 
 	@Test

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/eval/primities/BooleanTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/eval/primities/BooleanTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -103,6 +103,6 @@ public class BooleanTest extends AbstractEngineTest {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	private void check_boolean(String expression, boolean expected) throws Exception {
-		assertEquals(new Boolean(expected), evaluateExpression(expression, "boolean"));
+		assertEquals(Boolean.valueOf(expected), evaluateExpression(expression, "boolean"));
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/eval/primities/CharTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/eval/primities/CharTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -51,6 +51,6 @@ public class CharTest extends AbstractEngineTest {
 	////////////////////////////////////////////////////////////////////////////
 	private void check_char(String expression, char expected) throws Exception {
 		Object actual = evaluateExpression(expression, "char");
-		assertEquals(new Character(expected), actual);
+		assertEquals(Character.valueOf(expected), actual);
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/eval/primities/DoubleTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/eval/primities/DoubleTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -115,6 +115,6 @@ public class DoubleTest extends AbstractEngineTest {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	private void check_double(String expression, double expected) throws Exception {
-		assertEquals(new Double(expected), evaluateExpression(expression, "double"));
+		assertEquals(Double.valueOf(expected), evaluateExpression(expression, "double"));
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/eval/primities/IntegerTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/eval/primities/IntegerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -223,7 +223,7 @@ public class IntegerTest extends AbstractEngineTest {
 	////////////////////////////////////////////////////////////////////////////
 	private void check_short(String expression, short expected) throws Exception {
 		Object actual = evaluateExpression(expression, "short");
-		assertEquals(new Short(expected), actual);
+		assertEquals(Short.valueOf(expected), actual);
 	}
 
 	private void check_int(String expression, int expected) throws Exception {

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/eval/primities/LongTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/eval/primities/LongTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -135,6 +135,6 @@ public class LongTest extends AbstractEngineTest {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	private void check_long(String expression, long expected) throws Exception {
-		assertEquals(new Long(expected), evaluateExpression(expression, "long"));
+		assertEquals(Long.valueOf(expected), evaluateExpression(expression, "long"));
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/StandardConvertersTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/StandardConvertersTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -72,7 +72,7 @@ public class StandardConvertersTest extends SwingModelTest {
 
 	@Test
 	public void test_property_short() throws Exception {
-		check_converter("short", new Short((short) 123), "(short) 123");
+		check_converter("short", Short.valueOf((short) 123), "(short) 123");
 	}
 
 	@Test
@@ -82,7 +82,7 @@ public class StandardConvertersTest extends SwingModelTest {
 
 	@Test
 	public void test_property_float() throws Exception {
-		check_converter("float", new Float(123.4), "123.4f");
+		check_converter("float", Float.valueOf(123.4f), "123.4f");
 	}
 
 	@Test
@@ -146,7 +146,7 @@ public class StandardConvertersTest extends SwingModelTest {
 	public void test_CharacterConverter() throws Exception {
 		assertConverterEditor(char.class);
 		ExpressionConverter converter = CharacterConverter.INSTANCE;
-		assertEquals("'0'", converter.toJavaSource(null, new Character('0')));
+		assertEquals("'0'", converter.toJavaSource(null, Character.valueOf('0')));
 	}
 
 	@Test
@@ -161,8 +161,8 @@ public class StandardConvertersTest extends SwingModelTest {
 	public void test_ShortConverter() throws Exception {
 		assertConverterEditor(short.class);
 		ExpressionConverter converter = ShortConverter.INSTANCE;
-		assertEquals("(short) 1", converter.toJavaSource(null, new Short((short) 1)));
-		assertEquals("(short) -1", converter.toJavaSource(null, new Short((short) -1)));
+		assertEquals("(short) 1", converter.toJavaSource(null, Short.valueOf((short) 1)));
+		assertEquals("(short) -1", converter.toJavaSource(null, Short.valueOf((short) -1)));
 	}
 
 	@Test

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/accessor/FieldAccessorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/accessor/FieldAccessorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -177,7 +177,7 @@ public class FieldAccessorTest extends SwingModelTest {
 				fieldAccessor = (FieldAccessor) accessors.get(0);
 			}
 			// do checks
-			assertEquals(new Double(2.0), fieldAccessor.getDefaultValue(myComponent));
+			assertEquals(Double.valueOf(2.0), fieldAccessor.getDefaultValue(myComponent));
 			assertEquals("field_2", getPropertyTooltipText(fieldAccessor, property));
 			assertNull(fieldAccessor.getAdapter(null));
 			// check IExposableExpressionAccessor

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/editor/DatePropertyEditorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/editor/DatePropertyEditorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -90,7 +90,7 @@ public class DatePropertyEditorTest extends AbstractTextPropertyEditorTest {
 				"public class Test extends JPanel {",
 				"  public Test() {",
 				"    DateComponent component = new DateComponent();",
-				"    component.setDate(new Date(" + new Long(currentTimeMillis).toString() + "L));",
+				"    component.setDate(new Date(" + Long.valueOf(currentTimeMillis).toString() + "L));",
 				"    add(component);",
 				"  }",
 				"}");
@@ -144,7 +144,7 @@ public class DatePropertyEditorTest extends AbstractTextPropertyEditorTest {
 						"public class Test extends JPanel {",
 						"  public Test() {",
 						"    DateComponent component = new DateComponent();",
-						"    component.setDate(new Date(" + new Long(currentTimeMillis).toString() + "L));",
+						"    component.setDate(new Date(" + Long.valueOf(currentTimeMillis).toString() + "L));",
 						"    add(component);",
 						"  }",
 						"}");

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/editor/InstanceListPropertyEditorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/editor/InstanceListPropertyEditorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -108,8 +108,8 @@ public class InstanceListPropertyEditorTest extends AbstractTextPropertyEditorTe
 	public void test_getClipboardSource() throws Exception {
 		Map<String, Object> parameters = getEditorParameters();
 		InstanceListPropertyEditor editor = createEditor(InstanceListPropertyEditor.class, parameters);
-		assert_getClipboardSource("new java.lang.Integer()", editor, new Integer(3));
-		assert_getClipboardSource(null, editor, new Boolean(true));
+		assert_getClipboardSource("new java.lang.Integer()", editor, Integer.valueOf(3));
+		assert_getClipboardSource(null, editor, Boolean.valueOf(true));
 	}
 
 	/**

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/MethodOrderTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/MethodOrderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -1557,7 +1557,7 @@ public class MethodOrderTest extends SwingModelTest {
 		{
 			Property property = panel.getPropertyByTitle("property_2");
 			assertNotNull(property);
-			property.setValue(new Integer(7));
+			property.setValue(Integer.valueOf(7));
 			assertEditor(
 					"// filler filler filler",
 					"public class Test extends ContainerPanel {",
@@ -1569,7 +1569,7 @@ public class MethodOrderTest extends SwingModelTest {
 		{
 			Property property = panel.getPropertyByTitle("property_1");
 			assertNotNull(property);
-			property.setValue(new Integer(112));
+			property.setValue(Integer.valueOf(112));
 			assertEditor(
 					"// filler filler filler",
 					"public class Test extends ContainerPanel {",
@@ -1633,7 +1633,7 @@ public class MethodOrderTest extends SwingModelTest {
 		{
 			Property property = panel.getPropertyByTitle("property_2");
 			assertNotNull(property);
-			property.setValue(new Integer(7));
+			property.setValue(Integer.valueOf(7));
 			assertEditor(
 					"// filler filler filler",
 					"public class Test extends ContainerPanel {",
@@ -1651,7 +1651,7 @@ public class MethodOrderTest extends SwingModelTest {
 		{
 			Property property = panel.getPropertyByTitle("property_1");
 			assertNotNull(property);
-			property.setValue(new Integer(112));
+			property.setValue(Integer.valueOf(112));
 			assertEditor(
 					"// filler filler filler",
 					"public class Test extends ContainerPanel {",
@@ -1687,7 +1687,7 @@ public class MethodOrderTest extends SwingModelTest {
 		{
 			Property property = panel.getPropertyByTitle("property_2");
 			assertNotNull(property);
-			property.setValue(new Integer(7));
+			property.setValue(Integer.valueOf(7));
 			assertEditor(
 					"public class Test extends ContainerPanel {",
 					"  public Test() {",
@@ -1704,7 +1704,7 @@ public class MethodOrderTest extends SwingModelTest {
 		{
 			Property property = panel.getPropertyByTitle("property_1");
 			assertNotNull(property);
-			property.setValue(new Integer(112));
+			property.setValue(Integer.valueOf(112));
 			assertEditor(
 					"public class Test extends ContainerPanel {",
 					"  public Test() {",

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/GenericsUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/GenericsUtilsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -166,8 +166,8 @@ public class GenericsUtilsTest extends DesignerTestCase {
 	public void test_get() throws Exception {
 		Object[] objects = {"0", 1, 2.2};
 		assertEquals("0", GenericsUtils.get(String.class, objects));
-		assertEquals(new Integer(1), GenericsUtils.get(Integer.class, objects));
-		assertEquals(new Double(2.2), GenericsUtils.get(Double.class, objects));
+		assertEquals(Integer.valueOf(1), GenericsUtils.get(Integer.class, objects));
+		assertEquals(Double.valueOf(2.2), GenericsUtils.get(Double.class, objects));
 		assertEquals(null, GenericsUtils.get(Float.class, objects));
 	}
 
@@ -178,8 +178,8 @@ public class GenericsUtilsTest extends DesignerTestCase {
 	public void test_get_fromList() throws Exception {
 		List<?> objects = ImmutableList.<Object>of("0", 1, 2.2);
 		assertEquals("0", GenericsUtils.get(String.class, objects));
-		assertEquals(new Integer(1), GenericsUtils.get(Integer.class, objects));
-		assertEquals(new Double(2.2), GenericsUtils.get(Double.class, objects));
+		assertEquals(Integer.valueOf(1), GenericsUtils.get(Integer.class, objects));
+		assertEquals(Double.valueOf(2.2), GenericsUtils.get(Double.class, objects));
 		assertEquals(null, GenericsUtils.get(Float.class, objects));
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/reflect/ReflectionUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/reflect/ReflectionUtilsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -1188,7 +1188,7 @@ public class ReflectionUtilsTest extends DesignerTestCase {
 					ReflectionUtils.getConstructorForArguments(
 							Foo_getConstructorForArguments.class,
 							"a",
-							new Integer(1));
+							Integer.valueOf(1));
 			assertNotNull(constructor);
 		}
 		// compatible arguments, but parameter type is primitive "int"
@@ -1196,7 +1196,7 @@ public class ReflectionUtilsTest extends DesignerTestCase {
 			Constructor<?> constructor =
 					ReflectionUtils.getConstructorForArguments(
 							Foo_getConstructorForArguments.class,
-							new Integer(1));
+							Integer.valueOf(1));
 			assertNotNull(constructor);
 		}
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/FormLayout/FormDimensionInfoTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/FormLayout/FormDimensionInfoTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -151,7 +151,7 @@ public class FormDimensionInfoTest extends AbstractFormLayoutTest {
 		method.setAccessible(true);
 		assertEquals(
 				alignmentName,
-				(String) method.invoke(null, new Object[]{new Boolean(horizontal), alignment}));
+				method.invoke(null, new Object[]{Boolean.valueOf(horizontal), alignment}));
 	}
 
 	@Test

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/property/FontPropertyEditorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/property/FontPropertyEditorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -200,7 +200,7 @@ public class FontPropertyEditorTest extends SwingModelTest {
 							"Tahoma",
 							null,
 							null,
-							new Integer(5),
+							Integer.valueOf(5),
 							null);
 			Font font = fontInfo.getFont();
 			assertEquals(Font.BOLD, font.getStyle());
@@ -224,7 +224,7 @@ public class FontPropertyEditorTest extends SwingModelTest {
 							null,
 							null,
 							null,
-							new Integer(20));
+							Integer.valueOf(20));
 			Font font = fontInfo.getFont();
 			assertEquals(Font.BOLD, font.getStyle());
 			assertEquals(20, font.getSize());

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/RequestsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/RequestsTest.java
@@ -221,7 +221,8 @@ public class RequestsTest extends Assert {
 
 			@Override
 			public Object getNewObject() {
-				return new Integer(7);
+				// Has to be larger than then integer cache from [-128, 127]
+				return Integer.valueOf(273);
 			}
 		};
 		CreateRequest request = new CreateRequest(factory);
@@ -241,7 +242,7 @@ public class RequestsTest extends Assert {
 		//
 		// check work factory
 		Object newObject = request.getNewObject();
-		assertEquals(7, newObject);
+		assertEquals(273, newObject);
 		assertSame(newObject, request.getNewObject());
 		assertNotSame(newObject, factory.getNewObject());
 		//


### PR DESCRIPTION
Instead of e.g. new Integer(), we use the drop-in replacement Integer.valueOf().