### PR TITLE
Switch to ImageDescriptor in TypeImageProvider and adjust references

### DIFF
--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/presentation/SimpleObservePresentation.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/presentation/SimpleObservePresentation.java
@@ -11,7 +11,6 @@
 package org.eclipse.wb.internal.core.databinding.model.presentation;
 
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.swt.graphics.Image;
 
 /**
  *
@@ -21,18 +20,18 @@ import org.eclipse.swt.graphics.Image;
 public class SimpleObservePresentation extends ObservePresentation {
 	private final String m_text;
 	private final String m_textForBinding;
-	private final Image m_image;
+	private final ImageDescriptor m_image;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Constructor
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public SimpleObservePresentation(String text, Image image) {
+	public SimpleObservePresentation(String text, ImageDescriptor image) {
 		this(text, text, image);
 	}
 
-	public SimpleObservePresentation(String text, String textForBinding, Image image) {
+	public SimpleObservePresentation(String text, String textForBinding, ImageDescriptor image) {
 		m_text = text;
 		m_textForBinding = textForBinding;
 		m_image = image;
@@ -45,7 +44,7 @@ public class SimpleObservePresentation extends ObservePresentation {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	protected ImageDescriptor getInternalImage() throws Exception {
-		return m_image == null ? null : ImageDescriptor.createFromImage(m_image);
+		return m_image == null ? null : m_image;
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/ObserveElementsComposite.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/ObserveElementsComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,6 +26,7 @@ import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.IBaseLabelProvider;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
@@ -42,6 +43,7 @@ import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Composite;
@@ -522,8 +524,13 @@ final class ObserveElementsComposite extends SashForm {
 		// fill menu
 		for (PropertyFilter filter : filters) {
 			MenuItem item = new MenuItem(m_propertiesFilterMenu, SWT.RADIO);
+			ImageDescriptor imageDescriptor = filter.getImage();
+			if (imageDescriptor != null) {
+				Image image = imageDescriptor.createImage();
+				item.addDisposeListener(event -> image.dispose());
+				item.setImage(image);
+			}
 			item.setText(filter.getName());
-			item.setImage(filter.getImage());
 			item.setData(filter);
 			item.addSelectionListener(listener);
 		}

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/filter/AllPropertiesFilter.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/filter/AllPropertiesFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,8 +12,8 @@ package org.eclipse.wb.internal.core.databinding.ui.filter;
 
 import org.eclipse.wb.internal.core.databinding.model.IObserveInfo;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.Viewer;
-import org.eclipse.swt.graphics.Image;
 
 /**
  * This filter accept any property.
@@ -27,7 +27,7 @@ public final class AllPropertiesFilter extends PropertyFilter {
 	// Constructor
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public AllPropertiesFilter(String name, Image image) {
+	public AllPropertiesFilter(String name, ImageDescriptor image) {
 		super(name, image);
 	}
 

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/filter/PropertyFilter.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/filter/PropertyFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,8 +12,8 @@ package org.eclipse.wb.internal.core.databinding.ui.filter;
 
 import org.eclipse.wb.internal.core.databinding.model.IObserveInfo;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.Viewer;
-import org.eclipse.swt.graphics.Image;
 
 /**
  * Filter for {@link IObserveInfo} properties.
@@ -23,14 +23,14 @@ import org.eclipse.swt.graphics.Image;
  */
 public abstract class PropertyFilter {
 	private final String m_name;
-	private final Image m_image;
+	private final ImageDescriptor m_image;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Constructor
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public PropertyFilter(String name, Image image) {
+	public PropertyFilter(String name, ImageDescriptor image) {
 		m_name = name;
 		m_image = image;
 	}
@@ -50,7 +50,7 @@ public abstract class PropertyFilter {
 	/**
 	 * @return the image to display for user.
 	 */
-	public final Image getImage() {
+	public final ImageDescriptor getImage() {
 		return m_image;
 	}
 

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/filter/TypesPropertyFilter.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/filter/TypesPropertyFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,7 @@ package org.eclipse.wb.internal.core.databinding.ui.filter;
 
 import org.eclipse.wb.internal.core.databinding.model.IObserveInfo;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import org.apache.commons.lang.ArrayUtils;
 
@@ -30,7 +30,7 @@ public abstract class TypesPropertyFilter extends PropertyFilter {
 	// Constructor
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public TypesPropertyFilter(String name, Image image, Class<?>... types) {
+	public TypesPropertyFilter(String name, ImageDescriptor image, Class<?>... types) {
 		super(name, image);
 		m_types = types;
 	}

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/PropertyBindableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/PropertyBindableInfo.java
@@ -19,8 +19,8 @@ import org.eclipse.wb.internal.core.databinding.model.reference.StringReferenceP
 import org.eclipse.wb.internal.rcp.databinding.model.IObservableFactory;
 import org.eclipse.wb.internal.rcp.databinding.ui.providers.TypeImageProvider;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.IDecoration;
-import org.eclipse.swt.graphics.Image;
 
 /**
  * Abstract model for <code>Java Beans</code> object properties.
@@ -46,7 +46,7 @@ public abstract class PropertyBindableInfo extends BeanBindableInfo implements I
 	public PropertyBindableInfo(BeanSupport beanSupport,
 			IObserveInfo parent,
 			String text,
-			Image image,
+			ImageDescriptor image,
 			Class<?> objectType,
 			IReferenceProvider referenceProvider) {
 		this(beanSupport, parent, objectType, referenceProvider, new SimpleObservePresentation(text,
@@ -56,7 +56,7 @@ public abstract class PropertyBindableInfo extends BeanBindableInfo implements I
 	public PropertyBindableInfo(BeanSupport beanSupport,
 			IObserveInfo parent,
 			String text,
-			Image image,
+			ImageDescriptor image,
 			Class<?> objectType,
 			String reference) {
 		this(beanSupport, parent, text, image, objectType, new StringReferenceProvider(reference));

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/ViewerObservablePropertyBindableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/ViewerObservablePropertyBindableInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,7 @@ import org.eclipse.wb.internal.core.databinding.model.IObserveInfo;
 import org.eclipse.wb.internal.core.databinding.ui.decorate.IObserveDecorator;
 import org.eclipse.wb.internal.rcp.databinding.model.IObservableFactory;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.util.Collections;
 import java.util.List;
@@ -39,7 +39,7 @@ public final class ViewerObservablePropertyBindableInfo extends PropertyBindable
 	public ViewerObservablePropertyBindableInfo(BeanSupport beanSupport,
 			IObserveInfo parent,
 			String text,
-			Image image,
+			ImageDescriptor image,
 			Class<?> objectType,
 			String reference,
 			IObservableFactory factory,

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/bindables/WidgetPropertyBindableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/bindables/WidgetPropertyBindableInfo.java
@@ -22,8 +22,8 @@ import org.eclipse.wb.internal.rcp.databinding.model.BindableInfo;
 import org.eclipse.wb.internal.rcp.databinding.model.IObservableFactory;
 import org.eclipse.wb.internal.rcp.databinding.ui.providers.TypeImageProvider;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.IDecoration;
-import org.eclipse.swt.graphics.Image;
 
 import java.util.Collections;
 import java.util.List;
@@ -57,7 +57,7 @@ public final class WidgetPropertyBindableInfo extends BindableInfo implements IO
 	}
 
 	public WidgetPropertyBindableInfo(String text,
-			Image image,
+			ImageDescriptor image,
 			Class<?> objectType,
 			String reference,
 			IObservableFactory observableFactory,

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/contentproviders/TreeContentLabelProvidersUiContentProvider.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/contentproviders/TreeContentLabelProvidersUiContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,6 +25,9 @@ import org.eclipse.wb.internal.rcp.databinding.model.widgets.input.designer.Tree
 import org.eclipse.wb.internal.rcp.databinding.model.widgets.input.designer.TreeObservableLabelProviderInfo;
 import org.eclipse.wb.internal.rcp.databinding.ui.providers.TypeImageProvider;
 
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.resource.LocalResourceManager;
+import org.eclipse.jface.resource.ResourceManager;
 import org.eclipse.jface.viewers.CheckStateChangedEvent;
 import org.eclipse.jface.viewers.CheckboxTreeViewer;
 import org.eclipse.jface.viewers.ICheckStateListener;
@@ -406,6 +409,8 @@ public final class TreeContentLabelProvidersUiContentProvider implements IUiCont
 	 * Tree label provider.
 	 */
 	private static class TreePropertiesLabelProvider extends LabelProvider {
+		private final ResourceManager m_resourceManager = new LocalResourceManager(JFaceResources.getResources());
+
 		@Override
 		public String getText(Object element) {
 			if (element instanceof PropertiesGroup) {
@@ -420,11 +425,17 @@ public final class TreeContentLabelProvidersUiContentProvider implements IUiCont
 		@Override
 		public Image getImage(Object element) {
 			if (element instanceof PropertiesGroup) {
-				return TypeImageProvider.OBJECT_IMAGE;
+				return m_resourceManager.createImageWithDefault(TypeImageProvider.OBJECT_IMAGE);
 			}
 			//
 			TreePropertyWrapper wrapper = (TreePropertyWrapper) element;
-			return TypeImageProvider.getImage(wrapper.descriptor.getPropertyType());
+			return m_resourceManager.createImageWithDefault(TypeImageProvider.getImage(wrapper.descriptor.getPropertyType()));
+		}
+
+		@Override
+		public void dispose() {
+			super.dispose();
+			m_resourceManager.dispose();
 		}
 	}
 	/**

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/filter/AdvancedPropertyFilter.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/filter/AdvancedPropertyFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -32,7 +32,7 @@ public final class AdvancedPropertyFilter extends PropertyFilter {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	public AdvancedPropertyFilter() {
-		super(Messages.AdvancedPropertyFilter_title, Activator.getImage("advanced.png"));
+		super(Messages.AdvancedPropertyFilter_title, Activator.getImageDescriptor("advanced.png"));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/filter/TypesPropertyFilter.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/filter/TypesPropertyFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,8 +13,8 @@ package org.eclipse.wb.internal.rcp.databinding.ui.filter;
 import org.eclipse.wb.internal.core.databinding.model.IObserveInfo;
 import org.eclipse.wb.internal.rcp.databinding.model.BindableInfo;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.Viewer;
-import org.eclipse.swt.graphics.Image;
 
 /**
  * Filter for {@link BindableInfo} properties over {@link Class} type.
@@ -30,7 +30,7 @@ org.eclipse.wb.internal.core.databinding.ui.filter.TypesPropertyFilter {
 	// Constructor
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public TypesPropertyFilter(String name, Image image, Class<?>... types) {
+	public TypesPropertyFilter(String name, ImageDescriptor image, Class<?>... types) {
 		super(name, image, types);
 	}
 

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/providers/BindingLabelProvider.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/providers/BindingLabelProvider.java
@@ -12,7 +12,6 @@ package org.eclipse.wb.internal.rcp.databinding.ui.providers;
 
 import org.eclipse.wb.internal.core.databinding.model.IBindingInfo;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.rcp.databinding.Activator;
 import org.eclipse.wb.internal.rcp.databinding.model.ObservableInfo;
 import org.eclipse.wb.internal.rcp.databinding.model.beans.observables.DetailBeanObservableInfo;
@@ -134,7 +133,7 @@ public final class BindingLabelProvider extends LabelProvider implements ITableL
 		} else if (element instanceof SetBindingInfo) {
 			imageDescriptor = BIND_SET_IMAGE;
 		} else if (element instanceof AbstractViewerInputBindingInfo) {
-			imageDescriptor = new ImageImageDescriptor(TypeImageProvider.VIEWER_IMAGE);
+			imageDescriptor = TypeImageProvider.VIEWER_IMAGE;
 		} else {
 			return null;
 		}

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/providers/PropertyAdapterLabelProvider.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/providers/PropertyAdapterLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,9 @@ package org.eclipse.wb.internal.rcp.databinding.ui.providers;
 
 import org.eclipse.wb.internal.core.databinding.ui.editor.contentproviders.PropertyAdapter;
 
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.resource.LocalResourceManager;
+import org.eclipse.jface.resource.ResourceManager;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.swt.graphics.Image;
 
@@ -22,6 +25,8 @@ import org.eclipse.swt.graphics.Image;
  * @coverage bindings.rcp.ui
  */
 public final class PropertyAdapterLabelProvider extends LabelProvider {
+	private final ResourceManager m_resourceManager = new LocalResourceManager(JFaceResources.getResources());
+
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// LabelProvider
@@ -36,6 +41,12 @@ public final class PropertyAdapterLabelProvider extends LabelProvider {
 	@Override
 	public Image getImage(Object element) {
 		PropertyAdapter adapter = (PropertyAdapter) element;
-		return TypeImageProvider.getImage(adapter.getType());
+		return m_resourceManager.createImageWithDefault(TypeImageProvider.getImage(adapter.getType()));
+	}
+
+	@Override
+	public void dispose() {
+		super.dispose();
+		m_resourceManager.dispose();
 	}
 }

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/providers/TypeImageProvider.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/providers/TypeImageProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@ package org.eclipse.wb.internal.rcp.databinding.ui.providers;
 
 import org.eclipse.wb.internal.rcp.databinding.Activator;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Image;
@@ -19,26 +20,26 @@ import org.eclipse.swt.graphics.Image;
 import java.util.Collection;
 
 /**
- * Helper for association {@link Class} with {@link Image}.
+ * Helper for association {@link Class} with {@link ImageDescriptor}.
  *
  * @author lobas_av
  * @coverage bindings.rcp.ui
  */
 public final class TypeImageProvider {
-	public static final Image OBJECT_IMAGE = Activator.getImage("types/Object2.png");
-	public static final Image VIEWER_IMAGE = Activator.getImage("types/viewer.png");
-	public static final Image VIEWER_COLLECTION_IMAGE =
-			Activator.getImage("types/viewer_collection.png");
-	public static final Image STRING_IMAGE = Activator.getImage("types/String2.png");
-	public static final Image BOOLEAN_IMAGE = Activator.getImage("types/Boolean4.png");
-	public static final Image NUMBER_IMAGE = Activator.getImage("types/Number2.png");
-	public static final Image IMAGE_IMAGE = Activator.getImage("types/Image2.png");
-	public static final Image COLOR_IMAGE = Activator.getImage("types/Color2.png");
-	public static final Image FONT_IMAGE = Activator.getImage("types/Font2.png");
-	public static final Image ARRAY_IMAGE = Activator.getImage("types/Array.png");
-	public static final Image COLLECTION_IMAGE = Activator.getImage("types/Collection.png");
-	public static final Image DIRECT_IMAGE = Activator.getImage("types/Direct.png");
-	public static final Image METHOD_IMAGE = Activator.getImage("method.png");
+	public static final ImageDescriptor OBJECT_IMAGE = Activator.getImageDescriptor("types/Object2.png");
+	public static final ImageDescriptor VIEWER_IMAGE = Activator.getImageDescriptor("types/viewer.png");
+	public static final ImageDescriptor VIEWER_COLLECTION_IMAGE =
+			Activator.getImageDescriptor("types/viewer_collection.png");
+	public static final ImageDescriptor STRING_IMAGE = Activator.getImageDescriptor("types/String2.png");
+	public static final ImageDescriptor BOOLEAN_IMAGE = Activator.getImageDescriptor("types/Boolean4.png");
+	public static final ImageDescriptor NUMBER_IMAGE = Activator.getImageDescriptor("types/Number2.png");
+	public static final ImageDescriptor IMAGE_IMAGE = Activator.getImageDescriptor("types/Image2.png");
+	public static final ImageDescriptor COLOR_IMAGE = Activator.getImageDescriptor("types/Color2.png");
+	public static final ImageDescriptor FONT_IMAGE = Activator.getImageDescriptor("types/Font2.png");
+	public static final ImageDescriptor ARRAY_IMAGE = Activator.getImageDescriptor("types/Array.png");
+	public static final ImageDescriptor COLLECTION_IMAGE = Activator.getImageDescriptor("types/Collection.png");
+	public static final ImageDescriptor DIRECT_IMAGE = Activator.getImageDescriptor("types/Direct.png");
+	public static final ImageDescriptor METHOD_IMAGE = Activator.getImageDescriptor("method.png");
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -46,9 +47,9 @@ public final class TypeImageProvider {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * @return {@link Image} association with given {@link Class}.
+	 * @return {@link ImageDescriptor} association with given {@link Class}.
 	 */
-	public static Image getImage(Class<?> type) {
+	public static ImageDescriptor getImage(Class<?> type) {
 		// unknown type accept as object
 		if (type == null) {
 			return OBJECT_IMAGE;

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/BeanPropertyObserveInfo.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/BeanPropertyObserveInfo.java
@@ -16,6 +16,7 @@ import org.eclipse.wb.internal.core.databinding.model.presentation.SimpleObserve
 import org.eclipse.wb.internal.core.databinding.model.reference.IReferenceProvider;
 import org.eclipse.wb.internal.core.databinding.ui.ObserveType;
 import org.eclipse.wb.internal.core.databinding.ui.decorate.IObserveDecorator;
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.swing.databinding.model.ObserveCreationType;
 import org.eclipse.wb.internal.swing.databinding.model.ObserveInfo;
 import org.eclipse.wb.internal.swing.databinding.model.generic.IGenericType;
@@ -23,8 +24,8 @@ import org.eclipse.wb.internal.swing.databinding.model.properties.BeanPropertyIn
 import org.eclipse.wb.internal.swing.databinding.model.properties.PropertyInfo;
 import org.eclipse.wb.internal.swing.databinding.ui.providers.TypeImageProvider;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.IDecoration;
-import org.eclipse.swt.graphics.Image;
 
 /**
  * Model for <code>Java Beans</code> object properties.
@@ -57,7 +58,7 @@ public class BeanPropertyObserveInfo extends BeanObserveInfo implements IObserve
 				java.util.List.class.isAssignableFrom(getObjectClass())
 				? ObserveCreationType.ListProperty
 						: ObserveCreationType.AnyProperty;
-		Image beenImage = beanSupport.getBeanImage(getObjectClass(), null, false);
+		ImageDescriptor beenImage = new ImageImageDescriptor(beanSupport.getBeanImage(getObjectClass(), null, false));
 		m_presentation =
 				new SimpleObservePresentation(text, text, beenImage == null
 				? TypeImageProvider.getImage(getObjectClass())

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/LocalVariableObserveInfo.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/LocalVariableObserveInfo.java
@@ -41,7 +41,7 @@ public final class LocalVariableObserveInfo extends BeanObserveInfo {
 		setBindingDecoration(IDecoration.TOP_LEFT);
 		m_fragment = fragment;
 		m_presentation =
-				new SimpleObservePresentation(null, null, Activator.getImage("localvariable_obj.gif")) {
+				new SimpleObservePresentation(null, null, Activator.getImageDescriptor("localvariable_obj.gif")) {
 			@Override
 			public String getText() throws Exception {
 				return getReference() + " - " + getObjectType().getSimpleTypeName();

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/VirtualObserveInfo.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/VirtualObserveInfo.java
@@ -38,7 +38,7 @@ public final class VirtualObserveInfo extends BeanObserveInfo {
 		super(null, null, ClassGenericType.LIST_CLASS, StringReferenceProvider.EMPTY);
 		setBindingDecoration(IDecoration.TOP_LEFT);
 		m_presentation =
-				new SimpleObservePresentation("[Virtual]", "[Virtual]", Activator.getImage("virtual.png"));
+				new SimpleObservePresentation("[Virtual]", "[Virtual]", Activator.getImageDescriptor("virtual.png"));
 		setProperties(ImmutableList.<ObserveInfo>of(new ObjectPropertyObserveInfo(getObjectType())));
 	}
 

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/filters/HideAdvancedPropertyFilter.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/filters/HideAdvancedPropertyFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -32,7 +32,7 @@ public final class HideAdvancedPropertyFilter extends PropertyFilter {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	public HideAdvancedPropertyFilter() {
-		super(Messages.HideAdvancedPropertyFilter_title, Activator.getImage("hide_advanced.png"));
+		super(Messages.HideAdvancedPropertyFilter_title, Activator.getImageDescriptor("hide_advanced.png"));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/filters/ShowAdvancedPropertyFilter.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/filters/ShowAdvancedPropertyFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -32,7 +32,7 @@ public final class ShowAdvancedPropertyFilter extends PropertyFilter {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	public ShowAdvancedPropertyFilter() {
-		super(Messages.ShowAdvancedPropertyFilter_title, Activator.getImage("show_advanced.png"));
+		super(Messages.ShowAdvancedPropertyFilter_title, Activator.getImageDescriptor("show_advanced.png"));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/filters/TypesPropertyFilter.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/filters/TypesPropertyFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,8 +16,8 @@ import org.eclipse.wb.internal.swing.databinding.model.beans.BeanPropertyObserve
 import org.eclipse.wb.internal.swing.databinding.model.beans.ElPropertyObserveInfo;
 import org.eclipse.wb.internal.swing.databinding.model.beans.ObjectPropertyObserveInfo;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.Viewer;
-import org.eclipse.swt.graphics.Image;
 
 /**
  * Filter for {@link ObserveInfo} properties over {@link Class} type.
@@ -33,7 +33,7 @@ org.eclipse.wb.internal.core.databinding.ui.filter.TypesPropertyFilter {
 	// Constructor
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public TypesPropertyFilter(String name, Image image, Class<?>... types) {
+	public TypesPropertyFilter(String name, ImageDescriptor image, Class<?>... types) {
 		super(name, image, types);
 	}
 

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/providers/TypeImageProvider.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/providers/TypeImageProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,28 +12,28 @@ package org.eclipse.wb.internal.swing.databinding.ui.providers;
 
 import org.eclipse.wb.internal.swing.databinding.Activator;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.util.Collection;
 
 /**
- * Helper for association {@link Class} with {@link Image}.
+ * Helper for association {@link Class} with {@link ImageDescriptor}.
  *
  * @author lobas_av
  * @coverage bindings.swing.ui
  */
 public final class TypeImageProvider {
-	public static final Image OBJECT_IMAGE = Activator.getImage("types/Object.png");
-	public static final Image STRING_IMAGE = Activator.getImage("types/String.png");
-	public static final Image BOOLEAN_IMAGE = Activator.getImage("types/Boolean.png");
-	public static final Image NUMBER_IMAGE = Activator.getImage("types/Number.png");
-	public static final Image IMAGE_IMAGE = Activator.getImage("types/Image.png");
-	public static final Image COLOR_IMAGE = Activator.getImage("types/Color.png");
-	public static final Image FONT_IMAGE = Activator.getImage("types/Font.png");
-	public static final Image ARRAY_IMAGE = Activator.getImage("types/Array.png");
-	public static final Image COLLECTION_IMAGE = Activator.getImage("types/Collection.png");
-	public static final Image EL_PROPERTY_IMAGE = Activator.getImage("el_property2.gif");
-	public static final Image OBJECT_PROPERTY_IMAGE = Activator.getImage("SelfObject.png");
+	public static final ImageDescriptor OBJECT_IMAGE = Activator.getImageDescriptor("types/Object.png");
+	public static final ImageDescriptor STRING_IMAGE = Activator.getImageDescriptor("types/String.png");
+	public static final ImageDescriptor BOOLEAN_IMAGE = Activator.getImageDescriptor("types/Boolean.png");
+	public static final ImageDescriptor NUMBER_IMAGE = Activator.getImageDescriptor("types/Number.png");
+	public static final ImageDescriptor IMAGE_IMAGE = Activator.getImageDescriptor("types/Image.png");
+	public static final ImageDescriptor COLOR_IMAGE = Activator.getImageDescriptor("types/Color.png");
+	public static final ImageDescriptor FONT_IMAGE = Activator.getImageDescriptor("types/Font.png");
+	public static final ImageDescriptor ARRAY_IMAGE = Activator.getImageDescriptor("types/Array.png");
+	public static final ImageDescriptor COLLECTION_IMAGE = Activator.getImageDescriptor("types/Collection.png");
+	public static final ImageDescriptor EL_PROPERTY_IMAGE = Activator.getImageDescriptor("el_property2.gif");
+	public static final ImageDescriptor OBJECT_PROPERTY_IMAGE = Activator.getImageDescriptor("SelfObject.png");
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -41,9 +41,9 @@ public final class TypeImageProvider {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * @return {@link Image} association with given {@link Class}.
+	 * @return {@link ImageDescriptor} association with given {@link Class}.
 	 */
-	public static Image getImage(Class<?> type) {
+	public static ImageDescriptor getImage(Class<?> type) {
 		// unknown type accept as object
 		if (type == null) {
 			return OBJECT_IMAGE;


### PR DESCRIPTION
The images stored by the TypeImageProvider have been changed from raw images to image-descriptors. The signatures of all classes referencing this provider have been adjusted to also use the descriptor, when possible.
When an instance of the image needs to be created, resource managers are used as much as possible. This should move the responsibility for disposing the images to the class that creates it and thus reduce the chance of unintentional memory leaks.