### PR TITLE
Partial migrate SwingImageUtils to use ImageDescriptors.

### DIFF
--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/BeanSupport.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/BeanSupport.java
@@ -21,7 +21,6 @@ import org.eclipse.wb.internal.core.databinding.model.ObserveComparator;
 import org.eclipse.wb.internal.core.databinding.model.reference.StringReferenceProvider;
 import org.eclipse.wb.internal.core.databinding.ui.decorate.IObserveDecorator;
 import org.eclipse.wb.internal.core.databinding.utils.CoreUtils;
-import org.eclipse.wb.internal.core.utils.ui.ImageImageDescriptor;
 import org.eclipse.wb.internal.swing.databinding.Activator;
 import org.eclipse.wb.internal.swing.databinding.model.ObserveInfo;
 import org.eclipse.wb.internal.swing.databinding.model.bindings.BindingInfo;
@@ -301,8 +300,7 @@ public final class BeanSupport {
 					beanImage = useDefault ? Activator.getImageDescriptor("javabean.gif") : null;
 				} else {
 					// convert to SWT image
-					// FIXME: memory leak
-					beanImage = new ImageImageDescriptor(SwingImageUtils.convertImage_AWT_to_SWT(awtBeanIcon));
+					beanImage = SwingImageUtils.convertImage_AWT_to_SWT(awtBeanIcon);
 				}
 			} catch (Throwable e) {
 				// set default

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/beans/PropertyEditorWrapper.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/beans/PropertyEditorWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,6 +23,7 @@ import org.eclipse.wb.internal.swing.model.ModelMessages;
 import org.eclipse.wb.internal.swing.utils.SwingImageUtils;
 import org.eclipse.wb.internal.swing.utils.SwingUtils;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.FontData;
@@ -136,7 +137,7 @@ public final class PropertyEditorWrapper {
 		m_propertyEditor.setValue(property.getValue());
 		// paint
 		if (m_propertyEditor.isPaintable()) {
-			Image image = paintValue(gc, width, height);
+			Image image = paintValue(gc, width, height).createImage();
 			gc.drawImage(image, x, y);
 			image.dispose();
 			return;
@@ -150,7 +151,7 @@ public final class PropertyEditorWrapper {
 		}
 	}
 
-	private Image paintValue(GC gc, int width, int height) throws Exception {
+	private ImageDescriptor paintValue(GC gc, int width, int height) throws Exception {
 		// create AWT graphics
 		BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
 		Graphics2D graphics2D = (Graphics2D) image.getGraphics();

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/font/FontPreviewCanvas.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/font/FontPreviewCanvas.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -92,7 +92,7 @@ public final class FontPreviewCanvas extends Canvas {
 					Image image;
 					{
 						label.setSize(label.getPreferredSize());
-						image = SwingImageUtils.createComponentShot(label);
+						image = SwingImageUtils.createComponentShot(label).createImage();
 					}
 					// draw image
 					try {

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingImageUtils.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingImageUtils.java
@@ -25,6 +25,7 @@ import org.eclipse.wb.internal.swing.model.CoordinateUtils;
 import org.eclipse.wb.os.OSSupport;
 
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
@@ -69,15 +70,10 @@ public class SwingImageUtils {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * @return the {@link Image} of given {@link Component}.
+	 * @return the {@link ImageDescriptor} of given {@link Component}.
 	 */
-	public static Image createComponentShot(final Component component) throws Exception {
-		return SwingUtils.runObjectLaterAndWait(new RunnableObjectEx<Image>() {
-			@Override
-			public Image runObject() throws Exception {
-				return convertImage_AWT_to_SWT(createComponentShotAWT(component));
-			}
-		});
+	public static ImageDescriptor createComponentShot(final Component component) throws Exception {
+		return SwingUtils.runObjectLaterAndWait(() -> convertImage_AWT_to_SWT(createComponentShotAWT(component)));
 	}
 
 	/**
@@ -450,7 +446,7 @@ public class SwingImageUtils {
 				frame.pack();
 				prepareForPrinting(frame);
 				try {
-					menuData.m_menuImage = createComponentShot(menuObject);
+					menuData.m_menuImage = createComponentShot(menuObject).createImage();
 				} finally {
 					setVisible(frame, false);
 					frame.dispose();
@@ -496,7 +492,7 @@ public class SwingImageUtils {
 					popupMenuParent.doLayout();
 				}
 				popupMenu.doLayout();
-				menuData.m_menuImage = createComponentShot(popupMenu);
+				menuData.m_menuImage = createComponentShot(popupMenu).createImage();
 			} finally {
 				setVisible(popupMenu, false);
 				if (parent != null) {
@@ -531,10 +527,10 @@ public class SwingImageUtils {
 	/**
 	 * Converts AWT image into SWT one. Yours, C.O. ;-)
 	 */
-	public static Image convertImage_AWT_to_SWT(final java.awt.Image image) throws Exception {
-		return SwingUtils.runObjectLaterAndWait(new RunnableObjectEx<Image>() {
+	public static ImageDescriptor convertImage_AWT_to_SWT(final java.awt.Image image) throws Exception {
+		return SwingUtils.runObjectLaterAndWait(new RunnableObjectEx<ImageDescriptor>() {
 			@Override
-			public Image runObject() throws Exception {
+			public ImageDescriptor runObject() throws Exception {
 				BufferedImage bufferedImage = (BufferedImage) image;
 				int imageWidth = bufferedImage.getWidth();
 				int imageHeight = bufferedImage.getHeight();
@@ -543,10 +539,10 @@ public class SwingImageUtils {
 				try {
 					ImageProducer source = image.getSource();
 					source.startProduction(new AwtToSwtImageConverter(bufferedImage, swtImageData));
-					return new Image(null, swtImageData);
+					return ImageDescriptor.createFromImageDataProvider(zoom -> zoom == 100 ? swtImageData : null);
 				} catch (Throwable e) {
 					// fallback to ImageIO.
-					return ImageUtils.convertToSWT(image).createImage();
+					return ImageUtils.convertToSWT(image);
 				} finally {
 					swtImage.dispose();
 				}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingScreenshotMaker.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingScreenshotMaker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -165,7 +165,7 @@ public final class SwingScreenshotMaker {
 		for (Component keyComponent : Collections.unmodifiableMap(m_componentImages).keySet()) {
 			java.awt.Image image2 = m_componentImages.get(keyComponent);
 			if (image2 != null) {
-				convertedImages.put(keyComponent, SwingImageUtils.convertImage_AWT_to_SWT(image2));
+				convertedImages.put(keyComponent, SwingImageUtils.convertImage_AWT_to_SWT(image2).createImage());
 			}
 		}
 		// draw decorations on OS X


### PR DESCRIPTION
The createComponentShot now returns an image descriptor instead of an image. This resolves a potential memory leak in the BeanSupport class, when loading the beam images.