### PR TITLE
Adjust action-image/image provider to return ImageDescriptors

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/generic/AbstractPopupFigure.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/generic/AbstractPopupFigure.java
@@ -22,6 +22,7 @@ import org.eclipse.draw2d.MouseListener;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Control;
@@ -92,12 +93,14 @@ public abstract class AbstractPopupFigure extends Figure {
 		graphics.drawRectangle(clientArea.getResized(-1, -1));
 		// draw image
 		{
-			Image image = getImage();
-			if (image != null) {
+			ImageDescriptor imageDescriptor = getImage();
+			if (imageDescriptor != null) {
+				Image image = imageDescriptor.createImage();
 				org.eclipse.swt.graphics.Rectangle imageBounds = image.getBounds();
 				int x = (clientArea.width - imageBounds.width) / 2;
 				int y = (clientArea.height - imageBounds.height) / 2;
 				graphics.drawImage(image, x, y);
+				image.dispose();
 			}
 		}
 	}
@@ -110,7 +113,7 @@ public abstract class AbstractPopupFigure extends Figure {
 	/**
 	 * @return the image to display.
 	 */
-	protected abstract Image getImage();
+	protected abstract ImageDescriptor getImage();
 
 	/**
 	 * Creates the actions on given {@link IMenuManager}.

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/AbsoluteComplexSelectionEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/AbsoluteComplexSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -38,8 +38,8 @@ import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.draw2d.geometry.Transposer;
 import org.eclipse.jface.action.IMenuManager;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Image;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -363,7 +363,7 @@ AbsoluteBasedSelectionEditPolicy<C> implements IActionImageProvider {
 		}
 
 		@Override
-		protected Image getImage() {
+		protected ImageDescriptor getImage() {
 			boolean isLeftAttached = isAttached(m_widget, IPositionConstants.LEFT);
 			boolean isRightAttached = isAttached(m_widget, IPositionConstants.RIGHT);
 			if (isLeftAttached && isRightAttached) {
@@ -392,7 +392,7 @@ AbsoluteBasedSelectionEditPolicy<C> implements IActionImageProvider {
 		}
 
 		@Override
-		protected Image getImage() {
+		protected ImageDescriptor getImage() {
 			boolean isTopAttached = isAttached(m_widget, IPositionConstants.TOP);
 			boolean isBottomAttached = isAttached(m_widget, IPositionConstants.BOTTOM);
 			if (isTopAttached && isBottomAttached) {

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/actions/IActionImageProvider.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/actions/IActionImageProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.gef.policy.layout.absolute.actions;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * Helper interface to provide the image for action.
@@ -18,5 +18,5 @@ import org.eclipse.swt.graphics.Image;
  * @author mitin_aa
  */
 public interface IActionImageProvider {
-	Image getActionImage(String imagePath);
+	ImageDescriptor getActionImage(String imagePath);
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/layout/absolute/IImageProvider.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/layout/absolute/IImageProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.layout.absolute;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * Interface which provides the image by relative path. See the all of the our Activator instances.
@@ -21,5 +21,5 @@ public interface IImageProvider {
 	/**
 	 * @return the Image instance by given path.
 	 */
-	Image getImage(String path);
+	ImageDescriptor getImage(String path);
 }

--- a/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/gef/GroupSelectionEditPolicy2.java
+++ b/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/gef/GroupSelectionEditPolicy2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -45,7 +45,7 @@ import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.draw2d.geometry.Translatable;
 import org.eclipse.jface.action.IMenuManager;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import org.netbeans.modules.form.layoutdesign.LayoutConstants;
 import org.netbeans.modules.form.layoutdesign.LayoutDesigner;
@@ -412,7 +412,7 @@ LayoutConstants {
 		}
 
 		@Override
-		protected Image getImage() {
+		protected ImageDescriptor getImage() {
 			int anchors = m_anchorsSupport.getCurrentAnchors(m_component, true);
 			IImageProvider imageProvider = getImageProvider();
 			switch (anchors) {
@@ -441,7 +441,7 @@ LayoutConstants {
 		}
 
 		@Override
-		protected Image getImage() {
+		protected ImageDescriptor getImage() {
 			int anchors = m_anchorsSupport.getCurrentAnchors(m_component, false);
 			IImageProvider imageProvider = getImageProvider();
 			switch (anchors) {

--- a/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/model/AnchorsSupport.java
+++ b/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/model/AnchorsSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,6 @@ import org.eclipse.wb.core.editor.IContextMenuConstants;
 import org.eclipse.wb.core.model.AbstractComponentInfo;
 import org.eclipse.wb.internal.core.model.layout.absolute.IImageProvider;
 import org.eclipse.wb.internal.core.model.util.ObjectInfoAction;
-import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.layout.group.Messages;
 
 import org.eclipse.jface.action.IContributionManager;
@@ -261,8 +260,7 @@ public final class AnchorsSupport implements LayoutConstants {
 				int alignment) {
 			super(component,
 					text,
-					new ImageImageDescriptor(
-							getImageProvider().getImage("info/layout/groupLayout/" + imageName)),
+					getImageProvider().getImage("info/layout/groupLayout/" + imageName),
 					AS_CHECK_BOX);
 			m_isHorizontal = isHorizontal;
 			m_component = component;
@@ -293,8 +291,7 @@ public final class AnchorsSupport implements LayoutConstants {
 				boolean isHorizontal) {
 			super(component,
 					Messages.AnchorsSupport_autoResizable,
-					new ImageImageDescriptor(
-							getImageProvider().getImage("info/layout/groupLayout/" + imageName)),
+					getImageProvider().getImage("info/layout/groupLayout/" + imageName),
 					AS_CHECK_BOX);
 			m_component = component;
 			m_isHorizontal = isHorizontal;
@@ -325,8 +322,7 @@ public final class AnchorsSupport implements LayoutConstants {
 					isHorizontal
 					? Messages.AnchorsSupport_resizableHorizontal
 							: Messages.AnchorsSupport_resizableVertical,
-							new ImageImageDescriptor(
-									getImageProvider().getImage("info/layout/groupLayout/" + imageName)),
+							getImageProvider().getImage("info/layout/groupLayout/" + imageName),
 							AS_CHECK_BOX);
 			m_component = component;
 			m_isHorizontal = isHorizontal;

--- a/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/model/assistant/GroupLayoutSpacesPage.java
+++ b/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/model/assistant/GroupLayoutSpacesPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -31,6 +31,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
@@ -139,8 +140,11 @@ LayoutConstants {
 	private Control createClearButton(Composite parent, SelectionListener selectionListener) {
 		ToolBar toolBar = new ToolBar(parent, SWT.FLAT | SWT.RIGHT);
 		ToolItem toolItem = new ToolItem(toolBar, SWT.NONE);
-		toolItem.setImage(m_layout.getAdapter(IImageProvider.class).getImage(
-				"info/layout/groupLayout/clear.gif"));
+		Image image = m_layout.getAdapter(IImageProvider.class) //
+				.getImage("info/layout/groupLayout/clear.gif") //
+				.createImage();
+		toolItem.addDisposeListener(event -> image.dispose());
+		toolItem.setImage(image);
 		toolItem.setToolTipText(Messages.GroupLayoutSpacesPage_setDefaultSize);
 		toolItem.addSelectionListener(selectionListener);
 		return toolBar;

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/TableWrapSelectionEditPolicy.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/TableWrapSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,7 +33,7 @@ import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.jface.action.IMenuManager;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.ui.forms.widgets.TableWrapData;
 
 import java.util.List;
@@ -121,7 +121,7 @@ AbstractGridSelectionEditPolicy {
 			if (horizontal) {
 				return new AbstractPopupFigure(viewer, 9, 5) {
 					@Override
-					protected Image getImage() {
+					protected ImageDescriptor getImage() {
 						return layoutData.getSmallAlignmentImage(true);
 					}
 
@@ -133,7 +133,7 @@ AbstractGridSelectionEditPolicy {
 			} else {
 				return new AbstractPopupFigure(viewer, 5, 9) {
 					@Override
-					protected Image getImage() {
+					protected ImageDescriptor getImage() {
 						return layoutData.getSmallAlignmentImage(false);
 					}
 

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/forms/layout/table/ITableWrapDataInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/forms/layout/table/ITableWrapDataInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,7 @@ import org.eclipse.wb.internal.swt.model.layout.ILayoutDataInfo;
 
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuManager;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.ui.forms.widgets.TableWrapData;
 
 /**
@@ -130,9 +130,10 @@ public interface ITableWrapDataInfo extends ILayoutDataInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * @return the small {@link Image} that represents horizontal/vertical alignment.
+	 * @return the small {@link ImageDescriptor} that represents horizontal/vertical
+	 *         alignment.
 	 */
-	Image getSmallAlignmentImage(boolean horizontal);
+	ImageDescriptor getSmallAlignmentImage(boolean horizontal);
 
 	/**
 	 * Adds the horizontal alignment {@link Action}'s.

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/forms/layout/table/TableWrapDataInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/forms/layout/table/TableWrapDataInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,7 +33,7 @@ import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.action.Separator;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.ui.forms.widgets.TableWrapData;
 
 import java.util.List;
@@ -445,30 +445,30 @@ public final class TableWrapDataInfo extends LayoutDataInfo implements ITableWra
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getSmallAlignmentImage(boolean horizontal) {
+	public ImageDescriptor getSmallAlignmentImage(boolean horizontal) {
 		if (horizontal) {
 			switch (horizontalAlignment) {
 			case TableWrapData.LEFT :
-				return TableWrapLayoutImages.getImage("h/left.gif");
+				return TableWrapLayoutImages.getImageDescriptor("h/left.gif");
 			case TableWrapData.CENTER :
-				return TableWrapLayoutImages.getImage("h/center.gif");
+				return TableWrapLayoutImages.getImageDescriptor("h/center.gif");
 			case TableWrapData.RIGHT :
-				return TableWrapLayoutImages.getImage("h/right.gif");
+				return TableWrapLayoutImages.getImageDescriptor("h/right.gif");
 			default :
 				Assert.isTrue(horizontalAlignment == TableWrapData.FILL);
-				return TableWrapLayoutImages.getImage("h/fill.gif");
+				return TableWrapLayoutImages.getImageDescriptor("h/fill.gif");
 			}
 		} else {
 			switch (verticalAlignment) {
 			case TableWrapData.TOP :
-				return TableWrapLayoutImages.getImage("v/top.gif");
+				return TableWrapLayoutImages.getImageDescriptor("v/top.gif");
 			case TableWrapData.MIDDLE :
-				return TableWrapLayoutImages.getImage("v/middle.gif");
+				return TableWrapLayoutImages.getImageDescriptor("v/middle.gif");
 			case TableWrapData.BOTTOM :
-				return TableWrapLayoutImages.getImage("v/bottom.gif");
+				return TableWrapLayoutImages.getImageDescriptor("v/bottom.gif");
 			default :
 				Assert.isTrue(verticalAlignment == TableWrapData.FILL);
-				return TableWrapLayoutImages.getImage("v/fill.gif");
+				return TableWrapLayoutImages.getImageDescriptor("v/fill.gif");
 			}
 		}
 	}

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/FormSelectionEditPolicy.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/FormSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,7 +33,7 @@ import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.jface.action.IMenuManager;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import com.jgoodies.forms.layout.CellConstraints;
 import com.jgoodies.forms.layout.CellConstraints.Alignment;
@@ -118,7 +118,7 @@ public final class FormSelectionEditPolicy extends AbstractGridSelectionEditPoli
 		if (horizontal) {
 			return new AbstractPopupFigure(viewer, 9, 5) {
 				@Override
-				protected Image getImage() {
+				protected ImageDescriptor getImage() {
 					return constraints.getSmallAlignmentImage(true);
 				}
 
@@ -130,7 +130,7 @@ public final class FormSelectionEditPolicy extends AbstractGridSelectionEditPoli
 		} else {
 			return new AbstractPopupFigure(viewer, 5, 9) {
 				@Override
-				protected Image getImage() {
+				protected ImageDescriptor getImage() {
 					return constraints.getSmallAlignmentImage(false);
 				}
 

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/model/CellConstraintsSupport.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/model/CellConstraintsSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -31,6 +31,7 @@ import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
 
 import com.jgoodies.forms.layout.CellConstraints;
@@ -524,28 +525,28 @@ public final class CellConstraintsSupport {
 	/**
 	 * @return the small {@link Image} that represents horizontal/vertical alignment.
 	 */
-	public Image getSmallAlignmentImage(boolean horizontal) {
+	public ImageDescriptor getSmallAlignmentImage(boolean horizontal) {
 		if (horizontal) {
 			if (alignH == CellConstraints.LEFT) {
-				return Activator.getImage("alignment/h/left.gif");
+				return Activator.getImageDescriptor("alignment/h/left.gif");
 			} else if (alignH == CellConstraints.CENTER) {
-				return Activator.getImage("alignment/h/center.gif");
+				return Activator.getImageDescriptor("alignment/h/center.gif");
 			} else if (alignH == CellConstraints.RIGHT) {
-				return Activator.getImage("alignment/h/right.gif");
+				return Activator.getImageDescriptor("alignment/h/right.gif");
 			} else if (alignH == CellConstraints.FILL) {
-				return Activator.getImage("alignment/h/fill.gif");
+				return Activator.getImageDescriptor("alignment/h/fill.gif");
 			} else {
 				return null;
 			}
 		} else {
 			if (alignV == CellConstraints.TOP) {
-				return Activator.getImage("alignment/v/top.gif");
+				return Activator.getImageDescriptor("alignment/v/top.gif");
 			} else if (alignV == CellConstraints.CENTER) {
-				return Activator.getImage("alignment/v/center.gif");
+				return Activator.getImageDescriptor("alignment/v/center.gif");
 			} else if (alignV == CellConstraints.BOTTOM) {
-				return Activator.getImage("alignment/v/bottom.gif");
+				return Activator.getImageDescriptor("alignment/v/bottom.gif");
 			} else if (alignV == CellConstraints.FILL) {
-				return Activator.getImage("alignment/v/fill.gif");
+				return Activator.getImageDescriptor("alignment/v/fill.gif");
 			} else {
 				return null;
 			}

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/MigSelectionEditPolicy.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/MigSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,7 +35,7 @@ import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.jface.action.IMenuManager;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.util.List;
 
@@ -117,7 +117,7 @@ public final class MigSelectionEditPolicy extends AbstractGridSelectionEditPolic
 		if (horizontal) {
 			return new AbstractPopupFigure(viewer, 9, 5) {
 				@Override
-				protected Image getImage() {
+				protected ImageDescriptor getImage() {
 					return constraints.getSmallAlignmentImage(true);
 				}
 
@@ -129,7 +129,7 @@ public final class MigSelectionEditPolicy extends AbstractGridSelectionEditPolic
 		} else {
 			return new AbstractPopupFigure(viewer, 5, 9) {
 				@Override
-				protected Image getImage() {
+				protected ImageDescriptor getImage() {
 					return constraints.getSmallAlignmentImage(false);
 				}
 

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/edit/ColumnHeaderEditPart.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/edit/ColumnHeaderEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -97,9 +97,10 @@ public class ColumnHeaderEditPart extends DimensionHeaderEditPart<MigColumnInfo>
 				}
 				// draw alignment indicator
 				if (titleLeft - r.x > 3 + 7 + 3) {
-					Image image = m_column.getAlignment(true).getSmallImage();
+					Image image = m_column.getAlignment(true).getSmallImage().createImage();
 					int x = r.x + 2;
 					drawCentered(graphics, image, x);
+					image.dispose();
 				}
 				// draw grow indicator
 				if (m_column.hasGrow()) {

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/edit/RowHeaderEditPart.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/edit/RowHeaderEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -97,9 +97,10 @@ public class RowHeaderEditPart extends DimensionHeaderEditPart<MigRowInfo> {
 				}
 				// draw alignment indicator
 				if (titleTop - r.y > 3 + 7 + 3) {
-					Image image = m_row.getAlignment(true).getSmallImage();
+					Image image = m_row.getAlignment(true).getSmallImage().createImage();
 					int y = r.y + 2;
 					drawCentered(graphics, image, y);
+					image.dispose();
 				}
 				// draw grow indicator
 				if (m_dimension.hasGrow()) {

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/CellConstraintsSupport.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/CellConstraintsSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -36,7 +36,7 @@ import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import net.miginfocom.layout.CC;
 import net.miginfocom.layout.ConstraintParser;
@@ -835,9 +835,10 @@ public final class CellConstraintsSupport {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * @return the small {@link Image} that represents horizontal/vertical alignment.
+	 * @return the small {@link ImageDescriptor} that represents horizontal/vertical
+	 *         alignment.
 	 */
-	public Image getSmallAlignmentImage(boolean horizontal) {
+	public ImageDescriptor getSmallAlignmentImage(boolean horizontal) {
 		if (horizontal) {
 			return getHorizontalAlignment().getSmallImage();
 		} else {

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/MigColumnInfo.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/MigColumnInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,6 @@ import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.swing.MigLayout.Activator;
 
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.swt.graphics.Image;
 
 import net.miginfocom.layout.AC;
 import net.miginfocom.layout.ConstraintParser;
@@ -41,10 +40,10 @@ public final class MigColumnInfo extends MigDimensionInfo {
 		/**
 		 * @return the small image (5x9) to display current alignment to user.
 		 */
-		public Image getSmallImage() {
+		public ImageDescriptor getSmallImage() {
 			String pattern = "alignment/h/small/{0}.gif";
 			String path = MessageFormat.format(pattern, name().toLowerCase());
-			return Activator.getImage(path);
+			return Activator.getImageDescriptor(path);
 		}
 
 		/**

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/MigRowInfo.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/MigRowInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,6 @@ import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.swing.MigLayout.Activator;
 
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.swt.graphics.Image;
 
 import net.miginfocom.layout.AC;
 import net.miginfocom.layout.ConstraintParser;
@@ -41,10 +40,10 @@ public final class MigRowInfo extends MigDimensionInfo {
 		/**
 		 * @return the small image (5x9) to display current alignment to user.
 		 */
-		public Image getSmallImage() {
+		public ImageDescriptor getSmallImage() {
 			String pattern = "alignment/v/small/{0}.gif";
 			String path = MessageFormat.format(pattern, name().toLowerCase());
-			return Activator.getImage(path);
+			return Activator.getImageDescriptor(path);
 		}
 
 		/**

--- a/org.eclipse.wb.swing.java6/src/org/eclipse/wb/internal/swing/java6/gef/GroupSelectionEditPolicy.java
+++ b/org.eclipse.wb.swing.java6/src/org/eclipse/wb/internal/swing/java6/gef/GroupSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,7 @@ import org.eclipse.wb.internal.core.gef.policy.layout.absolute.AbsoluteComplexSe
 import org.eclipse.wb.internal.core.gef.policy.snapping.ComponentAttachmentInfo;
 import org.eclipse.wb.internal.swing.java6.model.GroupLayoutInfo;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import javax.swing.GroupLayout;
 
@@ -44,7 +44,7 @@ public final class GroupSelectionEditPolicy extends AbsoluteComplexSelectionEdit
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getActionImage(String imageName) {
+	public ImageDescriptor getActionImage(String imageName) {
 		return GroupLayoutInfo.getImage(imageName);
 	}
 

--- a/org.eclipse.wb.swing.java6/src/org/eclipse/wb/internal/swing/java6/model/GroupLayoutInfo.java
+++ b/org.eclipse.wb.swing.java6/src/org/eclipse/wb/internal/swing/java6/model/GroupLayoutInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,7 +27,7 @@ import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.layout.LayoutInfo;
 
 import org.eclipse.jdt.core.dom.MethodInvocation;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.util.List;
 import java.util.Map;
@@ -162,8 +162,8 @@ public final class GroupLayoutInfo extends LayoutInfo implements IAbsoluteLayout
 	// Misc
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public static Image getImage(String imageName) {
-		return Activator.getImage("info/layout/groupLayout/" + imageName);
+	public static ImageDescriptor getImage(String imageName) {
+		return Activator.getImageDescriptor("info/layout/groupLayout/" + imageName);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.swing.java6/src/org/eclipse/wb/internal/swing/java6/model/GroupLayoutInfo2.java
+++ b/org.eclipse.wb.swing.java6/src/org/eclipse/wb/internal/swing/java6/model/GroupLayoutInfo2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -34,7 +34,7 @@ import org.eclipse.wb.internal.swing.model.layout.LayoutClipboardCommand;
 import org.eclipse.wb.internal.swing.model.layout.LayoutInfo;
 
 import org.eclipse.draw2d.geometry.Insets;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import org.netbeans.modules.form.layoutdesign.VisualMapper;
 
@@ -157,8 +157,8 @@ public final class GroupLayoutInfo2 extends LayoutInfo implements IAdaptable {
 		static final IImageProvider INSTANCE = new ImageProvider();
 
 		@Override
-		public Image getImage(String path) {
-			return Activator.getImage(path);
+		public ImageDescriptor getImage(String path) {
+			return Activator.getImageDescriptor(path);
 		}
 	}
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/SpringSelectionEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/SpringSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,7 @@ import org.eclipse.wb.internal.core.gef.policy.layout.absolute.AbsoluteComplexSe
 import org.eclipse.wb.internal.core.gef.policy.snapping.ComponentAttachmentInfo;
 import org.eclipse.wb.internal.swing.model.layout.spring.SpringLayoutInfo;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.layout.FormLayout;
 
 /**
@@ -43,7 +43,8 @@ public final class SpringSelectionEditPolicy extends AbsoluteComplexSelectionEdi
 	// Overrides
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public Image getActionImage(String imageName) {
+	@Override
+	public ImageDescriptor getActionImage(String imageName) {
 		return SpringLayoutInfo.getImage(imageName);
 	}
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/GridBagSelectionEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/GridBagSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -36,6 +36,7 @@ import org.eclipse.wb.internal.swing.model.layout.gbl.RowInfo;
 
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.jface.action.IMenuManager;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
 
 import java.util.List;
@@ -117,7 +118,7 @@ public final class GridBagSelectionEditPolicy extends AbstractGridSelectionEditP
 		if (horizontal) {
 			return new AbstractPopupFigure(viewer, 9, 5) {
 				@Override
-				protected Image getImage() {
+				protected ImageDescriptor getImage() {
 					switch (constraints.getHorizontalAlignment()) {
 					case LEFT :
 						return getImage2("h/alignment/left.gif");
@@ -139,7 +140,7 @@ public final class GridBagSelectionEditPolicy extends AbstractGridSelectionEditP
 		} else {
 			return new AbstractPopupFigure(viewer, 5, 9) {
 				@Override
-				protected Image getImage() {
+				protected ImageDescriptor getImage() {
 					switch (constraints.getVerticalAlignment()) {
 					case TOP :
 						return getImage2("v/alignment/top.gif");
@@ -173,10 +174,10 @@ public final class GridBagSelectionEditPolicy extends AbstractGridSelectionEditP
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * @return the {@link Image} for {@link AbstractGridBagLayoutInfo}.
+	 * @return the {@link ImageDescriptor} for {@link AbstractGridBagLayoutInfo}.
 	 */
-	protected final Image getImage2(String name) {
-		return AbstractGridBagLayoutInfo.getImage("headers/" + name);
+	protected final ImageDescriptor getImage2(String name) {
+		return AbstractGridBagLayoutInfo.getImageDescriptor("headers/" + name);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/spring/SpringLayoutInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/spring/SpringLayoutInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -31,7 +31,7 @@ import org.eclipse.wb.internal.swing.model.layout.LayoutInfo;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Rectangle;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.util.List;
 
@@ -270,8 +270,8 @@ public final class SpringLayoutInfo extends LayoutInfo implements IAbsoluteLayou
 		return !getAttachment(widget, side).isVirtual();
 	}
 
-	public static Image getImage(String imageName) {
-		return Activator.getImage("info/layout/springLayout/" + imageName);
+	public static ImageDescriptor getImage(String imageName) {
+		return Activator.getImageDescriptor("info/layout/springLayout/" + imageName);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/AnchorFiguresClassic.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/AnchorFiguresClassic.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,7 +28,7 @@ import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.jface.action.IMenuManager;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import org.apache.commons.lang.exception.NestableError;
 
@@ -217,7 +217,7 @@ public final class AnchorFiguresClassic<C extends IControlInfo> {
 		}
 
 		@Override
-		protected Image getImage() {
+		protected ImageDescriptor getImage() {
 			return m_layoutImpl.getAnchorActions().getImageHorizontal(m_widget, m_side);
 		}
 
@@ -237,7 +237,7 @@ public final class AnchorFiguresClassic<C extends IControlInfo> {
 		}
 
 		@Override
-		protected Image getImage() {
+		protected ImageDescriptor getImage() {
 			try {
 				return m_layoutImpl.getAnchorActions().getImageVertical(m_widget, m_side);
 			} catch (Throwable e) {

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormSelectionEditPolicy.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,7 @@ import org.eclipse.wb.internal.swt.model.layout.form.FormLayoutInfoImplAutomatic
 import org.eclipse.wb.internal.swt.model.layout.form.IFormLayoutInfo;
 import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.layout.FormLayout;
 
 /**
@@ -48,7 +48,7 @@ AbsoluteComplexSelectionEditPolicy {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getActionImage(String imageName) {
+	public ImageDescriptor getActionImage(String imageName) {
 		return FormLayoutInfoImplAutomatic.getImage(imageName);
 	}
 

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/GridSelectionEditPolicy.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/GridSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,8 +33,8 @@ import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.jface.action.IMenuManager;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Image;
 
 import java.util.List;
 
@@ -124,7 +124,7 @@ AbstractGridSelectionEditPolicy {
 			if (horizontal) {
 				return new AbstractPopupFigure(viewer, 9, 5) {
 					@Override
-					protected Image getImage() {
+					protected ImageDescriptor getImage() {
 						return constraints.getSmallAlignmentImage(true);
 					}
 
@@ -136,7 +136,7 @@ AbstractGridSelectionEditPolicy {
 			} else {
 				return new AbstractPopupFigure(viewer, 5, 9) {
 					@Override
-					protected Image getImage() {
+					protected ImageDescriptor getImage() {
 						return constraints.getSmallAlignmentImage(false);
 					}
 

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/FormLayoutInfoImplAutomatic.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/FormLayoutInfoImplAutomatic.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,8 +26,8 @@ import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Interval;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.draw2d.geometry.Transposer;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Image;
 
 import java.util.List;
 
@@ -726,8 +726,8 @@ FormLayoutInfoImpl<C> implements IAbsoluteLayoutCommands {
 		return null;
 	}
 
-	public static Image getImage(String imageName) {
-		return Activator.getImage("info/layout/FormLayout/" + imageName);
+	public static ImageDescriptor getImage(String imageName) {
+		return Activator.getImageDescriptor("info/layout/FormLayout/" + imageName);
 	}
 
 	@Override

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/LayoutAssistantPage.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/LayoutAssistantPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -32,7 +32,6 @@ import org.eclipse.jface.action.IContributionManager;
 import org.eclipse.jface.action.Separator;
 import org.eclipse.jface.action.ToolBarManager;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
 
@@ -51,12 +50,7 @@ ILayoutAssistantPage {
 	private final List<C> m_selection;
 	private final IFormLayoutInfo<C> m_layout;
 	private final PlacementsSupport m_placementsSupport;
-	private final IActionImageProvider m_imageProvider = new IActionImageProvider() {
-		@Override
-		public Image getActionImage(String imagePath) {
-			return FormLayoutInfoImplAutomatic.getImage(imagePath);
-		}
-	};
+	private final IActionImageProvider m_imageProvider = FormLayoutInfoImplAutomatic::getImage;
 
 	////////////////////////////////////////////////////////////////////////////
 	//

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/actions/AnchorActionsClassic.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/actions/AnchorActionsClassic.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,6 @@ import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.draw2d.IPositionConstants;
 import org.eclipse.wb.internal.core.model.util.ObjectInfoAction;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.swt.Activator;
 import org.eclipse.wb.internal.swt.model.ModelMessages;
 import org.eclipse.wb.internal.swt.model.layout.form.FormLayoutInfoImplClassic;
@@ -23,7 +22,7 @@ import org.eclipse.wb.internal.swt.model.layout.form.IFormAttachmentInfo;
 import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
 import org.eclipse.jface.action.IMenuManager;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
  * Support for actions changing the alignment of the control.
@@ -223,16 +222,11 @@ public class AnchorActionsClassic<C extends IControlInfo> {
 		}
 	}
 
-	public Image getImageHorizontal(final C control, final int side) {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<Image>() {
-			@Override
-			public Image runObject() throws Exception {
-				return getImageHorizontal0(control, side);
-			}
-		}, null);
+	public ImageDescriptor getImageHorizontal(final C control, final int side) {
+		return ExecutionUtils.runObjectLog(() -> getImageHorizontal0(control, side), null);
 	}
 
-	private Image getImageHorizontal0(C control, int side) throws Exception {
+	private ImageDescriptor getImageHorizontal0(C control, int side) throws Exception {
 		IFormAttachmentInfo<C> attachment = m_layoutImpl.getAttachment(control, side);
 		String imageName = side == IPositionConstants.LEFT ? "left_" : "right_";
 		if (attachment == null) {
@@ -250,19 +244,14 @@ public class AnchorActionsClassic<C extends IControlInfo> {
 		} else {
 			imageName = "left_percent";
 		}
-		return Activator.getImage(IMAGE_PREFIX + "/h/" + imageName + ".png");
+		return Activator.getImageDescriptor(IMAGE_PREFIX + "/h/" + imageName + ".png");
 	}
 
-	public Image getImageVertical(final C control, final int side) {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<Image>() {
-			@Override
-			public Image runObject() throws Exception {
-				return getImageVertical0(control, side);
-			}
-		}, null);
+	public ImageDescriptor getImageVertical(final C control, final int side) {
+		return ExecutionUtils.runObjectLog(() -> getImageVertical0(control, side), null);
 	}
 
-	private Image getImageVertical0(C control, int side) throws Exception {
+	private ImageDescriptor getImageVertical0(C control, int side) throws Exception {
 		IFormAttachmentInfo<C> attachment = m_layoutImpl.getAttachment(control, side);
 		String imageName = side == IPositionConstants.TOP ? "top_" : "bottom_";
 		if (attachment == null) {
@@ -280,6 +269,6 @@ public class AnchorActionsClassic<C extends IControlInfo> {
 		} else {
 			imageName = "top_percent";
 		}
-		return Activator.getImage(IMAGE_PREFIX + "/v/" + imageName + ".png");
+		return Activator.getImageDescriptor(IMAGE_PREFIX + "/v/" + imageName + ".png");
 	}
 }

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/grid/GridDataInfo.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/grid/GridDataInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -37,8 +37,8 @@ import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.action.Separator;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
 
 import java.util.List;
@@ -478,30 +478,30 @@ public final class GridDataInfo extends LayoutDataInfo implements IGridDataInfo 
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Image getSmallAlignmentImage(boolean horizontal) {
+	public ImageDescriptor getSmallAlignmentImage(boolean horizontal) {
 		if (horizontal) {
 			switch (horizontalAlignment) {
 			case SWT.LEFT :
-				return GridImages.getImage("h/left.gif");
+				return GridImages.getImageDescriptor("h/left.gif");
 			case SWT.CENTER :
-				return GridImages.getImage("h/center.gif");
+				return GridImages.getImageDescriptor("h/center.gif");
 			case SWT.RIGHT :
-				return GridImages.getImage("h/right.gif");
+				return GridImages.getImageDescriptor("h/right.gif");
 			case SWT.FILL :
-				return GridImages.getImage("h/fill.gif");
+				return GridImages.getImageDescriptor("h/fill.gif");
 			default :
 				return null;
 			}
 		} else {
 			switch (verticalAlignment) {
 			case SWT.TOP :
-				return GridImages.getImage("v/top.gif");
+				return GridImages.getImageDescriptor("v/top.gif");
 			case SWT.CENTER :
-				return GridImages.getImage("v/center.gif");
+				return GridImages.getImageDescriptor("v/center.gif");
 			case SWT.BOTTOM :
-				return GridImages.getImage("v/bottom.gif");
+				return GridImages.getImageDescriptor("v/bottom.gif");
 			case SWT.FILL :
-				return GridImages.getImage("v/fill.gif");
+				return GridImages.getImageDescriptor("v/fill.gif");
 			default :
 				return null;
 			}

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/grid/IGridDataInfo.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/grid/IGridDataInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,7 @@ import org.eclipse.wb.core.model.IObjectInfo;
 
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuManager;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.layout.GridData;
 
 /**
@@ -135,9 +135,10 @@ public interface IGridDataInfo extends IObjectInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * @return the small {@link Image} that represents horizontal/vertical alignment.
+	 * @return the small {@link ImageDescriptor} that represents horizontal/vertical
+	 *         alignment.
 	 */
-	Image getSmallAlignmentImage(boolean horizontal);
+	ImageDescriptor getSmallAlignmentImage(boolean horizontal);
 
 	/**
 	 * Adds the horizontal alignment {@link Action}'s.

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/forms/table/TableWrapDataTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/forms/table/TableWrapDataTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,7 +22,7 @@ import org.eclipse.wb.tests.designer.rcp.model.forms.AbstractFormsTest;
 
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.IMenuManager;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.forms.widgets.TableWrapData;
 import org.eclipse.ui.forms.widgets.TableWrapLayout;
@@ -88,7 +88,7 @@ public class TableWrapDataTest extends AbstractFormsTest {
 			String[] paths) throws Exception {
 		for (int i = 0; i < alignments.length; i++) {
 			int alignment = alignments[i];
-			Image expectedImage = TableWrapLayoutImages.getImage((horizontal ? "/h/" : "/v/") + paths[i]);
+			ImageDescriptor expectedImage = TableWrapLayoutImages.getImageDescriptor((horizontal ? "/h/" : "/v/") + paths[i]);
 			if (horizontal) {
 				layoutData.setHorizontalAlignment(alignment);
 			} else {

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/FormLayout/CellConstraintsSupportTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/FormLayout/CellConstraintsSupportTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.IMenuManager;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import com.jgoodies.forms.layout.CellConstraints;
 import com.jgoodies.forms.layout.CellConstraints.Alignment;
@@ -301,7 +301,7 @@ public class CellConstraintsSupportTest extends AbstractFormLayoutTest {
 			constraints.setAlignV(alignment);
 		}
 		// check image
-		Image alignmentImage = constraints.getSmallAlignmentImage(horizontal);
+		ImageDescriptor alignmentImage = constraints.getSmallAlignmentImage(horizontal);
 		if (notNullExpected) {
 			assertNotNull(alignmentImage);
 		} else {

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/MigLayout/MigLayoutConstraintsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/MigLayout/MigLayoutConstraintsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -869,7 +869,7 @@ public class MigLayoutConstraintsTest extends AbstractMigLayoutTest {
 			constraints.setHorizontalAlignment(alignment);
 		}
 		assertSame(
-				Activator.getImage("alignment/h/small/" + imageName),
+				Activator.getImageDescriptor("alignment/h/small/" + imageName),
 				constraints.getSmallAlignmentImage(true));
 	}
 
@@ -926,7 +926,7 @@ public class MigLayoutConstraintsTest extends AbstractMigLayoutTest {
 			constraints.setVerticalAlignment(alignment);
 		}
 		assertSame(
-				Activator.getImage("alignment/v/small/" + imageName),
+				Activator.getImageDescriptor("alignment/v/small/" + imageName),
 				constraints.getSmallAlignmentImage(false));
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/layouts/grid/GridDataTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/layouts/grid/GridDataTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,8 +24,8 @@ import org.eclipse.wb.tests.designer.rcp.RcpModelTest;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.IMenuManager;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -283,7 +283,7 @@ public class GridDataTest extends RcpModelTest {
 			String[] paths) throws Exception {
 		for (int i = 0; i < alignments.length; i++) {
 			int alignment = alignments[i];
-			Image expectedImage = GridImages.getImage((horizontal ? "h/" : "v/") + paths[i]);
+			ImageDescriptor expectedImage = GridImages.getImageDescriptor((horizontal ? "h/" : "v/") + paths[i]);
 			if (horizontal) {
 				gridData.setHorizontalAlignment(alignment);
 			} else {

--- a/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/forms/layout/table/TableWrapDataInfo.java
+++ b/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/forms/layout/table/TableWrapDataInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,7 +33,7 @@ import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.action.Separator;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.ui.forms.widgets.TableWrapData;
 
 import java.util.List;
@@ -305,30 +305,30 @@ public final class TableWrapDataInfo extends LayoutDataInfo implements ITableWra
 	// Images
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public Image getSmallAlignmentImage(boolean horizontal) {
+	public ImageDescriptor getSmallAlignmentImage(boolean horizontal) {
 		if (horizontal) {
 			switch (horizontalAlignment) {
 			case TableWrapData.LEFT :
-				return TableWrapLayoutImages.getImage("h/left.gif");
+				return TableWrapLayoutImages.getImageDescriptor("h/left.gif");
 			case TableWrapData.CENTER :
-				return TableWrapLayoutImages.getImage("h/center.gif");
+				return TableWrapLayoutImages.getImageDescriptor("h/center.gif");
 			case TableWrapData.RIGHT :
-				return TableWrapLayoutImages.getImage("h/right.gif");
+				return TableWrapLayoutImages.getImageDescriptor("h/right.gif");
 			default :
 				Assert.isTrue(horizontalAlignment == TableWrapData.FILL);
-				return TableWrapLayoutImages.getImage("h/fill.gif");
+				return TableWrapLayoutImages.getImageDescriptor("h/fill.gif");
 			}
 		} else {
 			switch (verticalAlignment) {
 			case TableWrapData.TOP :
-				return TableWrapLayoutImages.getImage("v/top.gif");
+				return TableWrapLayoutImages.getImageDescriptor("v/top.gif");
 			case TableWrapData.MIDDLE :
-				return TableWrapLayoutImages.getImage("v/middle.gif");
+				return TableWrapLayoutImages.getImageDescriptor("v/middle.gif");
 			case TableWrapData.BOTTOM :
-				return TableWrapLayoutImages.getImage("v/bottom.gif");
+				return TableWrapLayoutImages.getImageDescriptor("v/bottom.gif");
 			default :
 				Assert.isTrue(verticalAlignment == TableWrapData.FILL);
-				return TableWrapLayoutImages.getImage("v/fill.gif");
+				return TableWrapLayoutImages.getImageDescriptor("v/fill.gif");
 			}
 		}
 	}

--- a/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/layout/grid/GridDataInfo.java
+++ b/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/layout/grid/GridDataInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -37,8 +37,8 @@ import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.action.Separator;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
 
 import java.util.List;
@@ -454,30 +454,31 @@ public final class GridDataInfo extends LayoutDataInfo implements IGridDataInfo 
 	// Images
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public Image getSmallAlignmentImage(boolean horizontal) {
+	@Override
+	public ImageDescriptor getSmallAlignmentImage(boolean horizontal) {
 		if (horizontal) {
 			switch (horizontalAlignment) {
 			case SWT.LEFT :
-				return GridImages.getImage("h/left.gif");
+				return GridImages.getImageDescriptor("h/left.gif");
 			case SWT.CENTER :
-				return GridImages.getImage("h/center.gif");
+				return GridImages.getImageDescriptor("h/center.gif");
 			case SWT.RIGHT :
-				return GridImages.getImage("h/right.gif");
+				return GridImages.getImageDescriptor("h/right.gif");
 			case SWT.FILL :
-				return GridImages.getImage("h/fill.gif");
+				return GridImages.getImageDescriptor("h/fill.gif");
 			default :
 				return null;
 			}
 		} else {
 			switch (verticalAlignment) {
 			case SWT.TOP :
-				return GridImages.getImage("v/top.gif");
+				return GridImages.getImageDescriptor("v/top.gif");
 			case SWT.CENTER :
-				return GridImages.getImage("v/center.gif");
+				return GridImages.getImageDescriptor("v/center.gif");
 			case SWT.BOTTOM :
-				return GridImages.getImage("v/bottom.gif");
+				return GridImages.getImageDescriptor("v/bottom.gif");
 			case SWT.FILL :
-				return GridImages.getImage("v/fill.gif");
+				return GridImages.getImageDescriptor("v/fill.gif");
 			default :
 				return null;
 			}


### PR DESCRIPTION
The IActionImageProvider and IImageProvider now return an ImageDescriptor instance, rather than an Image. This should clean up a big chunk of the remaining cases, where we use images in non-ui classes.