### PR TITLE
Synchronize methods and fields with descriptor-based implementation

### DIFF
--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/presentation/JavaInfoDecorator.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/presentation/JavaInfoDecorator.java
@@ -21,7 +21,6 @@ import org.eclipse.wb.internal.core.databinding.model.IObserveInfo;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.DecorationOverlayIcon;
 import org.eclipse.jface.viewers.IDecoration;
-import org.eclipse.swt.graphics.Image;
 
 import java.util.Iterator;
 
@@ -32,11 +31,6 @@ import java.util.Iterator;
  * @coverage bindings.model
  */
 public abstract class JavaInfoDecorator {
-	/**
-	 * @deprecated Use {@link #IMAGE_DESCRIPTOR} instead.
-	 */
-	@Deprecated
-	public static final Image IMAGE = Activator.getImage("decorator.gif");
 	public static final ImageDescriptor IMAGE_DESCRIPTOR = Activator.getImageDescriptor("decorator.gif");
 	private final IDatabindingsProvider m_provider;
 

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/presentation/ObservePresentation.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/presentation/ObservePresentation.java
@@ -34,13 +34,13 @@ IObservePresentationDecorator {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public final ImageDescriptor getImageDescriptor() throws Exception {
-		return m_decorateImage == null ? getInternalImage() : m_decorateImage;
+		return m_decorateImage == null ? getInternalImageDescriptor() : m_decorateImage;
 	}
 
 	/**
 	 * @return {@link ImageDescriptor} for displaying and decorate.
 	 */
-	protected abstract ImageDescriptor getInternalImage() throws Exception;
+	protected abstract ImageDescriptor getInternalImageDescriptor() throws Exception;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -50,7 +50,7 @@ IObservePresentationDecorator {
 	@Override
 	public final void setBindingDecorator(int corner) throws Exception {
 		if (corner != 0) {
-			ImageDescriptor image = getInternalImage();
+			ImageDescriptor image = getInternalImageDescriptor();
 			if (image != null) {
 				m_decorateImage = new DecorationOverlayIcon(image, JavaInfoDecorator.IMAGE_DESCRIPTOR, corner);
 			}

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/presentation/SimpleObservePresentation.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/presentation/SimpleObservePresentation.java
@@ -43,7 +43,7 @@ public class SimpleObservePresentation extends ObservePresentation {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected ImageDescriptor getInternalImage() throws Exception {
+	protected ImageDescriptor getInternalImageDescriptor() throws Exception {
 		return m_image == null ? null : m_image;
 	}
 

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/ObserveElementsComposite.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/ObserveElementsComposite.java
@@ -524,7 +524,7 @@ final class ObserveElementsComposite extends SashForm {
 		// fill menu
 		for (PropertyFilter filter : filters) {
 			MenuItem item = new MenuItem(m_propertiesFilterMenu, SWT.RADIO);
-			ImageDescriptor imageDescriptor = filter.getImage();
+			ImageDescriptor imageDescriptor = filter.getImageDescriptor();
 			if (imageDescriptor != null) {
 				Image image = imageDescriptor.createImage();
 				item.addDisposeListener(event -> image.dispose());

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/filter/PropertyFilter.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/filter/PropertyFilter.java
@@ -50,7 +50,7 @@ public abstract class PropertyFilter {
 	/**
 	 * @return the image to display for user.
 	 */
-	public final ImageDescriptor getImage() {
+	public final ImageDescriptor getImageDescriptor() {
 		return m_image;
 	}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/ComponentPresentationHelper.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/ComponentPresentationHelper.java
@@ -135,7 +135,7 @@ public final class ComponentPresentationHelper {
 			String name = parseHelper.getName(componentClassName, creationId);
 			String key = getKey(componentClassName, creationId);
 			String toolkitId = getToolkitId(state, resource);
-			ImageDescriptor icon = getComponentImage(componentClass, creationId, context);
+			ImageDescriptor icon = getComponentImageDescriptor(componentClass, creationId, context);
 			ComponentPresentation presentation =
 					new ComponentPresentation(key, toolkitId, name, desc, icon);
 			if (shouldCacheFast(resource.getBundle())) {
@@ -159,13 +159,13 @@ public final class ComponentPresentationHelper {
 		return false;
 	}
 
-	private static ImageDescriptor getComponentImage(Class<?> clazz, String creationId, ILoadingContext context)
+	private static ImageDescriptor getComponentImageDescriptor(Class<?> clazz, String creationId, ILoadingContext context)
 			throws Exception {
 		String iconPath = getImageName(clazz.getName(), creationId);
 		ImageDescriptor image = DescriptionHelper.getIcon(context, iconPath);
 		if (image == null) {
 			// no image for this type, use super type
-			return getComponentImage(clazz.getSuperclass(), null/*use default id*/, context);
+			return getComponentImageDescriptor(clazz.getSuperclass(), null/*use default id*/, context);
 		}
 		return image;
 	}

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/description/ComponentPresentationHelper.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/description/ComponentPresentationHelper.java
@@ -130,7 +130,7 @@ public final class ComponentPresentationHelper {
 			String name = parseHelper.getName(componentClassName, creationId);
 			String key = getKey(componentClassName, creationId);
 			String toolkitId = getToolkitId(context, resource);
-			ImageDescriptor icon = getComponentImage(componentClass, creationId, loadingContext);
+			ImageDescriptor icon = getComponentImageDescriptor(componentClass, creationId, loadingContext);
 			ComponentPresentation presentation =
 					new ComponentPresentation(key, toolkitId, name, desc, icon);
 			if (shouldCacheFast(resource.getBundle())) {
@@ -154,18 +154,18 @@ public final class ComponentPresentationHelper {
 		return false;
 	}
 
-	private static ImageDescriptor getComponentImage(Class<?> clazz, String creationId, ILoadingContext context)
+	private static ImageDescriptor getComponentImageDescriptor(Class<?> clazz, String creationId, ILoadingContext context)
 			throws Exception {
 		String iconPath = getImageName(clazz.getName(), creationId);
 		ImageDescriptor image = DescriptionHelper.getIcon(context, iconPath);
 		if (image == null) {
 			// no image for this type, use super type
-			return getComponentImage(clazz.getSuperclass(), null/*use default id*/, context);
+			return getComponentImageDescriptor(clazz.getSuperclass(), null/*use default id*/, context);
 		}
 		return image;
 	}
 
-	private static ImageDescriptor getComponentImage(Bundle bundle, String componentClassName, String creationId)
+	private static ImageDescriptor getComponentImageDescriptor(Bundle bundle, String componentClassName, String creationId)
 			throws Exception {
 		String iconPath = "/wbp-meta/" + getImageName(componentClassName, creationId);
 		for (String ext : DescriptionHelper.ICON_EXTS) {
@@ -633,7 +633,7 @@ public final class ComponentPresentationHelper {
 			String desc = parseHelper.getDescription(creationId);
 			String name = parseHelper.getName(componentClassName, creationId);
 			String key = getKey(componentClassName, creationId);
-			ImageDescriptor icon = getComponentImage(bundle, componentClassName, creationId);
+			ImageDescriptor icon = getComponentImageDescriptor(bundle, componentClassName, creationId);
 			if (icon == null) {
 				// no image -- no presentation ;)
 				return;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/generic/AbstractPopupFigure.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/generic/AbstractPopupFigure.java
@@ -93,7 +93,7 @@ public abstract class AbstractPopupFigure extends Figure {
 		graphics.drawRectangle(clientArea.getResized(-1, -1));
 		// draw image
 		{
-			ImageDescriptor imageDescriptor = getImage();
+			ImageDescriptor imageDescriptor = getImageDescriptor();
 			if (imageDescriptor != null) {
 				Image image = imageDescriptor.createImage();
 				org.eclipse.swt.graphics.Rectangle imageBounds = image.getBounds();
@@ -113,7 +113,7 @@ public abstract class AbstractPopupFigure extends Figure {
 	/**
 	 * @return the image to display.
 	 */
-	protected abstract ImageDescriptor getImage();
+	protected abstract ImageDescriptor getImageDescriptor();
 
 	/**
 	 * Creates the actions on given {@link IMenuManager}.

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/AbsoluteComplexSelectionEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/AbsoluteComplexSelectionEditPolicy.java
@@ -363,15 +363,15 @@ AbsoluteBasedSelectionEditPolicy<C> implements IActionImageProvider {
 		}
 
 		@Override
-		protected ImageDescriptor getImage() {
+		protected ImageDescriptor getImageDescriptor() {
 			boolean isLeftAttached = isAttached(m_widget, IPositionConstants.LEFT);
 			boolean isRightAttached = isAttached(m_widget, IPositionConstants.RIGHT);
 			if (isLeftAttached && isRightAttached) {
-				return getActionImage("h/both.gif");
+				return getActionImageDescriptor("h/both.gif");
 			} else if (isRightAttached) {
-				return getActionImage("h/right.gif");
+				return getActionImageDescriptor("h/right.gif");
 			} else {
-				return getActionImage("h/left.gif");
+				return getActionImageDescriptor("h/left.gif");
 			}
 		}
 
@@ -392,15 +392,15 @@ AbsoluteBasedSelectionEditPolicy<C> implements IActionImageProvider {
 		}
 
 		@Override
-		protected ImageDescriptor getImage() {
+		protected ImageDescriptor getImageDescriptor() {
 			boolean isTopAttached = isAttached(m_widget, IPositionConstants.TOP);
 			boolean isBottomAttached = isAttached(m_widget, IPositionConstants.BOTTOM);
 			if (isTopAttached && isBottomAttached) {
-				return getActionImage("v/both.gif");
+				return getActionImageDescriptor("v/both.gif");
 			} else if (isBottomAttached) {
-				return getActionImage("v/bottom.gif");
+				return getActionImageDescriptor("v/bottom.gif");
 			} else {
-				return getActionImage("v/top.gif");
+				return getActionImageDescriptor("v/top.gif");
 			}
 		}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/actions/AnchorsActionsSupport.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/actions/AnchorsActionsSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -73,7 +73,7 @@ public class AnchorsActionsSupport {
 				String text,
 				String imageName,
 				int alignment) {
-			super(widget.getUnderlyingModel(), text, m_imageProvider.getActionImage(imageName));
+			super(widget.getUnderlyingModel(), text, m_imageProvider.getActionImageDescriptor(imageName));
 			m_widget = widget;
 			m_alignment = alignment;
 		}
@@ -91,7 +91,7 @@ public class AnchorsActionsSupport {
 				String text,
 				String imageName,
 				boolean isHorizontal) {
-			super(widget.getUnderlyingModel(), text, m_imageProvider.getActionImage(imageName));
+			super(widget.getUnderlyingModel(), text, m_imageProvider.getActionImageDescriptor(imageName));
 			m_widget = widget;
 			m_isHorizontal = isHorizontal;
 		}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/actions/IActionImageProvider.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/actions/IActionImageProvider.java
@@ -18,5 +18,5 @@ import org.eclipse.jface.resource.ImageDescriptor;
  * @author mitin_aa
  */
 public interface IActionImageProvider {
-	ImageDescriptor getActionImage(String imagePath);
+	ImageDescriptor getActionImageDescriptor(String imagePath);
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/layout/absolute/IImageProvider.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/layout/absolute/IImageProvider.java
@@ -21,5 +21,5 @@ public interface IImageProvider {
 	/**
 	 * @return the Image instance by given path.
 	 */
-	ImageDescriptor getImage(String path);
+	ImageDescriptor getImageDescriptor(String path);
 }

--- a/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/gef/GroupSelectionEditPolicy2.java
+++ b/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/gef/GroupSelectionEditPolicy2.java
@@ -412,18 +412,18 @@ LayoutConstants {
 		}
 
 		@Override
-		protected ImageDescriptor getImage() {
+		protected ImageDescriptor getImageDescriptor() {
 			int anchors = m_anchorsSupport.getCurrentAnchors(m_component, true);
 			IImageProvider imageProvider = getImageProvider();
 			switch (anchors) {
 			case AnchorsSupport.RESIZABLE :
-				return imageProvider.getImage("info/layout/groupLayout/h/both.gif");
+				return imageProvider.getImageDescriptor("info/layout/groupLayout/h/both.gif");
 			case LEADING :
-				return imageProvider.getImage("info/layout/groupLayout/h/left.gif");
+				return imageProvider.getImageDescriptor("info/layout/groupLayout/h/left.gif");
 			case TRAILING :
-				return imageProvider.getImage("info/layout/groupLayout/h/right.gif");
+				return imageProvider.getImageDescriptor("info/layout/groupLayout/h/right.gif");
 			default :
-				return imageProvider.getImage("info/layout/groupLayout/h/default.gif");
+				return imageProvider.getImageDescriptor("info/layout/groupLayout/h/default.gif");
 			}
 		}
 
@@ -441,18 +441,18 @@ LayoutConstants {
 		}
 
 		@Override
-		protected ImageDescriptor getImage() {
+		protected ImageDescriptor getImageDescriptor() {
 			int anchors = m_anchorsSupport.getCurrentAnchors(m_component, false);
 			IImageProvider imageProvider = getImageProvider();
 			switch (anchors) {
 			case AnchorsSupport.RESIZABLE :
-				return imageProvider.getImage("info/layout/groupLayout/v/both.gif");
+				return imageProvider.getImageDescriptor("info/layout/groupLayout/v/both.gif");
 			case LEADING :
-				return imageProvider.getImage("info/layout/groupLayout/v/top.gif");
+				return imageProvider.getImageDescriptor("info/layout/groupLayout/v/top.gif");
 			case TRAILING :
-				return imageProvider.getImage("info/layout/groupLayout/v/bottom.gif");
+				return imageProvider.getImageDescriptor("info/layout/groupLayout/v/bottom.gif");
 			default :
-				return imageProvider.getImage("info/layout/groupLayout/v/default.gif");
+				return imageProvider.getImageDescriptor("info/layout/groupLayout/v/default.gif");
 			}
 		}
 

--- a/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/model/AnchorsSupport.java
+++ b/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/model/AnchorsSupport.java
@@ -260,7 +260,7 @@ public final class AnchorsSupport implements LayoutConstants {
 				int alignment) {
 			super(component,
 					text,
-					getImageProvider().getImage("info/layout/groupLayout/" + imageName),
+					getImageProvider().getImageDescriptor("info/layout/groupLayout/" + imageName),
 					AS_CHECK_BOX);
 			m_isHorizontal = isHorizontal;
 			m_component = component;
@@ -291,7 +291,7 @@ public final class AnchorsSupport implements LayoutConstants {
 				boolean isHorizontal) {
 			super(component,
 					Messages.AnchorsSupport_autoResizable,
-					getImageProvider().getImage("info/layout/groupLayout/" + imageName),
+					getImageProvider().getImageDescriptor("info/layout/groupLayout/" + imageName),
 					AS_CHECK_BOX);
 			m_component = component;
 			m_isHorizontal = isHorizontal;
@@ -322,7 +322,7 @@ public final class AnchorsSupport implements LayoutConstants {
 					isHorizontal
 					? Messages.AnchorsSupport_resizableHorizontal
 							: Messages.AnchorsSupport_resizableVertical,
-							getImageProvider().getImage("info/layout/groupLayout/" + imageName),
+							getImageProvider().getImageDescriptor("info/layout/groupLayout/" + imageName),
 							AS_CHECK_BOX);
 			m_component = component;
 			m_isHorizontal = isHorizontal;

--- a/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/model/assistant/GroupLayoutSpacesPage.java
+++ b/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/model/assistant/GroupLayoutSpacesPage.java
@@ -141,7 +141,7 @@ LayoutConstants {
 		ToolBar toolBar = new ToolBar(parent, SWT.FLAT | SWT.RIGHT);
 		ToolItem toolItem = new ToolItem(toolBar, SWT.NONE);
 		Image image = m_layout.getAdapter(IImageProvider.class) //
-				.getImage("info/layout/groupLayout/clear.gif") //
+				.getImageDescriptor("info/layout/groupLayout/clear.gif") //
 				.createImage();
 		toolItem.addDisposeListener(event -> image.dispose());
 		toolItem.setImage(image);

--- a/org.eclipse.wb.rcp.databinding.emf/src/org/eclipse/wb/internal/rcp/databinding/emf/model/bindables/EObjectObservePresentation.java
+++ b/org.eclipse.wb.rcp.databinding.emf/src/org/eclipse/wb/internal/rcp/databinding/emf/model/bindables/EObjectObservePresentation.java
@@ -42,7 +42,7 @@ public final class EObjectObservePresentation extends ObservePresentation {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected ImageDescriptor getInternalImage() throws Exception {
+	protected ImageDescriptor getInternalImageDescriptor() throws Exception {
 		return IMAGE;
 	}
 

--- a/org.eclipse.wb.rcp.databinding.emf/src/org/eclipse/wb/internal/rcp/databinding/emf/model/bindables/EPropertyBindableInfo.java
+++ b/org.eclipse.wb.rcp.databinding.emf/src/org/eclipse/wb/internal/rcp/databinding/emf/model/bindables/EPropertyBindableInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -63,7 +63,7 @@ public class EPropertyBindableInfo extends BindableInfo implements IObserveDecor
 			String text,
 			String reference) {
 		this(objectType, reference, new SimpleObservePresentation(text,
-				TypeImageProvider.getImage(objectType)));
+				TypeImageProvider.getImageDescriptor(objectType)));
 		m_propertiesSupport = propertiesSupport;
 		m_parent = parent;
 		m_internalReference = reference;

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanBindableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanBindableInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -62,7 +62,7 @@ public class BeanBindableInfo extends BindableInfo {
 				new BeanBindablePresentation(objectType,
 						presentationReferenceProvider,
 						javaInfo,
-						beanSupport.getBeanImage(objectType, javaInfo)));
+						beanSupport.getBeanImageDescriptor(objectType, javaInfo)));
 	}
 
 	public BeanBindableInfo(BeanSupport beanSupport,

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanBindablePresentation.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanBindablePresentation.java
@@ -73,7 +73,7 @@ public final class BeanBindablePresentation extends ObservePresentation {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected ImageDescriptor getInternalImage() throws Exception {
+	protected ImageDescriptor getInternalImageDescriptor() throws Exception {
 		if (m_beanImage == null && m_javaInfo == null) {
 			return null;
 		}

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanPropertyDescriptorBindableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanPropertyDescriptorBindableInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -66,9 +66,9 @@ public final class BeanPropertyDescriptorBindableInfo extends BeanPropertyBindab
 			final String bindingReference = parentReference + "." + reference;
 			return new SimpleObservePresentation(reference,
 					bindingReference,
-					TypeImageProvider.getImage(objectType));
+					TypeImageProvider.getImageDescriptor(objectType));
 		}
-		return new SimpleObservePresentation(reference, TypeImageProvider.getImage(objectType));
+		return new SimpleObservePresentation(reference, TypeImageProvider.getImageDescriptor(objectType));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanSupport.java
@@ -413,7 +413,7 @@ public final class BeanSupport {
 	/**
 	 * @return {@link ImageDescriptor} represented given bean class.
 	 */
-	public ImageDescriptor getBeanImage(Class<?> beanClass, ObjectInfo javaInfo) throws Exception {
+	public ImageDescriptor getBeanImageDescriptor(Class<?> beanClass, ObjectInfo javaInfo) throws Exception {
 		// check java info
 		if (javaInfo != null) {
 			return null;

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/FieldBeanBindableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/FieldBeanBindableInfo.java
@@ -122,7 +122,7 @@ public final class FieldBeanBindableInfo extends BeanBindableInfo {
 			//
 			presentation.setJavaInfo(newJavaInfo);
 			presentation.setObjectType(componentClass);
-			presentation.setBeanImage(getBeanSupport().getBeanImage(componentClass, newJavaInfo));
+			presentation.setBeanImage(getBeanSupport().getBeanImageDescriptor(componentClass, newJavaInfo));
 			//
 			if (m_hostJavaInfo != null) {
 				m_hostJavaInfo = newJavaInfo;

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/PropertyBindableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/PropertyBindableInfo.java
@@ -67,7 +67,7 @@ public abstract class PropertyBindableInfo extends BeanBindableInfo implements I
 			String text,
 			Class<?> objectType,
 			String reference) {
-		this(beanSupport, parent, text, TypeImageProvider.getImage(objectType), objectType, reference);
+		this(beanSupport, parent, text, TypeImageProvider.getImageDescriptor(objectType), objectType, reference);
 	}
 
 	public PropertyBindableInfo(BeanSupport beanSupport,
@@ -78,7 +78,7 @@ public abstract class PropertyBindableInfo extends BeanBindableInfo implements I
 		this(beanSupport,
 				parent,
 				text,
-				TypeImageProvider.getImage(objectType),
+				TypeImageProvider.getImageDescriptor(objectType),
 				objectType,
 				referenceProvider);
 	}

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/bindables/WidgetPropertyBindableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/bindables/WidgetPropertyBindableInfo.java
@@ -75,7 +75,7 @@ public final class WidgetPropertyBindableInfo extends BindableInfo implements IO
 			IObservableFactory observableFactory,
 			IObserveDecorator decorator) {
 		this(text,
-				TypeImageProvider.getImage(objectType),
+				TypeImageProvider.getImageDescriptor(objectType),
 				objectType,
 				reference,
 				observableFactory,

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/contentproviders/TreeContentLabelProvidersUiContentProvider.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/contentproviders/TreeContentLabelProvidersUiContentProvider.java
@@ -429,7 +429,7 @@ public final class TreeContentLabelProvidersUiContentProvider implements IUiCont
 			}
 			//
 			TreePropertyWrapper wrapper = (TreePropertyWrapper) element;
-			return m_resourceManager.createImageWithDefault(TypeImageProvider.getImage(wrapper.descriptor.getPropertyType()));
+			return m_resourceManager.createImageWithDefault(TypeImageProvider.getImageDescriptor(wrapper.descriptor.getPropertyType()));
 		}
 
 		@Override

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/providers/PropertyAdapterLabelProvider.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/providers/PropertyAdapterLabelProvider.java
@@ -41,7 +41,7 @@ public final class PropertyAdapterLabelProvider extends LabelProvider {
 	@Override
 	public Image getImage(Object element) {
 		PropertyAdapter adapter = (PropertyAdapter) element;
-		return m_resourceManager.createImageWithDefault(TypeImageProvider.getImage(adapter.getType()));
+		return m_resourceManager.createImageWithDefault(TypeImageProvider.getImageDescriptor(adapter.getType()));
 	}
 
 	@Override

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/providers/TypeImageProvider.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/providers/TypeImageProvider.java
@@ -49,7 +49,7 @@ public final class TypeImageProvider {
 	/**
 	 * @return {@link ImageDescriptor} association with given {@link Class}.
 	 */
-	public static ImageDescriptor getImage(Class<?> type) {
+	public static ImageDescriptor getImageDescriptor(Class<?> type) {
 		// unknown type accept as object
 		if (type == null) {
 			return OBJECT_IMAGE;

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/TableWrapSelectionEditPolicy.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/TableWrapSelectionEditPolicy.java
@@ -121,8 +121,8 @@ AbstractGridSelectionEditPolicy {
 			if (horizontal) {
 				return new AbstractPopupFigure(viewer, 9, 5) {
 					@Override
-					protected ImageDescriptor getImage() {
-						return layoutData.getSmallAlignmentImage(true);
+					protected ImageDescriptor getImageDescriptor() {
+						return layoutData.getSmallAlignmentImageDescriptor(true);
 					}
 
 					@Override
@@ -133,8 +133,8 @@ AbstractGridSelectionEditPolicy {
 			} else {
 				return new AbstractPopupFigure(viewer, 5, 9) {
 					@Override
-					protected ImageDescriptor getImage() {
-						return layoutData.getSmallAlignmentImage(false);
+					protected ImageDescriptor getImageDescriptor() {
+						return layoutData.getSmallAlignmentImageDescriptor(false);
 					}
 
 					@Override

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/forms/layout/table/ITableWrapDataInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/forms/layout/table/ITableWrapDataInfo.java
@@ -133,7 +133,7 @@ public interface ITableWrapDataInfo extends ILayoutDataInfo {
 	 * @return the small {@link ImageDescriptor} that represents horizontal/vertical
 	 *         alignment.
 	 */
-	ImageDescriptor getSmallAlignmentImage(boolean horizontal);
+	ImageDescriptor getSmallAlignmentImageDescriptor(boolean horizontal);
 
 	/**
 	 * Adds the horizontal alignment {@link Action}'s.

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/forms/layout/table/TableWrapDataInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/forms/layout/table/TableWrapDataInfo.java
@@ -445,7 +445,7 @@ public final class TableWrapDataInfo extends LayoutDataInfo implements ITableWra
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public ImageDescriptor getSmallAlignmentImage(boolean horizontal) {
+	public ImageDescriptor getSmallAlignmentImageDescriptor(boolean horizontal) {
 		if (horizontal) {
 			switch (horizontalAlignment) {
 			case TableWrapData.LEFT :

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/WorkbenchPartLikeInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/WorkbenchPartLikeInfo.java
@@ -20,7 +20,6 @@ import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.model.util.IJavaInfoRendering;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.ast.DomGenerics;
-import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.core.utils.state.GlobalState;
 import org.eclipse.wb.internal.core.utils.ui.TabFolderDecorator;
@@ -39,7 +38,6 @@ import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabItem;
-import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Shell;
@@ -168,12 +166,7 @@ IJavaInfoRendering {
 
 	@Override
 	protected void refresh_fetch() throws Exception {
-		ControlInfo.refresh_fetch(this, new RunnableEx() {
-			@Override
-			public void run() throws Exception {
-				WorkbenchPartLikeInfo.super.refresh_fetch();
-			}
-		});
+		ControlInfo.refresh_fetch(this, () -> WorkbenchPartLikeInfo.super.refresh_fetch());
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -216,9 +209,7 @@ IJavaInfoRendering {
 					IProject project = getEditor().getJavaProject().getProject();
 					IFile iconFile = project.getFile(new Path(iconPath));
 					if (iconFile.exists()) {
-						String iconLocation = iconFile.getLocation().toOSString();
-						ImageData imageData = new ImageData(iconLocation);
-						icon = ImageDescriptor.createFromImageDataProvider((zoom) -> zoom == 100 ? imageData : null);
+						icon = ImageDescriptor.createFromURL(iconFile.getLocationURI().toURL());
 					}
 				}
 			}

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/FormSelectionEditPolicy.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/FormSelectionEditPolicy.java
@@ -118,8 +118,8 @@ public final class FormSelectionEditPolicy extends AbstractGridSelectionEditPoli
 		if (horizontal) {
 			return new AbstractPopupFigure(viewer, 9, 5) {
 				@Override
-				protected ImageDescriptor getImage() {
-					return constraints.getSmallAlignmentImage(true);
+				protected ImageDescriptor getImageDescriptor() {
+					return constraints.getSmallAlignmentImageDescriptor(true);
 				}
 
 				@Override
@@ -130,8 +130,8 @@ public final class FormSelectionEditPolicy extends AbstractGridSelectionEditPoli
 		} else {
 			return new AbstractPopupFigure(viewer, 5, 9) {
 				@Override
-				protected ImageDescriptor getImage() {
-					return constraints.getSmallAlignmentImage(false);
+				protected ImageDescriptor getImageDescriptor() {
+					return constraints.getSmallAlignmentImageDescriptor(false);
 				}
 
 				@Override

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/model/CellConstraintsSupport.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/model/CellConstraintsSupport.java
@@ -32,7 +32,6 @@ import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.swt.graphics.Image;
 
 import com.jgoodies.forms.layout.CellConstraints;
 import com.jgoodies.forms.layout.CellConstraints.Alignment;
@@ -523,9 +522,9 @@ public final class CellConstraintsSupport {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * @return the small {@link Image} that represents horizontal/vertical alignment.
+	 * @return the small {@link ImageDescriptor} that represents horizontal/vertical alignment.
 	 */
-	public ImageDescriptor getSmallAlignmentImage(boolean horizontal) {
+	public ImageDescriptor getSmallAlignmentImageDescriptor(boolean horizontal) {
 		if (horizontal) {
 			if (alignH == CellConstraints.LEFT) {
 				return Activator.getImageDescriptor("alignment/h/left.gif");

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/MigSelectionEditPolicy.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/MigSelectionEditPolicy.java
@@ -117,8 +117,8 @@ public final class MigSelectionEditPolicy extends AbstractGridSelectionEditPolic
 		if (horizontal) {
 			return new AbstractPopupFigure(viewer, 9, 5) {
 				@Override
-				protected ImageDescriptor getImage() {
-					return constraints.getSmallAlignmentImage(true);
+				protected ImageDescriptor getImageDescriptor() {
+					return constraints.getSmallAlignmentImageDescriptor(true);
 				}
 
 				@Override
@@ -129,8 +129,8 @@ public final class MigSelectionEditPolicy extends AbstractGridSelectionEditPolic
 		} else {
 			return new AbstractPopupFigure(viewer, 5, 9) {
 				@Override
-				protected ImageDescriptor getImage() {
-					return constraints.getSmallAlignmentImage(false);
+				protected ImageDescriptor getImageDescriptor() {
+					return constraints.getSmallAlignmentImageDescriptor(false);
 				}
 
 				@Override

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/actions/SetAlignmentColumnAction.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/actions/SetAlignmentColumnAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -32,7 +32,7 @@ public final class SetAlignmentColumnAction extends DimensionHeaderAction<MigCol
 	//
 	////////////////////////////////////////////////////////////////////////////
 	public SetAlignmentColumnAction(DimensionHeaderEditPart<MigColumnInfo> header, Alignment alignment) {
-		super(header, alignment.getText(), alignment.getMenuImage(), AS_RADIO_BUTTON);
+		super(header, alignment.getText(), alignment.getMenuImageDescriptor(), AS_RADIO_BUTTON);
 		m_alignment = alignment;
 		setChecked(header.getDimension().getAlignment(false) == m_alignment);
 	}

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/actions/SetAlignmentRowAction.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/actions/SetAlignmentRowAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -32,7 +32,7 @@ public final class SetAlignmentRowAction extends DimensionHeaderAction<MigRowInf
 	//
 	////////////////////////////////////////////////////////////////////////////
 	public SetAlignmentRowAction(DimensionHeaderEditPart<MigRowInfo> header, Alignment alignment) {
-		super(header, alignment.getText(), alignment.getMenuImage(), AS_RADIO_BUTTON);
+		super(header, alignment.getText(), alignment.getMenuImageDescriptor(), AS_RADIO_BUTTON);
 		m_alignment = alignment;
 		setChecked(header.getDimension().getAlignment(false) == m_alignment);
 	}

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/edit/ColumnHeaderEditPart.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/edit/ColumnHeaderEditPart.java
@@ -97,7 +97,7 @@ public class ColumnHeaderEditPart extends DimensionHeaderEditPart<MigColumnInfo>
 				}
 				// draw alignment indicator
 				if (titleLeft - r.x > 3 + 7 + 3) {
-					Image image = m_column.getAlignment(true).getSmallImage().createImage();
+					Image image = m_column.getAlignment(true).getSmallImageDescriptor().createImage();
 					int x = r.x + 2;
 					drawCentered(graphics, image, x);
 					image.dispose();

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/edit/RowHeaderEditPart.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/edit/RowHeaderEditPart.java
@@ -97,7 +97,7 @@ public class RowHeaderEditPart extends DimensionHeaderEditPart<MigRowInfo> {
 				}
 				// draw alignment indicator
 				if (titleTop - r.y > 3 + 7 + 3) {
-					Image image = m_row.getAlignment(true).getSmallImage().createImage();
+					Image image = m_row.getAlignment(true).getSmallImageDescriptor().createImage();
 					int y = r.y + 2;
 					drawCentered(graphics, image, y);
 					image.dispose();

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/CellConstraintsSupport.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/CellConstraintsSupport.java
@@ -839,11 +839,11 @@ public final class CellConstraintsSupport {
 	 * @return the small {@link ImageDescriptor} that represents horizontal/vertical
 	 *         alignment.
 	 */
-	public ImageDescriptor getSmallAlignmentImage(boolean horizontal) {
+	public ImageDescriptor getSmallAlignmentImageDescriptor(boolean horizontal) {
 		if (horizontal) {
-			return getHorizontalAlignment().getSmallImage();
+			return getHorizontalAlignment().getSmallImageDescriptor();
 		} else {
-			return getVerticalAlignment().getSmallImage();
+			return getVerticalAlignment().getSmallImageDescriptor();
 		}
 	}
 
@@ -935,7 +935,7 @@ public final class CellConstraintsSupport {
 		public SetHorizontalAlignmentAction(String text, MigColumnInfo.Alignment alignment) {
 			super(m_layout, text, AS_RADIO_BUTTON);
 			m_alignment = alignment;
-			setImageDescriptor(alignment.getMenuImage());
+			setImageDescriptor(alignment.getMenuImageDescriptor());
 			// set check for current alignment
 			setChecked(getHorizontalAlignment() == m_alignment);
 		}
@@ -970,7 +970,7 @@ public final class CellConstraintsSupport {
 		public SetVerticalAlignmentAction(String text, MigRowInfo.Alignment alignment) {
 			super(m_layout, text, AS_RADIO_BUTTON);
 			m_alignment = alignment;
-			setImageDescriptor(alignment.getMenuImage());
+			setImageDescriptor(alignment.getMenuImageDescriptor());
 			// set check for current alignment
 			setChecked(getVerticalAlignment() == m_alignment);
 		}

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/MigColumnInfo.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/MigColumnInfo.java
@@ -40,7 +40,7 @@ public final class MigColumnInfo extends MigDimensionInfo {
 		/**
 		 * @return the small image (5x9) to display current alignment to user.
 		 */
-		public ImageDescriptor getSmallImage() {
+		public ImageDescriptor getSmallImageDescriptor() {
 			String pattern = "alignment/h/small/{0}.gif";
 			String path = MessageFormat.format(pattern, name().toLowerCase());
 			return Activator.getImageDescriptor(path);
@@ -49,7 +49,7 @@ public final class MigColumnInfo extends MigDimensionInfo {
 		/**
 		 * @return the big image (16x16) to display for user in menu.
 		 */
-		public ImageDescriptor getMenuImage() {
+		public ImageDescriptor getMenuImageDescriptor() {
 			String pattern = "alignment/h/menu/{0}.gif";
 			String path = MessageFormat.format(pattern, name().toLowerCase());
 			return Activator.getImageDescriptor(path);

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/MigRowInfo.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/MigRowInfo.java
@@ -40,7 +40,7 @@ public final class MigRowInfo extends MigDimensionInfo {
 		/**
 		 * @return the small image (5x9) to display current alignment to user.
 		 */
-		public ImageDescriptor getSmallImage() {
+		public ImageDescriptor getSmallImageDescriptor() {
 			String pattern = "alignment/v/small/{0}.gif";
 			String path = MessageFormat.format(pattern, name().toLowerCase());
 			return Activator.getImageDescriptor(path);
@@ -49,7 +49,7 @@ public final class MigRowInfo extends MigDimensionInfo {
 		/**
 		 * @return the big image (16x16) to display for user in menu.
 		 */
-		public ImageDescriptor getMenuImage() {
+		public ImageDescriptor getMenuImageDescriptor() {
 			String pattern = "alignment/v/menu/{0}.gif";
 			String path = MessageFormat.format(pattern, name().toLowerCase());
 			return Activator.getImageDescriptor(path);

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/SelectionActionsSupport.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/SelectionActionsSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -116,7 +116,7 @@ public class SelectionActionsSupport extends ObjectEventListener {
 		public HorizontalAlignmentAction(List<CellConstraintsSupport> constraints,
 				boolean checked,
 				MigColumnInfo.Alignment alignment) {
-			super(m_layout, alignment.getText(), alignment.getMenuImage(), AS_RADIO_BUTTON);
+			super(m_layout, alignment.getText(), alignment.getMenuImageDescriptor(), AS_RADIO_BUTTON);
 			setChecked(checked);
 			m_constraints = constraints;
 			m_alignment = alignment;
@@ -171,7 +171,7 @@ public class SelectionActionsSupport extends ObjectEventListener {
 		public VerticalAlignmentAction(List<CellConstraintsSupport> constraints,
 				boolean checked,
 				MigRowInfo.Alignment alignment) {
-			super(m_layout, alignment.getText(), alignment.getMenuImage(), AS_RADIO_BUTTON);
+			super(m_layout, alignment.getText(), alignment.getMenuImageDescriptor(), AS_RADIO_BUTTON);
 			setChecked(checked);
 			m_constraints = constraints;
 			m_alignment = alignment;

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/BeanPropertyObserveInfo.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/BeanPropertyObserveInfo.java
@@ -57,10 +57,10 @@ public class BeanPropertyObserveInfo extends BeanObserveInfo implements IObserve
 				java.util.List.class.isAssignableFrom(getObjectClass())
 				? ObserveCreationType.ListProperty
 						: ObserveCreationType.AnyProperty;
-		ImageDescriptor beenImage = beanSupport.getBeanImage(getObjectClass(), null, false);
+		ImageDescriptor beenImage = beanSupport.getBeanImageDescriptor(getObjectClass(), null, false);
 		m_presentation =
 				new SimpleObservePresentation(text, text, beenImage == null
-				? TypeImageProvider.getImage(getObjectClass())
+				? TypeImageProvider.getImageDescriptor(getObjectClass())
 						: beenImage);
 		m_decorator = decorator;
 	}

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/BeanSupport.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/BeanSupport.java
@@ -281,7 +281,7 @@ public final class BeanSupport {
 	/**
 	 * @return {@link ImageDescriptor} represented given bean class.
 	 */
-	public ImageDescriptor getBeanImage(Class<?> beanClass, JavaInfo javaInfo, boolean useDefault)
+	public ImageDescriptor getBeanImageDescriptor(Class<?> beanClass, JavaInfo javaInfo, boolean useDefault)
 			throws Exception {
 		// check java info
 		if (javaInfo != null) {

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/FieldBeanObserveInfo.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/FieldBeanObserveInfo.java
@@ -41,7 +41,7 @@ public final class FieldBeanObserveInfo extends BeanObserveInfo {
 		setBindingDecoration(IDecoration.TOP_LEFT);
 		m_fragment = fragment;
 		m_presentation =
-				new FieldBeanObservePresentation(this, javaInfo, beanSupport.getBeanImage(
+				new FieldBeanObservePresentation(this, javaInfo, beanSupport.getBeanImageDescriptor(
 						getObjectClass(),
 						javaInfo,
 						true));

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/FieldBeanObservePresentation.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/FieldBeanObservePresentation.java
@@ -45,7 +45,7 @@ public final class FieldBeanObservePresentation extends ObservePresentation {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected ImageDescriptor getInternalImage() throws Exception {
+	protected ImageDescriptor getInternalImageDescriptor() throws Exception {
 		if (m_beanImage == null && m_javaInfo == null) {
 			return null;
 		}

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/providers/TypeImageProvider.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/providers/TypeImageProvider.java
@@ -43,7 +43,7 @@ public final class TypeImageProvider {
 	/**
 	 * @return {@link ImageDescriptor} association with given {@link Class}.
 	 */
-	public static ImageDescriptor getImage(Class<?> type) {
+	public static ImageDescriptor getImageDescriptor(Class<?> type) {
 		// unknown type accept as object
 		if (type == null) {
 			return OBJECT_IMAGE;

--- a/org.eclipse.wb.swing.java6/src/org/eclipse/wb/internal/swing/java6/gef/GroupSelectionEditPolicy.java
+++ b/org.eclipse.wb.swing.java6/src/org/eclipse/wb/internal/swing/java6/gef/GroupSelectionEditPolicy.java
@@ -44,8 +44,8 @@ public final class GroupSelectionEditPolicy extends AbsoluteComplexSelectionEdit
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public ImageDescriptor getActionImage(String imageName) {
-		return GroupLayoutInfo.getImage(imageName);
+	public ImageDescriptor getActionImageDescriptor(String imageName) {
+		return GroupLayoutInfo.getImageDescriptor(imageName);
 	}
 
 	@Override

--- a/org.eclipse.wb.swing.java6/src/org/eclipse/wb/internal/swing/java6/model/GroupLayoutInfo.java
+++ b/org.eclipse.wb.swing.java6/src/org/eclipse/wb/internal/swing/java6/model/GroupLayoutInfo.java
@@ -162,7 +162,7 @@ public final class GroupLayoutInfo extends LayoutInfo implements IAbsoluteLayout
 	// Misc
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public static ImageDescriptor getImage(String imageName) {
+	public static ImageDescriptor getImageDescriptor(String imageName) {
 		return Activator.getImageDescriptor("info/layout/groupLayout/" + imageName);
 	}
 

--- a/org.eclipse.wb.swing.java6/src/org/eclipse/wb/internal/swing/java6/model/GroupLayoutInfo2.java
+++ b/org.eclipse.wb.swing.java6/src/org/eclipse/wb/internal/swing/java6/model/GroupLayoutInfo2.java
@@ -157,7 +157,7 @@ public final class GroupLayoutInfo2 extends LayoutInfo implements IAdaptable {
 		static final IImageProvider INSTANCE = new ImageProvider();
 
 		@Override
-		public ImageDescriptor getImage(String path) {
+		public ImageDescriptor getImageDescriptor(String path) {
 			return Activator.getImageDescriptor(path);
 		}
 	}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/SpringSelectionEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/SpringSelectionEditPolicy.java
@@ -44,8 +44,8 @@ public final class SpringSelectionEditPolicy extends AbsoluteComplexSelectionEdi
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public ImageDescriptor getActionImage(String imageName) {
-		return SpringLayoutInfo.getImage(imageName);
+	public ImageDescriptor getActionImageDescriptor(String imageName) {
+		return SpringLayoutInfo.getImageDescriptor(imageName);
 	}
 
 	@Override

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/GridBagSelectionEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/GridBagSelectionEditPolicy.java
@@ -118,7 +118,7 @@ public final class GridBagSelectionEditPolicy extends AbstractGridSelectionEditP
 		if (horizontal) {
 			return new AbstractPopupFigure(viewer, 9, 5) {
 				@Override
-				protected ImageDescriptor getImage() {
+				protected ImageDescriptor getImageDescriptor() {
 					switch (constraints.getHorizontalAlignment()) {
 					case LEFT :
 						return getImage2("h/alignment/left.gif");
@@ -140,7 +140,7 @@ public final class GridBagSelectionEditPolicy extends AbstractGridSelectionEditP
 		} else {
 			return new AbstractPopupFigure(viewer, 5, 9) {
 				@Override
-				protected ImageDescriptor getImage() {
+				protected ImageDescriptor getImageDescriptor() {
 					switch (constraints.getVerticalAlignment()) {
 					case TOP :
 						return getImage2("v/alignment/top.gif");

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/spring/SpringLayoutInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/spring/SpringLayoutInfo.java
@@ -280,7 +280,7 @@ public final class SpringLayoutInfo extends LayoutInfo implements IAbsoluteLayou
 		return !getAttachment(widget, side).isVirtual();
 	}
 
-	public static ImageDescriptor getImage(String imageName) {
+	public static ImageDescriptor getImageDescriptor(String imageName) {
 		return Activator.getImageDescriptor("info/layout/springLayout/" + imageName);
 	}
 

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/AnchorFiguresClassic.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/AnchorFiguresClassic.java
@@ -217,7 +217,7 @@ public final class AnchorFiguresClassic<C extends IControlInfo> {
 		}
 
 		@Override
-		protected ImageDescriptor getImage() {
+		protected ImageDescriptor getImageDescriptor() {
 			return m_layoutImpl.getAnchorActions().getImageHorizontal(m_widget, m_side);
 		}
 
@@ -237,7 +237,7 @@ public final class AnchorFiguresClassic<C extends IControlInfo> {
 		}
 
 		@Override
-		protected ImageDescriptor getImage() {
+		protected ImageDescriptor getImageDescriptor() {
 			try {
 				return m_layoutImpl.getAnchorActions().getImageVertical(m_widget, m_side);
 			} catch (Throwable e) {

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormSelectionEditPolicy.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormSelectionEditPolicy.java
@@ -48,8 +48,8 @@ AbsoluteComplexSelectionEditPolicy {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public ImageDescriptor getActionImage(String imageName) {
-		return FormLayoutInfoImplAutomatic.getImage(imageName);
+	public ImageDescriptor getActionImageDescriptor(String imageName) {
+		return FormLayoutInfoImplAutomatic.getImageDescriptor(imageName);
 	}
 
 	@Override

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/GridSelectionEditPolicy.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/GridSelectionEditPolicy.java
@@ -124,8 +124,8 @@ AbstractGridSelectionEditPolicy {
 			if (horizontal) {
 				return new AbstractPopupFigure(viewer, 9, 5) {
 					@Override
-					protected ImageDescriptor getImage() {
-						return constraints.getSmallAlignmentImage(true);
+					protected ImageDescriptor getImageDescriptor() {
+						return constraints.getSmallAlignmentImageDescriptor(true);
 					}
 
 					@Override
@@ -136,8 +136,8 @@ AbstractGridSelectionEditPolicy {
 			} else {
 				return new AbstractPopupFigure(viewer, 5, 9) {
 					@Override
-					protected ImageDescriptor getImage() {
-						return constraints.getSmallAlignmentImage(false);
+					protected ImageDescriptor getImageDescriptor() {
+						return constraints.getSmallAlignmentImageDescriptor(false);
 					}
 
 					@Override

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/FormLayoutInfoImplAutomatic.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/FormLayoutInfoImplAutomatic.java
@@ -726,7 +726,7 @@ FormLayoutInfoImpl<C> implements IAbsoluteLayoutCommands {
 		return null;
 	}
 
-	public static ImageDescriptor getImage(String imageName) {
+	public static ImageDescriptor getImageDescriptor(String imageName) {
 		return Activator.getImageDescriptor("info/layout/FormLayout/" + imageName);
 	}
 

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/LayoutAssistantPage.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/LayoutAssistantPage.java
@@ -50,7 +50,7 @@ ILayoutAssistantPage {
 	private final List<C> m_selection;
 	private final IFormLayoutInfo<C> m_layout;
 	private final PlacementsSupport m_placementsSupport;
-	private final IActionImageProvider m_imageProvider = FormLayoutInfoImplAutomatic::getImage;
+	private final IActionImageProvider m_imageProvider = FormLayoutInfoImplAutomatic::getImageDescriptor;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -201,7 +201,7 @@ ILayoutAssistantPage {
 		private final List<C> m_widgets;
 
 		private SetCornerAnchorsAction(List<C> selection, String text, String imageName, int alignment) {
-			super(m_layout.getUnderlyingModel(), text, m_imageProvider.getActionImage(imageName));
+			super(m_layout.getUnderlyingModel(), text, m_imageProvider.getActionImageDescriptor(imageName));
 			m_widgets = selection;
 			m_alignment = alignment;
 		}

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/grid/GridDataInfo.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/grid/GridDataInfo.java
@@ -478,7 +478,7 @@ public final class GridDataInfo extends LayoutDataInfo implements IGridDataInfo 
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public ImageDescriptor getSmallAlignmentImage(boolean horizontal) {
+	public ImageDescriptor getSmallAlignmentImageDescriptor(boolean horizontal) {
 		if (horizontal) {
 			switch (horizontalAlignment) {
 			case SWT.LEFT :

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/grid/IGridDataInfo.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/grid/IGridDataInfo.java
@@ -138,7 +138,7 @@ public interface IGridDataInfo extends IObjectInfo {
 	 * @return the small {@link ImageDescriptor} that represents horizontal/vertical
 	 *         alignment.
 	 */
-	ImageDescriptor getSmallAlignmentImage(boolean horizontal);
+	ImageDescriptor getSmallAlignmentImageDescriptor(boolean horizontal);
 
 	/**
 	 * Adds the horizontal alignment {@link Action}'s.

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XWT/model/forms/table/TableWrapDataTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XWT/model/forms/table/TableWrapDataTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -93,7 +93,7 @@ public class TableWrapDataTest extends XwtModelTest {
 			} else {
 				layoutData.setVerticalAlignment(alignment);
 			}
-			assertSame(expectedImage, layoutData.getSmallAlignmentImage(horizontal));
+			assertSame(expectedImage, layoutData.getSmallAlignmentImageDescriptor(horizontal));
 		}
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XWT/model/layout/grid/GridDataTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XWT/model/layout/grid/GridDataTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -202,7 +202,7 @@ public class GridDataTest extends XwtModelTest {
 			} else {
 				gridData.setVerticalAlignment(alignment);
 			}
-			assertSame(expectedImage, gridData.getSmallAlignmentImage(horizontal));
+			assertSame(expectedImage, gridData.getSmallAlignmentImageDescriptor(horizontal));
 		}
 	}
 
@@ -227,8 +227,8 @@ public class GridDataTest extends XwtModelTest {
 		ControlInfo button = getObjectByName("button");
 		//
 		GridDataInfo gridData = getGridData(button);
-		assertSame(null, gridData.getSmallAlignmentImage(true));
-		assertSame(null, gridData.getSmallAlignmentImage(false));
+		assertSame(null, gridData.getSmallAlignmentImageDescriptor(true));
+		assertSame(null, gridData.getSmallAlignmentImageDescriptor(false));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/forms/table/TableWrapDataTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/forms/table/TableWrapDataTest.java
@@ -94,7 +94,7 @@ public class TableWrapDataTest extends AbstractFormsTest {
 			} else {
 				layoutData.setVerticalAlignment(alignment);
 			}
-			assertSame(expectedImage, layoutData.getSmallAlignmentImage(horizontal));
+			assertSame(expectedImage, layoutData.getSmallAlignmentImageDescriptor(horizontal));
 		}
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/FormLayout/CellConstraintsSupportTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/FormLayout/CellConstraintsSupportTest.java
@@ -301,7 +301,7 @@ public class CellConstraintsSupportTest extends AbstractFormLayoutTest {
 			constraints.setAlignV(alignment);
 		}
 		// check image
-		ImageDescriptor alignmentImage = constraints.getSmallAlignmentImage(horizontal);
+		ImageDescriptor alignmentImage = constraints.getSmallAlignmentImageDescriptor(horizontal);
 		if (notNullExpected) {
 			assertNotNull(alignmentImage);
 		} else {

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/MigLayout/MigColumnTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/MigLayout/MigColumnTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -48,8 +48,8 @@ public class MigColumnTest extends AbstractMigLayoutTest {
 	}
 
 	private static void checkAlignment(MigColumnInfo.Alignment alignment, String expectedText) {
-		assertNotNull(alignment.getSmallImage());
-		assertNotNull(alignment.getMenuImage());
+		assertNotNull(alignment.getSmallImageDescriptor());
+		assertNotNull(alignment.getMenuImageDescriptor());
 		assertEquals(expectedText, alignment.getText());
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/MigLayout/MigLayoutConstraintsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/MigLayout/MigLayoutConstraintsTest.java
@@ -870,7 +870,7 @@ public class MigLayoutConstraintsTest extends AbstractMigLayoutTest {
 		}
 		assertSame(
 				Activator.getImageDescriptor("alignment/h/small/" + imageName),
-				constraints.getSmallAlignmentImage(true));
+				constraints.getSmallAlignmentImageDescriptor(true));
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -927,7 +927,7 @@ public class MigLayoutConstraintsTest extends AbstractMigLayoutTest {
 		}
 		assertSame(
 				Activator.getImageDescriptor("alignment/v/small/" + imageName),
-				constraints.getSmallAlignmentImage(false));
+				constraints.getSmallAlignmentImageDescriptor(false));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/MigLayout/MigRowTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/MigLayout/MigRowTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -47,8 +47,8 @@ public class MigRowTest extends AbstractMigLayoutTest {
 	}
 
 	private static void checkAlignment(MigRowInfo.Alignment alignment, String expectedText) {
-		assertNotNull(alignment.getSmallImage());
-		assertNotNull(alignment.getMenuImage());
+		assertNotNull(alignment.getSmallImageDescriptor());
+		assertNotNull(alignment.getMenuImageDescriptor());
 		assertEquals(expectedText, alignment.getText());
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/spring/SpringLayoutTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/spring/SpringLayoutTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -53,11 +53,11 @@ public class SpringLayoutTest extends AbstractLayoutTest {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * Test for {@link SpringLayoutInfo#getImage(String)}.
+	 * Test for {@link SpringLayoutInfo#getImageDescriptor(String)}.
 	 */
 	@Test
 	public void test_getImage() throws Exception {
-		assertNotNull(SpringLayoutInfo.getImage("h/left.gif"));
+		assertNotNull(SpringLayoutInfo.getImageDescriptor("h/left.gif"));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/layouts/grid/GridDataTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/layouts/grid/GridDataTest.java
@@ -289,7 +289,7 @@ public class GridDataTest extends RcpModelTest {
 			} else {
 				gridData.setVerticalAlignment(alignment);
 			}
-			assertSame(expectedImage, gridData.getSmallAlignmentImage(horizontal));
+			assertSame(expectedImage, gridData.getSmallAlignmentImageDescriptor(horizontal));
 		}
 	}
 
@@ -313,8 +313,8 @@ public class GridDataTest extends RcpModelTest {
 		ControlInfo button = shell.getChildrenControls().get(0);
 		//
 		GridDataInfo gridData = getGridData(button);
-		assertSame(null, gridData.getSmallAlignmentImage(true));
-		assertSame(null, gridData.getSmallAlignmentImage(false));
+		assertSame(null, gridData.getSmallAlignmentImageDescriptor(true));
+		assertSame(null, gridData.getSmallAlignmentImageDescriptor(false));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/forms/layout/table/TableWrapDataInfo.java
+++ b/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/forms/layout/table/TableWrapDataInfo.java
@@ -322,7 +322,7 @@ public final class TableWrapDataInfo extends LayoutDataInfo implements ITableWra
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public ImageDescriptor getSmallAlignmentImage(boolean horizontal) {
+	public ImageDescriptor getSmallAlignmentImageDescriptor(boolean horizontal) {
 		if (horizontal) {
 			switch (horizontalAlignment) {
 			case TableWrapData.LEFT :

--- a/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/layout/grid/GridDataInfo.java
+++ b/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/layout/grid/GridDataInfo.java
@@ -473,7 +473,7 @@ public final class GridDataInfo extends LayoutDataInfo implements IGridDataInfo 
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public ImageDescriptor getSmallAlignmentImage(boolean horizontal) {
+	public ImageDescriptor getSmallAlignmentImageDescriptor(boolean horizontal) {
 		if (horizontal) {
 			switch (horizontalAlignment) {
 			case SWT.LEFT :


### PR DESCRIPTION
The methods that used to return plain images and that were called getXImage() have been renamed to getXImageDescriptor(), in case they now return a descriptor. This change should avoid any confusion as to what type this method is returned.

Furthermore, the deprecatead/unused methods and fields used by the old image-based implementation have been removed.