### PR TITLE
[GEF] Harmonize Figure color accessors with GEF base-class

### DIFF
--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
@@ -23,7 +23,6 @@ import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
-import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Cursor;
 
 import java.util.Collections;
@@ -42,8 +41,6 @@ public class Figure extends org.eclipse.draw2d.Figure {
 	private final Rectangle m_bounds = new Rectangle();
 	private List<Figure> m_children;
 	private Border m_border;
-	private Color m_background;
-	private Color m_foreground;
 	private Cursor m_cursor;
 	private Object m_data;
 	private String m_toolTipText;
@@ -327,11 +324,11 @@ public class Figure extends org.eclipse.draw2d.Figure {
 	@Override
 	public final void paint(Graphics graphics) {
 		// set figure state
-		if (m_background != null) {
-			graphics.setBackgroundColor(m_background);
+		if (getBackgroundColor() != null) {
+			graphics.setBackgroundColor(getBackgroundColor());
 		}
-		if (m_foreground != null) {
-			graphics.setForegroundColor(m_foreground);
+		if (getForegroundColor() != null) {
+			graphics.setForegroundColor(getForegroundColor());
 		}
 		if (getFont() != null) {
 			graphics.setFont(getFont());
@@ -545,40 +542,6 @@ public class Figure extends org.eclipse.draw2d.Figure {
 				revalidate();
 				repaint();
 			}
-		}
-	}
-
-	/**
-	 * Returns the background Color of this Figure.
-	 */
-	public Color getBackground() {
-		return m_background;
-	}
-
-	/**
-	 * Sets the background color.
-	 */
-	public void setBackground(Color background) {
-		if (m_background != background) {
-			m_background = background;
-			repaint();
-		}
-	}
-
-	/**
-	 * Returns the local foreground Color of this Figure.
-	 */
-	public Color getForeground() {
-		return m_foreground;
-	}
-
-	/**
-	 * Sets the foreground color.
-	 */
-	public void setForeground(Color foreground) {
-		if (m_foreground != foreground) {
-			m_foreground = foreground;
-			repaint();
 		}
 	}
 

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/CustomTooltipProvider.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/CustomTooltipProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -38,8 +38,8 @@ public abstract class CustomTooltipProvider implements ICustomTooltipProvider {
 		canvas.addListener(SWT.MouseExit, site.getHideListener());
 		//
 		RootFigure rootFigure = canvas.getRootFigure();
-		rootFigure.setForeground(parent.getForeground());
-		rootFigure.setBackground(parent.getBackground());
+		rootFigure.setForegroundColor(parent.getForeground());
+		rootFigure.setBackgroundColor(parent.getBackground());
 		//
 		Layer layer = new Layer("Tooltip");
 		layer.add(createTooltipFigure(figure));

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/FigureCanvas.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/FigureCanvas.java
@@ -69,8 +69,8 @@ public class FigureCanvas extends Canvas {
 
 	private void createRootFigure() {
 		m_rootFigure = new RootFigure(this);
-		m_rootFigure.setBackground(getBackground());
-		m_rootFigure.setForeground(getForeground());
+		m_rootFigure.setBackgroundColor(getBackground());
+		m_rootFigure.setForegroundColor(getForeground());
 		m_rootFigure.setFont(getFont());
 		setDefaultEventManager();
 	}

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/IRootFigure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/IRootFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -73,22 +73,22 @@ public interface IRootFigure {
 	/**
 	 * Returns the background Color of this Figure.
 	 */
-	Color getBackground();
+	Color getBackgroundColor();
 
 	/**
 	 * Sets the background color.
 	 */
-	void setBackground(Color background);
+	void setBackgroundColor(Color background);
 
 	/**
 	 * Returns the local foreground Color of this Figure.
 	 */
-	Color getForeground();
+	Color getForegroundColor();
 
 	/**
 	 * Sets the foreground color.
 	 */
-	void setForeground(Color foreground);
+	void setForegroundColor(Color foreground);
 
 	/**
 	 * Returns the current Font by reference.

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/SemiTransparentFigure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/SemiTransparentFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -49,7 +49,7 @@ public class SemiTransparentFigure extends Figure {
 		{
 			PaletteData palette = new PaletteData(0xFF, 0xFF00, 0xFF0000);
 			ImageData data = new ImageData(1, 1, 32, palette);
-			int pixel = palette.getPixel(getBackground().getRGB());
+			int pixel = palette.getPixel(getBackgroundColor().getRGB());
 			data.setPixel(0, 0, pixel);
 			data.setAlpha(0, 0, m_alpha);
 			//

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/tools/MarqueeSelectionTool.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/tools/MarqueeSelectionTool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -246,8 +246,8 @@ public class MarqueeSelectionTool extends Tool {
 					graphics.drawRectangle(0, 0, r.width - 1, r.height - 1);
 				}
 			};
-			m_marqueeFeedbackFigure.setForeground(IColorConstants.white);
-			m_marqueeFeedbackFigure.setBackground(IColorConstants.black);
+			m_marqueeFeedbackFigure.setForegroundColor(IColorConstants.white);
+			m_marqueeFeedbackFigure.setBackgroundColor(IColorConstants.black);
 			getFeedbackPane().add(m_marqueeFeedbackFigure);
 		}
 		// update feedback figure

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
@@ -131,8 +131,8 @@ public final class PaletteComposite extends Composite {
 		// prepare draw2d FigureCanvas
 		{
 			m_figureCanvas = new FigureCanvas(this, SWT.V_SCROLL);
-			m_figureCanvas.getRootFigure().setBackground(COLOR_PALETTE_BACKGROUND);
-			m_figureCanvas.getRootFigure().setForeground(COLOR_TEXT_ENABLED);
+			m_figureCanvas.getRootFigure().setBackgroundColor(COLOR_PALETTE_BACKGROUND);
+			m_figureCanvas.getRootFigure().setForegroundColor(COLOR_TEXT_ENABLED);
 		}
 		// prepare GC (for layout)
 		{

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/figure/GhostPositionFeedback.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/figure/GhostPositionFeedback.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -46,7 +46,7 @@ public final class GhostPositionFeedback extends AbstractPositionFeedback {
 	@Override
 	protected Figure createFigure() {
 		Figure figure = new SemiTransparentFigure(50);
-		figure.setBackground(m_fillColor);
+		figure.setBackgroundColor(m_fillColor);
 		figure.setBorder(new LineBorder(m_borderColor));
 		return figure;
 	}
@@ -54,9 +54,9 @@ public final class GhostPositionFeedback extends AbstractPositionFeedback {
 	@Override
 	public void update(boolean contains) {
 		if (contains) {
-			m_figure.setBackground(m_activeColor);
+			m_figure.setBackgroundColor(m_activeColor);
 		} else {
-			m_figure.setBackground(m_fillColor);
+			m_figure.setBackgroundColor(m_fillColor);
 		}
 	}
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/figure/OutlineImageFigure.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/figure/OutlineImageFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -41,7 +41,7 @@ public final class OutlineImageFigure extends Figure {
 
 	public OutlineImageFigure(Image image, Color borderColor) {
 		m_image = image;
-		setForeground(borderColor);
+		setForegroundColor(borderColor);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/figure/SolidPositionFeedback.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/figure/SolidPositionFeedback.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -50,9 +50,9 @@ public final class SolidPositionFeedback extends AbstractPositionFeedback {
 	@Override
 	public void update(boolean contains) {
 		if (contains) {
-			m_figure.setBackground(getActiveColor());
+			m_figure.setBackgroundColor(getActiveColor());
 		} else {
-			m_figure.setBackground(getInactiveColor());
+			m_figure.setBackgroundColor(getInactiveColor());
 		}
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/figure/TextFeedback.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/figure/TextFeedback.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -45,8 +45,8 @@ public final class TextFeedback {
 		// create label
 		m_label = isHorizontal ? new Label() : new VerticalLabel();
 		m_label.setOpaque(true);
-		m_label.setBackground(IColorConstants.tooltipBackground);
-		m_label.setForeground(IColorConstants.tooltipForeground);
+		m_label.setBackgroundColor(IColorConstants.tooltipBackground);
+		m_label.setForegroundColor(IColorConstants.tooltipForeground);
 		{
 			Border outer = new LineBorder(IColorConstants.tooltipForeground);
 			Border inner = new MarginBorder(2);
@@ -102,7 +102,7 @@ public final class TextFeedback {
 	 * Sets the background of feedback.
 	 */
 	public void setBackground(Color color) {
-		m_label.setBackground(color);
+		m_label.setBackgroundColor(color);
 	}
 
 	/**

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/flow/AbstractFlowLayoutEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/flow/AbstractFlowLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -437,7 +437,7 @@ public abstract class AbstractFlowLayoutEditPolicy extends LayoutEditPolicy {
 			m_insertionLine = new Polyline();
 			// presentation
 			m_insertionLine.setLineWidth(2);
-			m_insertionLine.setForeground(IColorConstants.red);
+			m_insertionLine.setForegroundColor(IColorConstants.red);
 			// default points
 			m_insertionLine.addPoint(new Point(0, 0));
 			m_insertionLine.addPoint(new Point(0, 0));

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/generic/AbstractColumnSelectionEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/generic/AbstractColumnSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -63,7 +63,7 @@ public class AbstractColumnSelectionEditPolicy extends SelectionEditPolicy {
 		List<Handle> handles = Lists.newArrayList();
 		// create move column handle
 		MoveHandle moveHandle = new MoveHandle(getHost());
-		moveHandle.setForeground(IColorConstants.red);
+		moveHandle.setForegroundColor(IColorConstants.red);
 		handles.add(moveHandle);
 		//
 		return handles;
@@ -141,7 +141,7 @@ public class AbstractColumnSelectionEditPolicy extends SelectionEditPolicy {
 			// create selection feedback
 			{
 				m_resizeFeedback = new RectangleFigure();
-				m_resizeFeedback.setForeground(IColorConstants.red);
+				m_resizeFeedback.setForegroundColor(IColorConstants.red);
 				addFeedback(m_resizeFeedback);
 			}
 			// create text feedback

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/generic/AbstractPopupFigure.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/generic/AbstractPopupFigure.java
@@ -61,8 +61,8 @@ public abstract class AbstractPopupFigure extends Figure {
 		m_viewer = viewer;
 		// configure figure
 		setSize(width + MARGIN, height + MARGIN);
-		setBackground(COLOR_BACKGROUND);
-		setForeground(COLOR_FOREGROUND);
+		setBackgroundColor(COLOR_BACKGROUND);
+		setForegroundColor(COLOR_FOREGROUND);
 		setCursor(ICursorConstants.HAND);
 		// add mouse listener
 		addMouseListener(new MouseListener.Stub() {

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/grid/AbstractGridHelper.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/grid/AbstractGridHelper.java
@@ -237,7 +237,7 @@ public abstract class AbstractGridHelper {
 		// add border around container
 		{
 			RectangleFigure borderFigure = new RectangleFigure();
-			borderFigure.setForeground(m_borderColor);
+			borderFigure.setForegroundColor(m_borderColor);
 			borderFigure.setBounds(hostClientArea);
 			m_gridFigure.add(borderFigure);
 		}
@@ -266,7 +266,7 @@ public abstract class AbstractGridHelper {
 	private void addGridLine(int x1, int y1, int x2, int y2, Color color) {
 		if (color != null) {
 			Polyline line = new Polyline();
-			line.setForeground(color);
+			line.setForegroundColor(color);
 			// prepare points
 			Point p1 = new Point(x1, y1);
 			Point p2 = new Point(x2, y2);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/grid/AbstractGridLayoutEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/grid/AbstractGridLayoutEditPolicy.java
@@ -143,10 +143,10 @@ IHeadersProvider {
 				// show target rectangle
 				{
 					if (m_target.m_valid) {
-						m_targetFeedback.setBackground(m_goodTargetFillColor);
+						m_targetFeedback.setBackgroundColor(m_goodTargetFillColor);
 						m_targetFeedback.setBorder(new LineBorder(m_goodTargetBorderColor));
 					} else {
-						m_targetFeedback.setBackground(m_badTargetFillColor);
+						m_targetFeedback.setBackgroundColor(m_badTargetFillColor);
 						m_targetFeedback.setBorder(new LineBorder(m_badTargetBorderColor));
 					}
 					getLayer(IEditPartViewer.HANDLE_LAYER_SUB_1).add(m_targetFeedback);
@@ -264,7 +264,7 @@ IHeadersProvider {
 	 */
 	public static Figure createInsertFigure() {
 		Figure figure = new SemiTransparentFigure(160);
-		figure.setBackground(m_insertTargetFillColor);
+		figure.setBackgroundColor(m_insertTargetFillColor);
 		figure.setBorder(new LineBorder(m_insertTargetBorderColor));
 		return figure;
 	}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/grid/AbstractGridSelectionEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/grid/AbstractGridSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -140,7 +140,7 @@ public abstract class AbstractGridSelectionEditPolicy extends SelectionEditPolic
 				}
 			}
 		});
-		moveHandle.setForeground(IColorConstants.red);
+		moveHandle.setForegroundColor(IColorConstants.red);
 		return moveHandle;
 	}
 
@@ -381,7 +381,7 @@ public abstract class AbstractGridSelectionEditPolicy extends SelectionEditPolic
 			// add feedback figure
 			if (m_lineFeedback == null) {
 				m_lineFeedback = new RectangleFigure();
-				m_lineFeedback.setForeground(IColorConstants.green);
+				m_lineFeedback.setForegroundColor(IColorConstants.green);
 				addFeedback(m_lineFeedback);
 			}
 			// set bounds
@@ -510,7 +510,7 @@ public abstract class AbstractGridSelectionEditPolicy extends SelectionEditPolic
 			// add feedback figure
 			if (m_lineFeedback == null) {
 				m_lineFeedback = new RectangleFigure();
-				m_lineFeedback.setForeground(IColorConstants.green);
+				m_lineFeedback.setForegroundColor(IColorConstants.green);
 				addFeedback(m_lineFeedback);
 			}
 			// set bounds

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/selection/MoveSelectionEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/selection/MoveSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -54,7 +54,7 @@ public final class MoveSelectionEditPolicy extends SelectionEditPolicy {
 		List<Handle> handles = Lists.newArrayList();
 		{
 			MoveHandle moveHandle = new MoveHandle(getHost());
-			moveHandle.setForeground(m_color);
+			moveHandle.setForegroundColor(m_color);
 			handles.add(moveHandle);
 		}
 		return handles;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/selection/TopResizeFigure.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/selection/TopResizeFigure.java
@@ -38,8 +38,8 @@ public class TopResizeFigure extends SemiTransparentFigure {
 	////////////////////////////////////////////////////////////////////////////
 	public TopResizeFigure() {
 		super(64);
-		setBackground(IColorConstants.lightGreen);
-		setForeground(IColorConstants.darkGray);
+		setBackgroundColor(IColorConstants.lightGreen);
+		setForegroundColor(IColorConstants.darkGray);
 		setBorder(new LineBorder(IColorConstants.darkBlue, 1));
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/DesignComposite.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/DesignComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -158,7 +158,7 @@ public abstract class DesignComposite extends Composite {
 		// configure main GEF viewer
 		{
 			m_viewer = m_viewersComposite.getViewer();
-			m_viewer.getRootFigure().setBackground(IColorConstants.listBackground);
+			m_viewer.getRootFigure().setBackgroundColor(IColorConstants.listBackground);
 			m_viewer.setEditDomain(domain);
 			m_viewer.setEditPartFactory(EditPartFactory.INSTANCE);
 		}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/AbsoluteBasedLayoutEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/AbsoluteBasedLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -930,14 +930,14 @@ IPreferenceConstants {
 	@Override
 	public Figure addHorizontalFeedbackLine(int y, int x, int width) {
 		Polyline line = createLineFeedback(x, y, x + width, y);
-		line.setForeground(AbsolutePolicyUtils.COLOR_FEEDBACK);
+		line.setForegroundColor(AbsolutePolicyUtils.COLOR_FEEDBACK);
 		return line;
 	}
 
 	@Override
 	public Figure addHorizontalMiddleLineFeedback(int y, int x, int width) {
 		Polyline line = createLineFeedback(x, y, x + width, y);
-		line.setForeground(AbsolutePolicyUtils.COLOR_FEEDBACK);
+		line.setForegroundColor(AbsolutePolicyUtils.COLOR_FEEDBACK);
 		line.setLineStyle(SWT.LINE_DASH);
 		return line;
 	}
@@ -958,14 +958,14 @@ IPreferenceConstants {
 	@Override
 	public Figure addVerticalFeedbackLine(int x, int y, int height) {
 		Polyline line = createLineFeedback(x, y, x, y + height);
-		line.setForeground(AbsolutePolicyUtils.COLOR_FEEDBACK);
+		line.setForegroundColor(AbsolutePolicyUtils.COLOR_FEEDBACK);
 		return line;
 	}
 
 	@Override
 	public Figure addVerticalMiddleLineFeedback(int x, int y, int height) {
 		Polyline line = createLineFeedback(x, y, x, y + height);
-		line.setForeground(AbsolutePolicyUtils.COLOR_FEEDBACK);
+		line.setForegroundColor(AbsolutePolicyUtils.COLOR_FEEDBACK);
 		line.setLineStyle(SWT.LINE_DASH);
 		return line;
 	}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/AbsoluteComplexSelectionEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/AbsoluteComplexSelectionEditPolicy.java
@@ -197,7 +197,7 @@ AbsoluteBasedSelectionEditPolicy<C> implements IActionImageProvider {
 		Polyline line = new Polyline();
 		line.addPoint(begin);
 		line.addPoint(end);
-		line.setForeground(AbsolutePolicyUtils.COLOR_FEEDBACK);
+		line.setForegroundColor(AbsolutePolicyUtils.COLOR_FEEDBACK);
 		line.setLineStyle(SWT.LINE_DASH);
 		addMyFeedback(line);
 	}

--- a/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/gef/FeedbacksDrawer.java
+++ b/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/gef/FeedbacksDrawer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -55,7 +55,7 @@ final class FeedbacksDrawer implements IFeedbacksDrawer {
 	@Override
 	public void drawLine(int x1, int y1, int x2, int y2) {
 		Polyline line = createLineFeedback(x1, y1, x2, y2);
-		line.setForeground(AbsolutePolicyUtils.COLOR_FEEDBACK);
+		line.setForegroundColor(AbsolutePolicyUtils.COLOR_FEEDBACK);
 		m_feedbacks.add(line);
 	}
 

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/ColumnLayoutSelectionEditPolicy.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/ColumnLayoutSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -139,7 +139,7 @@ SelectionEditPolicy {
 			// create selection feedback
 			{
 				m_resizeFeedback = new RectangleFigure();
-				m_resizeFeedback.setForeground(IColorConstants.red);
+				m_resizeFeedback.setForegroundColor(IColorConstants.red);
 				addFeedback(m_resizeFeedback);
 			}
 			// create text feedback

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/header/edit/DimensionHeaderEditPart.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/header/edit/DimensionHeaderEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -114,7 +114,7 @@ IHeaderMenuProvider {
 			@Override
 			public void run() throws Exception {
 				getFigure().setToolTipText(m_dimension.getTitle());
-				getFigure().setBackground(COLOR_NORMAL);
+				getFigure().setBackgroundColor(COLOR_NORMAL);
 			}
 		});
 	}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/header/selection/DimensionSelectionEditPolicy.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/header/selection/DimensionSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -58,7 +58,7 @@ AbstractHeaderSelectionEditPolicy {
 		// move handle
 		{
 			MoveHandle moveHandle = new MoveHandle(getHost(), new HeaderMoveHandleLocator());
-			moveHandle.setForeground(IColorConstants.red);
+			moveHandle.setForegroundColor(IColorConstants.red);
 			handles.add(moveHandle);
 		}
 		//

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/rcp/perspective/AbstractPartSelectionEditPolicy.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/rcp/perspective/AbstractPartSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -67,7 +67,7 @@ public final class AbstractPartSelectionEditPolicy extends SelectionEditPolicy {
 		List<Handle> handles = Lists.newArrayList();
 		// create move column handle
 		MoveHandle moveHandle = new MoveHandle(getHost());
-		moveHandle.setForeground(IColorConstants.red);
+		moveHandle.setForegroundColor(IColorConstants.red);
 		handles.add(moveHandle);
 		//
 		return handles;
@@ -160,7 +160,7 @@ public final class AbstractPartSelectionEditPolicy extends SelectionEditPolicy {
 			// create selection feedback
 			{
 				m_resizeFeedback = new RectangleFigure();
-				m_resizeFeedback.setForeground(IColorConstants.red);
+				m_resizeFeedback.setForegroundColor(IColorConstants.red);
 				addFeedback(m_resizeFeedback);
 			}
 		}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/widgets/SashFormSelectionEditPolicy.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/widgets/SashFormSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -66,7 +66,7 @@ public final class SashFormSelectionEditPolicy<C extends IControlInfo> extends S
 		List<Handle> handles = Lists.newArrayList();
 		// create move handle
 		MoveHandle moveHandle = new MoveHandle(getHost());
-		moveHandle.setForeground(IColorConstants.red);
+		moveHandle.setForegroundColor(IColorConstants.red);
 		handles.add(moveHandle);
 		//
 		return handles;
@@ -151,7 +151,7 @@ public final class SashFormSelectionEditPolicy<C extends IControlInfo> extends S
 			// create selection feedback
 			{
 				m_resizeFeedback = new RectangleFigure();
-				m_resizeFeedback.setForeground(IColorConstants.red);
+				m_resizeFeedback.setForegroundColor(IColorConstants.red);
 				addFeedback(m_resizeFeedback);
 			}
 			// create text feedback

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/widgets/TreeTreeColumnSelectionEditPolicy.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/widgets/TreeTreeColumnSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -62,7 +62,7 @@ public final class TreeTreeColumnSelectionEditPolicy extends SelectionEditPolicy
 		List<Handle> handles = Lists.newArrayList();
 		// create move column handle
 		MoveHandle moveHandle = new MoveHandle(getHost());
-		moveHandle.setForeground(IColorConstants.red);
+		moveHandle.setForegroundColor(IColorConstants.red);
 		handles.add(moveHandle);
 		//
 		return handles;
@@ -131,7 +131,7 @@ public final class TreeTreeColumnSelectionEditPolicy extends SelectionEditPolicy
 			// create selection feedback
 			{
 				m_resizeFeedback = new RectangleFigure();
-				m_resizeFeedback.setForeground(IColorConstants.red);
+				m_resizeFeedback.setForegroundColor(IColorConstants.red);
 				addFeedback(m_resizeFeedback);
 			}
 			// create text feedback

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/edit/DimensionHeaderEditPart.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/edit/DimensionHeaderEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -128,13 +128,13 @@ GraphicalEditPart implements IHeaderMenuProvider {
 		// update background
 		{
 			if (m_dimension.isGap()) {
-				getFigure().setBackground(COLOR_GAP);
+				getFigure().setBackgroundColor(COLOR_GAP);
 			} else {
 				int group = m_layout.getDimensionGroupIndex(m_dimension);
 				if (group != -1) {
-					getFigure().setBackground(GROUP_COLORS[group % GROUP_COLORS.length]);
+					getFigure().setBackgroundColor(GROUP_COLORS[group % GROUP_COLORS.length]);
 				} else {
-					getFigure().setBackground(COLOR_NORMAL);
+					getFigure().setBackgroundColor(COLOR_NORMAL);
 				}
 			}
 		}

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/selection/DimensionSelectionEditPolicy.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/selection/DimensionSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -69,7 +69,7 @@ AbstractHeaderSelectionEditPolicy {
 		// move handle
 		{
 			MoveHandle moveHandle = new MoveHandle(getHost(), new HeaderMoveHandleLocator());
-			moveHandle.setForeground(IColorConstants.red);
+			moveHandle.setForegroundColor(IColorConstants.red);
 			handles.add(moveHandle);
 		}
 		//

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/selection/ResizeHintFigure.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/selection/ResizeHintFigure.java
@@ -45,8 +45,8 @@ public final class ResizeHintFigure extends Figure {
 	////////////////////////////////////////////////////////////////////////////
 	public ResizeHintFigure() {
 		setOpaque(true);
-		setBackground(IColorConstants.tooltipBackground);
-		setForeground(IColorConstants.tooltipForeground);
+		setBackgroundColor(IColorConstants.tooltipBackground);
+		setForegroundColor(IColorConstants.tooltipForeground);
 		setBorder(new CompoundBorder(new LineBorder(IColorConstants.tooltipForeground),
 				new MarginBorder(2)));
 	}

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/edit/DimensionHeaderEditPart.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/edit/DimensionHeaderEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -123,7 +123,7 @@ IHeaderMenuProvider {
 		//getFigure().setToolTipText(m_dimension.getToolTip());
 		// update background
 		{
-			getFigure().setBackground(COLOR_NORMAL);
+			getFigure().setBackgroundColor(COLOR_NORMAL);
 			// XXX
 			/*if (m_dimension.isGap()) {
       	getFigure().setBackground(COLOR_GAP);

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/selection/DimensionSelectionEditPolicy.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/selection/DimensionSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -78,7 +78,7 @@ AbstractHeaderSelectionEditPolicy {
 		// move handle
 		{
 			MoveHandle moveHandle = new MoveHandle(getHost(), new HeaderMoveHandleLocator());
-			moveHandle.setForeground(IColorConstants.red);
+			moveHandle.setForegroundColor(IColorConstants.red);
 			handles.add(moveHandle);
 		}
 		//

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/selection/ResizeHintFigure.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/selection/ResizeHintFigure.java
@@ -44,8 +44,8 @@ public final class ResizeHintFigure extends Figure {
 	////////////////////////////////////////////////////////////////////////////
 	public ResizeHintFigure() {
 		setOpaque(true);
-		setBackground(IColorConstants.tooltipBackground);
-		setForeground(IColorConstants.tooltipForeground);
+		setBackgroundColor(IColorConstants.tooltipBackground);
+		setForegroundColor(IColorConstants.tooltipForeground);
 		setBorder(new CompoundBorder(new LineBorder(IColorConstants.tooltipForeground),
 				new MarginBorder(5)));
 	}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/component/box/GlueSelectionEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/component/box/GlueSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -38,7 +38,7 @@ public final class GlueSelectionEditPolicy extends SelectionEditPolicy {
 		List<Handle> handles = Lists.newArrayList();
 		// create move handle
 		MoveHandle moveHandle = new MoveHandle(getHost());
-		moveHandle.setForeground(IColorConstants.red);
+		moveHandle.setForegroundColor(IColorConstants.red);
 		handles.add(moveHandle);
 		//
 		return handles;

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/component/box/StrutSelectionEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/component/box/StrutSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -64,7 +64,7 @@ abstract class StrutSelectionEditPolicy extends SelectionEditPolicy {
 		List<Handle> handles = Lists.newArrayList();
 		// create move handle
 		MoveHandle moveHandle = new MoveHandle(getHost());
-		moveHandle.setForeground(IColorConstants.red);
+		moveHandle.setForegroundColor(IColorConstants.red);
 		handles.add(moveHandle);
 		//
 		return handles;
@@ -134,7 +134,7 @@ abstract class StrutSelectionEditPolicy extends SelectionEditPolicy {
 			// create size feedback
 			{
 				m_sizeFeedback = new RectangleFigure();
-				m_sizeFeedback.setForeground(IColorConstants.red);
+				m_sizeFeedback.setForegroundColor(IColorConstants.red);
 				addFeedback(m_sizeFeedback);
 			}
 			// create text feedback

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/header/edit/ColumnHeaderEditPart.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/header/edit/ColumnHeaderEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -128,7 +128,7 @@ public final class ColumnHeaderEditPart extends DimensionHeaderEditPart<ColumnIn
 		};
 		//
 		figure.setOpaque(true);
-		figure.setBackground(COLOR_NORMAL);
+		figure.setBackgroundColor(COLOR_NORMAL);
 		figure.setFont(DEFAULT_FONT);
 		return figure;
 	}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/header/edit/RowHeaderEditPart.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/header/edit/RowHeaderEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -133,7 +133,7 @@ public final class RowHeaderEditPart extends DimensionHeaderEditPart<RowInfo> {
 		};
 		//
 		figure.setOpaque(true);
-		figure.setBackground(COLOR_NORMAL);
+		figure.setBackgroundColor(COLOR_NORMAL);
 		figure.setFont(DEFAULT_FONT);
 		return figure;
 	}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/header/selection/DimensionSelectionEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/header/selection/DimensionSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -70,7 +70,7 @@ AbstractHeaderSelectionEditPolicy {
 		// move handle
 		{
 			MoveHandle moveHandle = new MoveHandle(getHost(), new HeaderMoveHandleLocator());
-			moveHandle.setForeground(IColorConstants.red);
+			moveHandle.setForegroundColor(IColorConstants.red);
 			handles.add(moveHandle);
 		}
 		//

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/menu/MenuBarDropLayoutEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/menu/MenuBarDropLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -90,7 +90,7 @@ public final class MenuBarDropLayoutEditPolicy extends LayoutEditPolicy {
 				}
 			};
 			m_feedback.setOpaque(true);
-			m_feedback.setBackground(IColorConstants.menuBackground);
+			m_feedback.setBackgroundColor(IColorConstants.menuBackground);
 			// set figure bounds
 			Insets clientAreaInsets = m_container.getInsets();
 			Rectangle bounds = getHostFigure().getBounds().getCopy();

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/TableTableColumnSelectionEditPolicy.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/TableTableColumnSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -64,7 +64,7 @@ public final class TableTableColumnSelectionEditPolicy extends SelectionEditPoli
 		List<Handle> handles = Lists.newArrayList();
 		// create move column handle
 		MoveHandle moveHandle = new MoveHandle(getHost());
-		moveHandle.setForeground(IColorConstants.red);
+		moveHandle.setForegroundColor(IColorConstants.red);
 		handles.add(moveHandle);
 		//
 		return handles;
@@ -135,7 +135,7 @@ public final class TableTableColumnSelectionEditPolicy extends SelectionEditPoli
 			// create selection feedback
 			{
 				m_resizeFeedback = new RectangleFigure();
-				m_resizeFeedback.setForeground(IColorConstants.red);
+				m_resizeFeedback.setForegroundColor(IColorConstants.red);
 				addFeedback(m_resizeFeedback);
 			}
 			// create text feedback

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/RowLayoutSelectionEditPolicy.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/RowLayoutSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -144,7 +144,7 @@ public final class RowLayoutSelectionEditPolicy<C extends IControlInfo> extends 
 			// create selection feedback
 			{
 				m_resizeFeedback = new RectangleFigure();
-				m_resizeFeedback.setForeground(IColorConstants.red);
+				m_resizeFeedback.setForegroundColor(IColorConstants.red);
 				addFeedback(m_resizeFeedback);
 			}
 			// create text feedback

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormLayoutEditPolicy2.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormLayoutEditPolicy2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -188,14 +188,14 @@ IHeadersProvider {
 	@Override
 	public Figure addHorizontalFeedbackLine(int y, int x, int width) {
 		Polyline line = createLineFeedback(x, y, x + width, y);
-		line.setForeground(AbsolutePolicyUtils.COLOR_FEEDBACK);
+		line.setForegroundColor(AbsolutePolicyUtils.COLOR_FEEDBACK);
 		return line;
 	}
 
 	@Override
 	public Figure addHorizontalMiddleLineFeedback(int y, int x, int width) {
 		Polyline line = createLineFeedback(x, y, x + width, y);
-		line.setForeground(AbsolutePolicyUtils.COLOR_FEEDBACK);
+		line.setForegroundColor(AbsolutePolicyUtils.COLOR_FEEDBACK);
 		line.setLineStyle(SWT.LINE_DASH);
 		return line;
 	}
@@ -216,14 +216,14 @@ IHeadersProvider {
 	@Override
 	public Figure addVerticalFeedbackLine(int x, int y, int height) {
 		Polyline line = createLineFeedback(x, y, x, y + height);
-		line.setForeground(AbsolutePolicyUtils.COLOR_FEEDBACK);
+		line.setForegroundColor(AbsolutePolicyUtils.COLOR_FEEDBACK);
 		return line;
 	}
 
 	@Override
 	public Figure addVerticalMiddleLineFeedback(int x, int y, int height) {
 		Polyline line = createLineFeedback(x, y, x, y + height);
-		line.setForeground(AbsolutePolicyUtils.COLOR_FEEDBACK);
+		line.setForegroundColor(AbsolutePolicyUtils.COLOR_FEEDBACK);
 		line.setLineStyle(SWT.LINE_DASH);
 		return line;
 	}

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormLayoutEditPolicyClassic.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormLayoutEditPolicyClassic.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -1187,7 +1187,7 @@ implements IHeadersProvider {
 		translateModelToFeedback(p2);
 		line.addPoint(p1);
 		line.addPoint(p2);
-		line.setForeground(color);
+		line.setForegroundColor(color);
 		line.setLineStyle(SWT.LINE_DOT);
 		// add the line to feedbacks
 		addFeedback(line);

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormSelectionEditPolicyClassic.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormSelectionEditPolicyClassic.java
@@ -1123,7 +1123,7 @@ SelectionEditPolicy {
 		translateModelToFeedback(p2);
 		line.addPoint(p1);
 		line.addPoint(p2);
-		line.setForeground(color);
+		line.setForegroundColor(color);
 		line.setLineStyle(SWT.LINE_DOT);
 		// add feedback
 		addFeedback(line);

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/header/edit/DimensionHeaderEditPart.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/header/edit/DimensionHeaderEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -114,7 +114,7 @@ IHeaderMenuProvider {
 			@Override
 			public void run() throws Exception {
 				getFigure().setToolTipText(m_dimension.getTitle());
-				getFigure().setBackground(COLOR_NORMAL);
+				getFigure().setBackgroundColor(COLOR_NORMAL);
 			}
 		});
 	}

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/header/selection/DimensionSelectionEditPolicy.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/header/selection/DimensionSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -58,7 +58,7 @@ AbstractHeaderSelectionEditPolicy {
 		// move handle
 		{
 			MoveHandle moveHandle = new MoveHandle(getHost(), new HeaderMoveHandleLocator());
-			moveHandle.setForeground(IColorConstants.red);
+			moveHandle.setForegroundColor(IColorConstants.red);
 			handles.add(moveHandle);
 		}
 		//

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/menu/MenuBarDropLayoutEditPolicy.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/menu/MenuBarDropLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -95,7 +95,7 @@ public class MenuBarDropLayoutEditPolicy extends LayoutEditPolicy {
 				}
 			};
 			m_fillFeedback.setOpaque(true);
-			m_fillFeedback.setBackground(IColorConstants.menuBackground);
+			m_fillFeedback.setBackgroundColor(IColorConstants.menuBackground);
 			// set figure bounds
 			Insets clientAreaInsets = m_shell.getClientAreaInsets();
 			final Rectangle bounds = getHostFigure().getBounds().getCopy();

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigurePaintingTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigurePaintingTest.java
@@ -241,26 +241,26 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		TestLogger expectedLogger = new TestLogger();
 		//
 		// check repaint during setBackground()
-		testFigure.setBackground(red);
+		testFigure.setBackgroundColor(red);
 		expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check no repaint during setBackground() if color not change
-		testFigure.setBackground(red);
+		testFigure.setBackgroundColor(red);
 		m_actualLogger.assertEmpty();
 		//
 		// check repaint during setBackground()
-		testFigure.setBackground(green);
+		testFigure.setBackgroundColor(green);
 		expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check repaint during setBackground()
-		testFigure.setBackground(null);
+		testFigure.setBackgroundColor(null);
 		expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check no repaint during setBackground() if color not change
-		testFigure.setBackground(null);
+		testFigure.setBackgroundColor(null);
 		m_actualLogger.assertEmpty();
 	}
 
@@ -270,26 +270,26 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		TestLogger expectedLogger = new TestLogger();
 		//
 		// check repaint during setForeground()
-		testFigure.setForeground(red);
+		testFigure.setForegroundColor(red);
 		expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check no repaint during setForeground() if color not change
-		testFigure.setForeground(red);
+		testFigure.setForegroundColor(red);
 		m_actualLogger.assertEmpty();
 		//
 		// check repaint during setForeground()
-		testFigure.setForeground(green);
+		testFigure.setForegroundColor(green);
 		expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check repaint during setForeground()
-		testFigure.setForeground(null);
+		testFigure.setForegroundColor(null);
 		expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check no repaint during setForeground() if color not change
-		testFigure.setForeground(null);
+		testFigure.setForegroundColor(null);
 		m_actualLogger.assertEmpty();
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigureTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigureTest.java
@@ -607,8 +607,8 @@ public class FigureTest extends Draw2dFigureTestCase {
 		assertEquals(new Rectangle(), testFigure.getClientArea(new Rectangle()));
 		assertEquals(new Insets(), testFigure.getInsets());
 		assertNull(testFigure.getBorder());
-		assertNull(testFigure.getBackground());
-		assertNull(testFigure.getForeground());
+		assertNull(testFigure.getBackgroundColor());
+		assertNull(testFigure.getForegroundColor());
 		assertNull(testFigure.getFont());
 		assertNull(testFigure.getCursor());
 		assertFalse(testFigure.isOpaque());
@@ -644,19 +644,19 @@ public class FigureTest extends Draw2dFigureTestCase {
 		Figure testFigure = new Figure();
 		//
 		// check color for new Figure
-		assertNull(testFigure.getBackground());
+		assertNull(testFigure.getBackgroundColor());
 		//
 		// check set color
-		testFigure.setBackground(black);
-		assertSame(black, testFigure.getBackground());
+		testFigure.setBackgroundColor(black);
+		assertSame(black, testFigure.getBackgroundColor());
 		//
 		// check set other color
-		testFigure.setBackground(red);
-		assertSame(red, testFigure.getBackground());
+		testFigure.setBackgroundColor(red);
+		assertSame(red, testFigure.getBackgroundColor());
 		//
 		// check set 'null' color
-		testFigure.setBackground(null);
-		assertNull(testFigure.getBackground());
+		testFigure.setBackgroundColor(null);
+		assertNull(testFigure.getBackgroundColor());
 	}
 
 	@Test
@@ -664,19 +664,19 @@ public class FigureTest extends Draw2dFigureTestCase {
 		Figure testFigure = new Figure();
 		//
 		// check color for new Figure
-		assertNull(testFigure.getForeground());
+		assertNull(testFigure.getForegroundColor());
 		//
 		// check set color
-		testFigure.setForeground(black);
-		assertSame(black, testFigure.getForeground());
+		testFigure.setForegroundColor(black);
+		assertSame(black, testFigure.getForegroundColor());
 		//
 		// check set other color
-		testFigure.setForeground(red);
-		assertSame(red, testFigure.getForeground());
+		testFigure.setForegroundColor(red);
+		assertSame(red, testFigure.getForegroundColor());
 		//
 		// check set 'null' color
-		testFigure.setForeground(null);
-		assertNull(testFigure.getForeground());
+		testFigure.setForegroundColor(null);
+		assertNull(testFigure.getForegroundColor());
 	}
 
 	@Test

--- a/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/gef/policy/MenuBarDropLayoutEditPolicy.java
+++ b/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/gef/policy/MenuBarDropLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -91,7 +91,7 @@ public class MenuBarDropLayoutEditPolicy extends LayoutEditPolicy {
 				}
 			};
 			m_fillFeedback.setOpaque(true);
-			m_fillFeedback.setBackground(IColorConstants.menuBackground);
+			m_fillFeedback.setBackgroundColor(IColorConstants.menuBackground);
 			// set figure bounds
 			Insets clientAreaInsets = m_shell.getClientAreaInsets();
 			final Rectangle bounds = getHostFigure().getBounds().getCopy();


### PR DESCRIPTION
The base class also defines methods for getting the foreground/background color of a figure. There is no need for us to specify our own method when we can re-use those already existing methods.

Following methods are affected and have been renamed: getBackground() -> getBackgroundColor()
setBackground() -> setBackgroundColor()
getForeground() -> getForegroundColor()
setForeground() -> setForegroundColor()