### PR TITLE
Fix: WindowBuilder can't be installed in Eclipse IDE

### DIFF
--- a/org.eclipse.wb.dependencies.feature_feature/feature.xml
+++ b/org.eclipse.wb.dependencies.feature_feature/feature.xml
@@ -162,4 +162,11 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.apache.commons.collections"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
The Eclipse IDE doesn't depend on commons-collections. Because we have a direct dependency to it, this prevents WindowBuilder from being installed without additional update sites. Furthermore, this breaks the dropin mechanism.
The solution consists of simply adding it to the dependencies feature so that this dependency is also included in the update site.