### PR TITLE
Code Cleanup - Replace Guava Functions with Java Functions

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/MorphingSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/MorphingSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.util;
 
-import com.google.common.base.Function;
 import com.google.common.collect.Sets;
 
 import org.eclipse.wb.core.model.JavaInfo;
@@ -232,14 +231,11 @@ public abstract class MorphingSupport<T extends JavaInfo> extends AbstractMorphi
 				final Class<?> targetClass = target.getComponentClass();
 				if (ReflectionUtils.getConstructorBySignature(targetClass, signature) != null) {
 					final ClassInstanceCreation creationNode = constructorCreation.getCreation();
-					String source = m_editor.getExternalSource(creationNode, new Function<ASTNode, String>() {
-						@Override
-						public String apply(ASTNode from) {
-							if (from == creationNode.getType()) {
-								return targetClass.getName();
-							}
-							return null;
+					String source = m_editor.getExternalSource(creationNode, from -> {
+						if (from == creationNode.getType()) {
+							return targetClass.getName();
 						}
+						return null;
 					});
 					return ConstructorCreationSupport.forSource(source);
 				}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/factory/FactoryCreateAction.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/factory/FactoryCreateAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.util.factory;
 
-import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -580,33 +579,30 @@ public final class FactoryCreateAction extends Action {
 	 *         needed.
 	 */
 	private String getFactorySource(final AbstractInvocationInfo invocation) {
-		return m_editor.getExternalSource(invocation.m_expression, new Function<ASTNode, String>() {
-			@Override
-			public String apply(ASTNode from) {
-				// replace arguments with parameters
-				for (ArgumentInfo argument : invocation.m_arguments) {
-					if (argument.m_parameter && argument.m_expression == from) {
-						return argument.m_parameterName;
-					}
+		return m_editor.getExternalSource(invocation.m_expression, from -> {
+			// replace arguments with parameters
+			for (ArgumentInfo argument : invocation.m_arguments) {
+				if (argument.m_parameter && argument.m_expression == from) {
+					return argument.m_parameterName;
 				}
-				// replace getClass() with ClassLiteral source
-				if (from instanceof MethodInvocation invocationNode) {
-					if (invocationNode.getExpression() == null
-							&& invocationNode.getName().getIdentifier().equals("getClass")
-							&& invocationNode.arguments().isEmpty()) {
-						TypeDeclaration enclosingType = AstNodeUtils.getEnclosingType(invocationNode);
-						return AstNodeUtils.getFullyQualifiedName(enclosingType, false) + ".class";
-					}
-				}
-				// replace "expression" of method invocation with empty string
-				if (invocation instanceof InvocationInfo methodInvocation) {
-					if (from == methodInvocation.m_invocation.getExpression()) {
-						return "";
-					}
-				}
-				// use usual expression source
-				return null;
 			}
+			// replace getClass() with ClassLiteral source
+			if (from instanceof MethodInvocation invocationNode) {
+				if (invocationNode.getExpression() == null
+						&& invocationNode.getName().getIdentifier().equals("getClass")
+						&& invocationNode.arguments().isEmpty()) {
+					TypeDeclaration enclosingType = AstNodeUtils.getEnclosingType(invocationNode);
+					return AstNodeUtils.getFullyQualifiedName(enclosingType, false) + ".class";
+				}
+			}
+			// replace "expression" of method invocation with empty string
+			if (invocation instanceof InvocationInfo methodInvocation) {
+				if (from == methodInvocation.m_invocation.getExpression()) {
+					return "";
+				}
+			}
+			// use usual expression source
+			return null;
 		});
 	}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/AstEditor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/AstEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.utils.ast;
 
-import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -92,6 +91,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 
 /**
  * {@link AstEditor} is central point for all AST and source editing operations, such as adding new

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/ExtensionElementProperty.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/ExtensionElementProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,9 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.rcp;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
-
 import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.model.property.editor.PropertyEditor;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
@@ -21,6 +18,8 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.pde.core.plugin.IPluginElement;
 
 import org.apache.commons.lang.ObjectUtils;
+
+import java.util.function.Function;
 
 /**
  * {@link Property} that updates PDE model.
@@ -34,19 +33,9 @@ public final class ExtensionElementProperty<T> extends Property {
 	// Converters
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public static final Function<String, String> IDENTITY = Functions.identity();
-	public static final Function<Boolean, String> FROM_BOOLEAN = new Function<>() {
-		@Override
-		public String apply(Boolean from) {
-			return from.toString();
-		}
-	};
-	public static final Function<String, Boolean> TO_BOOLEAN = new Function<>() {
-		@Override
-		public Boolean apply(String from) {
-			return Boolean.parseBoolean(from);
-		}
-	};
+	public static final Function<String, String> IDENTITY = Function.identity();
+	public static final Function<Boolean, String> FROM_BOOLEAN = from -> from.toString();
+	public static final Function<String, Boolean> TO_BOOLEAN = Boolean::parseBoolean;
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Instance fields

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/ExtensionPropertyHelper.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/ExtensionPropertyHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.rcp;
-
-import com.google.common.base.Function;
 
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.broadcast.JavaInfoAddProperties;
@@ -28,6 +26,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * Helper for creating property with name "Extension" for attributes in <code>plugin.xml</code>

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/gbl/AbstractGridBagLayoutInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/gbl/AbstractGridBagLayoutInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.model.layout.gbl;
 
-import com.google.common.base.Function;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
@@ -110,12 +109,7 @@ public abstract class AbstractGridBagLayoutInfo extends LayoutInfo implements IP
 			protected AbstractAssistantPage createConstraintsPage(Composite parent,
 					List<ObjectInfo> objects) {
 				List<AbstractGridBagConstraintsInfo> constraints =
-						Lists.transform(objects, new Function<ObjectInfo, AbstractGridBagConstraintsInfo>() {
-							@Override
-							public AbstractGridBagConstraintsInfo apply(ObjectInfo from) {
-								return getConstraints((ComponentInfo) from);
-							}
-						});
+						Lists.transform(objects, from -> getConstraints((ComponentInfo) from));
 				return new GridBagConstraintsAssistantPage(parent, constraints);
 			}
 		};

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/BorderPropertyEditor.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/BorderPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.model.property.editor.border;
-
-import com.google.common.base.Function;
 
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.DesignerPlugin;
@@ -30,7 +28,6 @@ import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 import org.eclipse.wb.internal.core.utils.jdt.core.CodeUtils;
 
-import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.IVariableBinding;
@@ -91,15 +88,12 @@ IClipboardSourceProvider {
 			// Ask "external" source.
 			// Replace each reference on variable with "bad" mark.
 			AstEditor editor = property.getJavaInfo().getEditor();
-			String source = editor.getExternalSource(expression, new Function<ASTNode, String>() {
-				@Override
-				public String apply(ASTNode input) {
-					IVariableBinding variableBinding = AstNodeUtils.getVariableBinding(input);
-					if (variableBinding != null && !variableBinding.isField()) {
-						return badExpressionMark;
-					}
-					return null;
+			String source = editor.getExternalSource(expression, input -> {
+				IVariableBinding variableBinding = AstNodeUtils.getVariableBinding(input);
+				if (variableBinding != null && !variableBinding.isField()) {
+					return badExpressionMark;
 				}
+				return null;
 			});
 			// if source has variable references, fail
 			if (source.contains(badExpressionMark)) {

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/LayoutAssistantSupport.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/LayoutAssistantSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swt.model.layout;
 
-import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.model.ObjectInfo;
@@ -65,12 +64,7 @@ org.eclipse.wb.core.editor.actions.assistant.LayoutAssistantSupport {
 	 */
 	protected final List<ILayoutDataInfo> getDataList(List<ObjectInfo> objects) {
 		List<ILayoutDataInfo> dataList =
-				Lists.transform(objects, new Function<ObjectInfo, ILayoutDataInfo>() {
-					@Override
-					public ILayoutDataInfo apply(ObjectInfo from) {
-						return m_layout.getLayoutData2((IControlInfo) from);
-					}
-				});
+				Lists.transform(objects, from -> m_layout.getLayoutData2((IControlInfo) from));
 		return dataList;
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/NlsSupportTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/NlsSupportTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.nls;
 
-import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
@@ -303,12 +302,7 @@ public class NlsSupportTest extends SwingModelTest {
 			preferencesRepairer.setValue(IPreferenceConstants.P_NLS_ALWAYS_VISIBLE_LOCALES, "de, ru_RU");
 			LocaleInfo[] locales = m_support.getLocales();
 			List<String> localeNames =
-					Lists.transform(ImmutableList.copyOf(locales), new Function<LocaleInfo, String>() {
-						@Override
-						public String apply(LocaleInfo from) {
-							return from.toString();
-						}
-					});
+					Lists.transform(ImmutableList.copyOf(locales), from -> from.toString());
 			Assertions.assertThat(localeNames).hasSize(4).containsOnly("(default)", "it", "de", "ru_RU");
 		} finally {
 			preferencesRepairer.restore();

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/ast/AstEditorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/ast/AstEditorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.util.ast;
 
-import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
@@ -93,6 +92,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * Tests for {@link AstEditor}.
@@ -1289,14 +1289,11 @@ public class AstEditorTest extends AbstractJavaTest {
 		assertEquals("new java.util.ArrayList(test.Constants.SIZE)", getExternalSource(fields[2], null));
 		assertEquals(
 				"new java.util.ArrayList(sizeParameter)",
-				getExternalSource(fields[2], new Function<ASTNode, String>() {
-					@Override
-					public String apply(ASTNode from) {
-						if (m_lastEditor.getSource(from).equals("Constants.SIZE")) {
-							return "sizeParameter";
-						}
-						return null;
+				getExternalSource(fields[2], from -> {
+					if (m_lastEditor.getSource(from).equals("Constants.SIZE")) {
+						return "sizeParameter";
 					}
+					return null;
 				}));
 		assertEquals("java.util.Collections.emptyList()", getExternalSource(fields[3], null));
 		assertEquals("java.util.List.class", getExternalSource(fields[4], null));


### PR DESCRIPTION
The Guava functions have been more or less deprecated with the Java functions being the drop-in replacement