### PR TITLE
Store visuals of bean components as image descriptors instead of images

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/part/nonvisual/BeanFigure.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/part/nonvisual/BeanFigure.java
@@ -11,7 +11,6 @@
 package org.eclipse.wb.internal.core.gef.part.nonvisual;
 
 import org.eclipse.wb.draw2d.Figure;
-import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.draw2d.Label;
 
 import org.eclipse.draw2d.Graphics;
@@ -39,10 +38,6 @@ public class BeanFigure extends Figure {
 	// Constructor
 	//
 	////////////////////////////////////////////////////////////////////////////
-	@Deprecated
-	public BeanFigure(Image image) {
-		this(new ImageImageDescriptor(image));
-	}
 
 	public BeanFigure(ImageDescriptor imageDescriptor) {
 		final ImageData imageData = imageDescriptor.getImageData(100);

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/BeanPropertyObserveInfo.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/BeanPropertyObserveInfo.java
@@ -16,7 +16,6 @@ import org.eclipse.wb.internal.core.databinding.model.presentation.SimpleObserve
 import org.eclipse.wb.internal.core.databinding.model.reference.IReferenceProvider;
 import org.eclipse.wb.internal.core.databinding.ui.ObserveType;
 import org.eclipse.wb.internal.core.databinding.ui.decorate.IObserveDecorator;
-import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.swing.databinding.model.ObserveCreationType;
 import org.eclipse.wb.internal.swing.databinding.model.ObserveInfo;
 import org.eclipse.wb.internal.swing.databinding.model.generic.IGenericType;
@@ -58,7 +57,7 @@ public class BeanPropertyObserveInfo extends BeanObserveInfo implements IObserve
 				java.util.List.class.isAssignableFrom(getObjectClass())
 				? ObserveCreationType.ListProperty
 						: ObserveCreationType.AnyProperty;
-		ImageDescriptor beenImage = new ImageImageDescriptor(beanSupport.getBeanImage(getObjectClass(), null, false));
+		ImageDescriptor beenImage = beanSupport.getBeanImage(getObjectClass(), null, false);
 		m_presentation =
 				new SimpleObservePresentation(text, text, beenImage == null
 				? TypeImageProvider.getImage(getObjectClass())

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/BeanSupport.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/BeanSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,6 +21,7 @@ import org.eclipse.wb.internal.core.databinding.model.ObserveComparator;
 import org.eclipse.wb.internal.core.databinding.model.reference.StringReferenceProvider;
 import org.eclipse.wb.internal.core.databinding.ui.decorate.IObserveDecorator;
 import org.eclipse.wb.internal.core.databinding.utils.CoreUtils;
+import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.swing.databinding.Activator;
 import org.eclipse.wb.internal.swing.databinding.model.ObserveInfo;
 import org.eclipse.wb.internal.swing.databinding.model.bindings.BindingInfo;
@@ -31,7 +32,7 @@ import org.eclipse.wb.internal.swing.databinding.model.generic.GenericUtils;
 import org.eclipse.wb.internal.swing.databinding.model.generic.IGenericType;
 import org.eclipse.wb.internal.swing.utils.SwingImageUtils;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import org.apache.commons.lang.ClassUtils;
 
@@ -55,7 +56,7 @@ import java.util.Map;
  * @coverage bindings.swing.model.beans
  */
 public final class BeanSupport {
-	private final Map<Class<?>, Image> m_classToImage = Maps.newHashMap();
+	private final Map<Class<?>, ImageDescriptor> m_classToImage = Maps.newHashMap();
 	private boolean m_addELProperty = true;
 	private boolean m_addSelfProperty = true;
 
@@ -278,16 +279,16 @@ public final class BeanSupport {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * @return {@link Image} represented given bean class.
+	 * @return {@link ImageDescriptor} represented given bean class.
 	 */
-	public Image getBeanImage(Class<?> beanClass, JavaInfo javaInfo, boolean useDefault)
+	public ImageDescriptor getBeanImage(Class<?> beanClass, JavaInfo javaInfo, boolean useDefault)
 			throws Exception {
 		// check java info
 		if (javaInfo != null) {
 			return null;
 		}
 		// prepare cached image
-		Image beanImage = m_classToImage.get(beanClass);
+		ImageDescriptor beanImage = m_classToImage.get(beanClass);
 		// check load image
 		if (beanImage == null) {
 			try {
@@ -296,15 +297,15 @@ public final class BeanSupport {
 				java.awt.Image awtBeanIcon = beanInfo.getIcon(BeanInfo.ICON_COLOR_16x16);
 				if (awtBeanIcon == null) {
 					// set default
-					beanImage = useDefault ? Activator.getImage("javabean.gif") : null;
+					beanImage = useDefault ? Activator.getImageDescriptor("javabean.gif") : null;
 				} else {
 					// convert to SWT image
 					// FIXME: memory leak
-					beanImage = SwingImageUtils.convertImage_AWT_to_SWT(awtBeanIcon);
+					beanImage = new ImageImageDescriptor(SwingImageUtils.convertImage_AWT_to_SWT(awtBeanIcon));
 				}
 			} catch (Throwable e) {
 				// set default
-				beanImage = useDefault ? Activator.getImage("javabean.gif") : null;
+				beanImage = useDefault ? Activator.getImageDescriptor("javabean.gif") : null;
 			}
 			m_classToImage.put(beanClass, beanImage);
 		}

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/FieldBeanObservePresentation.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/FieldBeanObservePresentation.java
@@ -12,10 +12,8 @@ package org.eclipse.wb.internal.swing.databinding.model.beans;
 
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.databinding.model.presentation.ObservePresentation;
-import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.swt.graphics.Image;
 
 /**
  * Presentation for {@link FieldBeanObserveInfo}.
@@ -26,7 +24,7 @@ import org.eclipse.swt.graphics.Image;
 public final class FieldBeanObservePresentation extends ObservePresentation {
 	private final FieldBeanObserveInfo m_observe;
 	private final JavaInfo m_javaInfo;
-	private final Image m_beanImage;
+	private final ImageDescriptor m_beanImage;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -35,7 +33,7 @@ public final class FieldBeanObservePresentation extends ObservePresentation {
 	////////////////////////////////////////////////////////////////////////////
 	public FieldBeanObservePresentation(FieldBeanObserveInfo observe,
 			JavaInfo javaInfo,
-			Image beanImage) {
+			ImageDescriptor beanImage) {
 		m_observe = observe;
 		m_javaInfo = javaInfo;
 		m_beanImage = beanImage;
@@ -51,7 +49,7 @@ public final class FieldBeanObservePresentation extends ObservePresentation {
 		if (m_beanImage == null && m_javaInfo == null) {
 			return null;
 		}
-		return m_beanImage == null ? m_javaInfo.getPresentation().getIcon() : new ImageImageDescriptor(m_beanImage);
+		return m_beanImage == null ? m_javaInfo.getPresentation().getIcon() : m_beanImage;
 	}
 
 	////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
We already convert images to descriptors on-the-fly. This is just a cleanup task to avoid this unnecessary wrapping.