### PR TITLE
[GEF] Synchronize reset method in Figure with downstream class

### DIFF
--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
@@ -232,8 +232,9 @@ public class Figure extends org.eclipse.draw2d.Figure {
 			childFigure.setParent(null);
 		}
 		// notify of change
-		if (m_children != null && !m_children.isEmpty()) {
-			resetState();
+		if (m_children != null && !m_children.isEmpty() && isVisible()) {
+			revalidate();
+			repaint();
 		}
 		// reset container
 		m_children = null;
@@ -306,24 +307,6 @@ public class Figure extends org.eclipse.draw2d.Figure {
 	}
 
 	/**
-	 * Request of change bounds and repaint this Figure. Use when bounds change is indirectly (change
-	 * visible, font, etc.).
-	 */
-	public final void resetState() {
-		resetState(getBounds());
-	}
-
-	/**
-	 * Request of change bounds and repaints the rectangular area within this Figure. Use into
-	 * <code>setBounds()</code> where <code>area</code> is union of <i>old</i> and <i>new</i> bounds.
-	 */
-	public final void resetState(Rectangle area) {
-		if (isVisible()) {
-			repaint(true, area.x, area.y, area.width, area.height);
-		}
-	}
-
-	/**
 	 * Request of change bounds and repaints the rectangular area within this Figure. Rectangular area
 	 * <code>childFigure</code>'s bounds. Use into {@link #add(Figure, Rectangle, int)} and
 	 * {@link #remove(Figure)}.
@@ -333,9 +316,8 @@ public class Figure extends org.eclipse.draw2d.Figure {
 			Rectangle bounds = getBounds();
 			Insets insets = getInsets();
 			Rectangle childBounds = childFigure.getBounds();
-			repaint(
-					true,
-					bounds.x + insets.left + childBounds.x,
+			revalidate();
+			repaint(bounds.x + insets.left + childBounds.x,
 					bounds.y + insets.top + childBounds.y,
 					childBounds.width,
 					childBounds.height);
@@ -349,7 +331,7 @@ public class Figure extends org.eclipse.draw2d.Figure {
 	public final void repaint() {
 		if (isVisible()) {
 			Rectangle bounds = getBounds();
-			repaint(false, bounds.x, bounds.y, bounds.width, bounds.height);
+			repaint(bounds.x, bounds.y, bounds.width, bounds.height);
 		}
 	}
 
@@ -359,12 +341,13 @@ public class Figure extends org.eclipse.draw2d.Figure {
 	 * respectively. If parameter <code>reset</code> is <code>true</code> then request of change
 	 * bounds and reconfigure scrolling.
 	 */
-	protected void repaint(boolean reset, int x, int y, int width, int height) {
+	@Override
+	public void repaint(int x, int y, int width, int height) {
 		Figure parent = getParent();
 		if (parent != null) {
 			Rectangle bounds = parent.getBounds();
 			Insets insets = parent.getInsets();
-			parent.repaint(reset, bounds.x + insets.left + x, bounds.y + insets.top + y, width, height);
+			parent.repaint(bounds.x + insets.left + x, bounds.y + insets.top + y, width, height);
 		}
 	}
 
@@ -510,7 +493,8 @@ public class Figure extends org.eclipse.draw2d.Figure {
 			// send move event
 			fireMoved();
 			// reset state
-			resetState(dirtyArea);
+			revalidate();
+			repaint(dirtyArea);
 		}
 	}
 
@@ -589,7 +573,10 @@ public class Figure extends org.eclipse.draw2d.Figure {
 	public void setBorder(Border border) {
 		if (m_border != border) {
 			m_border = border;
-			resetState();
+			if (isVisible()) {
+				revalidate();
+				repaint();
+			}
 		}
 	}
 
@@ -642,7 +629,8 @@ public class Figure extends org.eclipse.draw2d.Figure {
 	public void setFont(Font font) {
 		if (m_font != font) {
 			m_font = font;
-			resetState();
+			revalidate();
+			repaint();
 		}
 	}
 
@@ -699,9 +687,11 @@ public class Figure extends org.eclipse.draw2d.Figure {
 	@Override
 	public void setVisible(boolean visible) {
 		if (m_visible != visible) {
-			resetState();
+			revalidate();
+			repaint();
 			m_visible = visible;
-			resetState();
+			revalidate();
+			repaint();
 		}
 	}
 

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Polyline.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Polyline.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -37,7 +37,10 @@ public class Polyline extends Figure {
 	 */
 	public void addPoint(Point point) {
 		m_points.addPoint(point);
-		resetState();
+		if (isVisible()) {
+			revalidate();
+			repaint();
+		}
 	}
 
 	/**
@@ -45,7 +48,10 @@ public class Polyline extends Figure {
 	 */
 	public void insertPoint(Point point, int index) {
 		m_points.insertPoint(point, index);
-		resetState();
+		if (isVisible()) {
+			revalidate();
+			repaint();
+		}
 	}
 
 	/**
@@ -53,7 +59,10 @@ public class Polyline extends Figure {
 	 */
 	public void removePoint(int index) {
 		m_points.removePoint(index);
-		resetState();
+		if (isVisible()) {
+			revalidate();
+			repaint();
+		}
 	}
 
 	/**
@@ -61,7 +70,10 @@ public class Polyline extends Figure {
 	 */
 	public void removeAllPoints() {
 		m_points.removeAllPoints();
-		resetState();
+		if (isVisible()) {
+			revalidate();
+			repaint();
+		}
 	}
 
 	/**
@@ -79,7 +91,10 @@ public class Polyline extends Figure {
 	 */
 	public void setPoints(PointList points) {
 		m_points = points;
-		resetState();
+		if (isVisible()) {
+			revalidate();
+			repaint();
+		}
 	}
 
 	/**
@@ -134,7 +149,10 @@ public class Polyline extends Figure {
 	 */
 	public void setPoint(Point point, int index) {
 		m_points.setPoint(point, index);
-		resetState();
+		if (isVisible()) {
+			revalidate();
+			repaint();
+		}
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -280,7 +298,10 @@ public class Polyline extends Figure {
 		if (m_lineWidth != lineWidth) {
 			m_lineWidth = lineWidth;
 			m_pointsBounds = null;
-			resetState();
+			if (isVisible()) {
+				revalidate();
+				repaint();
+			}
 		}
 	}
 

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/Label.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/Label.java
@@ -84,7 +84,10 @@ public class Label extends Figure {
 		}
 		if (!m_text.equals(text)) {
 			m_text = text;
-			resetState();
+			if (isVisible()) {
+				revalidate();
+				repaint();
+			}
 		}
 	}
 
@@ -94,11 +97,9 @@ public class Label extends Figure {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void repaint(boolean reset, int x, int y, int width, int height) {
-		if (reset) {
-			m_preferredSize = null;
-		}
-		super.repaint(reset, x, y, width, height);
+	public void invalidate() {
+		m_preferredSize = null;
+		super.invalidate();
 	}
 
 	@Override

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/RootFigure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/RootFigure.java
@@ -162,11 +162,14 @@ public class RootFigure extends Figure implements IRootFigure {
 	 * reconfigure scrolling.
 	 */
 	@Override
-	protected void repaint(boolean reset, int x, int y, int width, int height) {
-		if (reset) {
-			m_preferredSize = null;
-		}
+	public void repaint(int x, int y, int width, int height) {
 		m_updateManager.addDirtyRegion(this, x, y, width, height);
+	}
+
+	@Override
+	public void invalidate() {
+		m_preferredSize = null;
+		super.invalidate();
 	}
 
 	/**

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/VerticalLabel.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/VerticalLabel.java
@@ -51,11 +51,9 @@ public final class VerticalLabel extends Label {
 	}
 
 	@Override
-	protected void repaint(boolean reset, int x, int y, int width, int height) {
-		if (reset) {
-			m_preferredSize = null;
-		}
-		super.repaint(reset, x, y, width, height);
+	public void invalidate() {
+		m_preferredSize = null;
+		super.invalidate();
 	}
 
 	/**

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigurePaintingTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigurePaintingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -64,31 +64,6 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 	// Figure notify tests
 	//
 	////////////////////////////////////////////////////////////////////////////
-	@Test
-	public void test_reset() throws Exception {
-		Figure testFigure = addFigure(10, 11, 50, 78);
-		TestLogger expectedLogger = new TestLogger();
-		//
-		// check reset state from figure fully
-		testFigure.resetState();
-		expectedLogger.log("repaint(true, 10, 11, 50, 78)");
-		m_actualLogger.assertEquals(expectedLogger);
-		//
-		// check reset state from part figure
-		testFigure.resetState(new Rectangle(1, 2, 3, 4));
-		expectedLogger.log("repaint(true, 1, 2, 3, 4)");
-		m_actualLogger.assertEquals(expectedLogger);
-		//
-		// check no reset state from invisible figure
-		testFigure.setVisible(false);
-		m_actualLogger.clear();
-		//
-		testFigure.resetState();
-		m_actualLogger.assertEmpty();
-		//
-		testFigure.resetState(new Rectangle(1, 2, 3, 4));
-		m_actualLogger.assertEmpty();
-	}
 
 	@Test
 	public void test_repaint() throws Exception {
@@ -97,7 +72,7 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		//
 		// check repaint from figure fully
 		testFigure.repaint();
-		expectedLogger.log("repaint(false, 10, 11, 50, 78)");
+		expectedLogger.log("repaint(10, 11, 50, 78)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check no repaint from invisible figure
@@ -115,26 +90,32 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		//
 		// check reset state during add child figure with empty bounds
 		testFigure.add(new Figure());
-		expectedLogger.log("repaint(true, 10, 11, 0, 0)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(10, 11, 0, 0)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check reset state during add(Figure) child figure with not empty bounds
 		Figure testChildFigure = new Figure();
 		testChildFigure.setBounds(new Rectangle(1, 2, 3, 4));
 		testFigure.add(testChildFigure);
-		expectedLogger.log("repaint(true, 11, 13, 3, 4)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(11, 13, 3, 4)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check reset state during add(Figure, Rectangle) child figure with not empty bounds
 		testFigure.add(new Figure(), new Rectangle(1, 2, 3, 4));
-		expectedLogger.log("repaint(true, 10, 11, 4, 6)");
-		expectedLogger.log("repaint(true, 11, 13, 3, 4)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(10, 11, 4, 6)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(11, 13, 3, 4)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check reset state during add(Figure, Rectangle, int) child figure with not empty bounds
 		testFigure.add(new Figure(), new Rectangle(1, 2, 3, 4), -1);
-		expectedLogger.log("repaint(true, 10, 11, 4, 6)");
-		expectedLogger.log("repaint(true, 11, 13, 3, 4)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(10, 11, 4, 6)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(11, 13, 3, 4)");
 		m_actualLogger.assertEquals(expectedLogger);
 	}
 
@@ -150,12 +131,14 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		//
 		// check reset state during remove child figure
 		testFigure.remove(testChildFigure);
-		expectedLogger.log("repaint(true, 31, 28, 25, 24)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(31, 28, 25, 24)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check reset state during remove all children figures
 		testFigure.removeAll();
-		expectedLogger.log("repaint(true, 10, 11, 50, 78)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(10, 11, 50, 78)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check no reset state during remove if not childrens
@@ -170,7 +153,8 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		//
 		// check reset state during setBounds()
 		testFigure.setBounds(new Rectangle(1, 2, 3, 4));
-		expectedLogger.log("repaint(true, 0, 0, 4, 6)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(0, 0, 4, 6)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check no reset state during setBounds() if bounds not change
@@ -183,12 +167,14 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		//
 		// check reset state during setSize(int, int)
 		testFigure.setSize(1, 5);
-		expectedLogger.log("repaint(true, 1, 2, 3, 5)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(1, 2, 3, 5)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check reset state during setSize(Dimension)
 		testFigure.setSize(new Dimension(11, 12));
-		expectedLogger.log("repaint(true, 1, 2, 11, 12)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(1, 2, 11, 12)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check no reset state during setSize(Dimension) if bounds not change
@@ -201,12 +187,14 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		//
 		// check reset state during setLocation(int, int)
 		testFigure.setLocation(3, 7);
-		expectedLogger.log("repaint(true, 1, 2, 13, 17)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(1, 2, 13, 17)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check reset state during setLocation(Point)
 		testFigure.setLocation(new Point());
-		expectedLogger.log("repaint(true, 0, 0, 14, 19)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(0, 0, 14, 19)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check no reset state during setLocation(Point) if bounds not change
@@ -222,7 +210,8 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		// check repaint during setBorder()
 		LineBorder border = new LineBorder();
 		testFigure.setBorder(border);
-		expectedLogger.log("repaint(true, 0, 0, 0, 0)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check no repaint during setBorder() if border not change
@@ -231,12 +220,14 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		//
 		// check repaint during setBorder()
 		testFigure.setBorder(new LineBorder(7));
-		expectedLogger.log("repaint(true, 0, 0, 0, 0)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check repaint during setBorder()
 		testFigure.setBorder(null);
-		expectedLogger.log("repaint(true, 0, 0, 0, 0)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check no repaint during setBorder() if border not change
@@ -251,7 +242,7 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		//
 		// check repaint during setBackground()
 		testFigure.setBackground(red);
-		expectedLogger.log("repaint(false, 0, 0, 0, 0)");
+		expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check no repaint during setBackground() if color not change
@@ -260,12 +251,12 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		//
 		// check repaint during setBackground()
 		testFigure.setBackground(green);
-		expectedLogger.log("repaint(false, 0, 0, 0, 0)");
+		expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check repaint during setBackground()
 		testFigure.setBackground(null);
-		expectedLogger.log("repaint(false, 0, 0, 0, 0)");
+		expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check no repaint during setBackground() if color not change
@@ -280,7 +271,7 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		//
 		// check repaint during setForeground()
 		testFigure.setForeground(red);
-		expectedLogger.log("repaint(false, 0, 0, 0, 0)");
+		expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check no repaint during setForeground() if color not change
@@ -289,12 +280,12 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		//
 		// check repaint during setForeground()
 		testFigure.setForeground(green);
-		expectedLogger.log("repaint(false, 0, 0, 0, 0)");
+		expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check repaint during setForeground()
 		testFigure.setForeground(null);
-		expectedLogger.log("repaint(false, 0, 0, 0, 0)");
+		expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check no repaint during setForeground() if color not change
@@ -309,12 +300,14 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		//
 		// check reset state during setFont()
 		testFigure.setFont(new Font(null, "Courier New", 12, SWT.BOLD));
-		expectedLogger.log("repaint(true, 0, 0, 0, 0)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check reset state during setFont()
 		testFigure.setFont(Display.getCurrent().getSystemFont());
-		expectedLogger.log("repaint(true, 0, 0, 0, 0)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check no reset state during setFont() if font not change
@@ -323,7 +316,8 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		//
 		// check reset state during setFont()
 		testFigure.setFont(null);
-		expectedLogger.log("repaint(true, 0, 0, 0, 0)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check no reset state during setFont() if font not change
@@ -367,7 +361,7 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		//
 		// check repaint during setOpaque()
 		testFigure.setOpaque(true);
-		expectedLogger.log("repaint(false, 0, 0, 0, 0)");
+		expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check no repaint during setOpaque() if opaque not change
@@ -376,7 +370,7 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		//
 		// check repaint during setOpaque()
 		testFigure.setOpaque(false);
-		expectedLogger.log("repaint(false, 0, 0, 0, 0)");
+		expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check no repaint during setOpaque() if opaque not change
@@ -391,7 +385,9 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		//
 		// check reset state during setVisible()
 		testFigure.setVisible(false);
-		expectedLogger.log("repaint(true, 0, 0, 0, 0)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(0, 0, 0, 0)");
+		expectedLogger.log("invalidate");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check no reset state during setVisible() if visible not change
@@ -400,7 +396,9 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		//
 		// check reset state during setVisible()
 		testFigure.setVisible(true);
-		expectedLogger.log("repaint(true, 0, 0, 0, 0)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check no reset state during setVisible() if visible not change

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/LabelTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/LabelTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -81,7 +81,8 @@ public class LabelTest extends Draw2dFigureTestCase {
 		//
 		// check reset state during setText()
 		label.setText("123");
-		expectedLogger.log("repaint(true, 0, 0, 0, 0)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(0, 0, 0, 0)");
 		actualLogger.assertEquals(expectedLogger);
 		//
 		// check no reset state during setText() if text not change
@@ -90,12 +91,14 @@ public class LabelTest extends Draw2dFigureTestCase {
 		//
 		// check reset state during setText()
 		label.setText("231");
-		expectedLogger.log("repaint(true, 0, 0, 0, 0)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(0, 0, 0, 0)");
 		actualLogger.assertEquals(expectedLogger);
 		//
 		// check reset state during setText()
 		label.setText(null);
-		expectedLogger.log("repaint(true, 0, 0, 0, 0)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(0, 0, 0, 0)");
 		actualLogger.assertEquals(expectedLogger);
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/PolylineTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/PolylineTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -59,19 +59,22 @@ public class PolylineTest extends Draw2dFigureTestCase {
 		// check reset state during addPoint()
 		m_polyline.addPoint(new Point(10, 20));
 		//
-		m_expectedLogger.log("repaint(true, 10, 20, 1, 1)");
+		m_expectedLogger.log("invalidate");
+		m_expectedLogger.log("repaint(10, 20, 1, 1)");
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		// check reset state during addPoint()
 		m_polyline.addPoint(new Point(-90, 0));
 		//
-		m_expectedLogger.log("repaint(true, -90, 0, 101, 21)");
+		m_expectedLogger.log("invalidate");
+		m_expectedLogger.log("repaint(-90, 0, 101, 21)");
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		// check reset state during addPoint()
 		m_polyline.addPoint(new Point(120, -70));
 		//
-		m_expectedLogger.log("repaint(true, -90, -70, 211, 91)");
+		m_expectedLogger.log("invalidate");
+		m_expectedLogger.log("repaint(-90, -70, 211, 91)");
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		// check add null point and not reset state
@@ -104,25 +107,29 @@ public class PolylineTest extends Draw2dFigureTestCase {
 		// check work insert point and reset state
 		m_polyline.insertPoint(new Point(), 0);
 		//
-		m_expectedLogger.log("repaint(true, 0, 0, 1, 1)");
+		m_expectedLogger.log("invalidate");
+		m_expectedLogger.log("repaint(0, 0, 1, 1)");
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		// check work insert point and reset state
 		m_polyline.addPoint(new Point(10, 20));
 		//
-		m_expectedLogger.log("repaint(true, 0, 0, 11, 21)");
+		m_expectedLogger.log("invalidate");
+		m_expectedLogger.log("repaint(0, 0, 11, 21)");
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		// check work insert point and reset state
 		m_polyline.addPoint(new Point(-90, 0));
 		//
-		m_expectedLogger.log("repaint(true, -90, 0, 101, 21)");
+		m_expectedLogger.log("invalidate");
+		m_expectedLogger.log("repaint(-90, 0, 101, 21)");
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		// check work insert point and reset state
 		m_polyline.insertPoint(new Point(-1, -1), 1);
 		//
-		m_expectedLogger.log("repaint(true, -90, -1, 101, 22)");
+		m_expectedLogger.log("invalidate");
+		m_expectedLogger.log("repaint(-90, -1, 101, 22)");
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		// check points order
@@ -163,7 +170,8 @@ public class PolylineTest extends Draw2dFigureTestCase {
 		// check remove point and reset state
 		m_polyline.removePoint(2);
 		//
-		m_expectedLogger.log("repaint(true, -90, -20, 101, 21)");
+		m_expectedLogger.log("invalidate");
+		m_expectedLogger.log("repaint(-90, -20, 101, 21)");
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		assertEquals(2, list.size());
@@ -173,7 +181,8 @@ public class PolylineTest extends Draw2dFigureTestCase {
 		// check remove point and reset state
 		m_polyline.removePoint(0);
 		//
-		m_expectedLogger.log("repaint(true, -90, 0, 1, 1)");
+		m_expectedLogger.log("invalidate");
+		m_expectedLogger.log("repaint(-90, 0, 1, 1)");
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		assertEquals(1, list.size());
@@ -182,7 +191,8 @@ public class PolylineTest extends Draw2dFigureTestCase {
 		// check remove point and reset state
 		m_polyline.removePoint(0);
 		//
-		m_expectedLogger.log("repaint(true, 0, 0, 0, 0)");
+		m_expectedLogger.log("invalidate");
+		m_expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		assertEquals(0, list.size());
@@ -201,7 +211,8 @@ public class PolylineTest extends Draw2dFigureTestCase {
 		// check work removeAllPoints() when not children
 		m_polyline.removeAllPoints();
 		//
-		m_expectedLogger.log("repaint(true, 0, 0, 0, 0)");
+		m_expectedLogger.log("invalidate");
+		m_expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		PointList list = m_polyline.getPoints();
@@ -217,7 +228,8 @@ public class PolylineTest extends Draw2dFigureTestCase {
 		// check work removeAllPoints()
 		m_polyline.removeAllPoints();
 		//
-		m_expectedLogger.log("repaint(true, 0, 0, 0, 0)");
+		m_expectedLogger.log("invalidate");
+		m_expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		assertEquals(0, list.size());
@@ -225,7 +237,8 @@ public class PolylineTest extends Draw2dFigureTestCase {
 		// check work removeAllPoints() when not children
 		m_polyline.removeAllPoints();
 		//
-		m_expectedLogger.log("repaint(true, 0, 0, 0, 0)");
+		m_expectedLogger.log("invalidate");
+		m_expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		assertEquals(0, list.size());
@@ -296,7 +309,8 @@ public class PolylineTest extends Draw2dFigureTestCase {
 		Point point = new Point(3, 4);
 		m_polyline.setPoint(point, 1);
 		//
-		m_expectedLogger.log("repaint(true, 3, -20, 8, 25)");
+		m_expectedLogger.log("invalidate");
+		m_expectedLogger.log("repaint(3, -20, 8, 25)");
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		assertEquals(new Point(3, 4), point);
@@ -307,7 +321,8 @@ public class PolylineTest extends Draw2dFigureTestCase {
 		point = new Point(-1, 2);
 		m_polyline.setPoint(point, 0);
 		//
-		m_expectedLogger.log("repaint(true, -1, 2, 5, 3)");
+		m_expectedLogger.log("invalidate");
+		m_expectedLogger.log("repaint(-1, 2, 5, 3)");
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		assertEquals(new Point(-1, 2), point);
@@ -322,7 +337,8 @@ public class PolylineTest extends Draw2dFigureTestCase {
 		// check work setStart() and reset state
 		m_polyline.setStart(new Point(10, 10));
 		//
-		m_expectedLogger.log("repaint(true, 10, 10, 1, 1)");
+		m_expectedLogger.log("invalidate");
+		m_expectedLogger.log("repaint(10, 10, 1, 1)");
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		assertEquals(1, m_polyline.getPoints().size());
@@ -331,7 +347,8 @@ public class PolylineTest extends Draw2dFigureTestCase {
 		// check work setStart() and reset state
 		m_polyline.setStart(new Point(120, -110));
 		//
-		m_expectedLogger.log("repaint(true, 120, -110, 1, 1)");
+		m_expectedLogger.log("invalidate");
+		m_expectedLogger.log("repaint(120, -110, 1, 1)");
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		assertEquals(1, m_polyline.getPoints().size());
@@ -345,7 +362,8 @@ public class PolylineTest extends Draw2dFigureTestCase {
 		// check work setEnd() and reset state
 		m_polyline.setEnd(new Point(1, 1));
 		//
-		m_expectedLogger.log("repaint(true, 1, 1, 1, 1)");
+		m_expectedLogger.log("invalidate");
+		m_expectedLogger.log("repaint(1, 1, 1, 1)");
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		assertEquals(1, m_polyline.getPoints().size());
@@ -362,7 +380,8 @@ public class PolylineTest extends Draw2dFigureTestCase {
 		// check work setEnd() and reset state
 		m_polyline.setEnd(new Point(10, 10));
 		//
-		m_expectedLogger.log("repaint(true, 0, 0, 11, 11)");
+		m_expectedLogger.log("invalidate");
+		m_expectedLogger.log("repaint(0, 0, 11, 11)");
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		assertEquals(2, m_polyline.getPoints().size());
@@ -371,7 +390,8 @@ public class PolylineTest extends Draw2dFigureTestCase {
 		// check work setEnd() and reset state
 		m_polyline.setEnd(new Point(120, -110));
 		//
-		m_expectedLogger.log("repaint(true, 0, -110, 121, 111)");
+		m_expectedLogger.log("invalidate");
+		m_expectedLogger.log("repaint(0, -110, 121, 111)");
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		assertEquals(2, m_polyline.getPoints().size());
@@ -389,8 +409,10 @@ public class PolylineTest extends Draw2dFigureTestCase {
 		// check work setEndpoints() and reset state
 		m_polyline.setEndpoints(new Point(10, 10), new Point(120, -110));
 		//
-		m_expectedLogger.log("repaint(true, 0, 0, 11, 11)");
-		m_expectedLogger.log("repaint(true, 10, -110, 111, 121)");
+		m_expectedLogger.log("invalidate");
+		m_expectedLogger.log("repaint(0, 0, 11, 11)");
+		m_expectedLogger.log("invalidate");
+		m_expectedLogger.log("repaint(10, -110, 111, 121)");
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		assertEquals(2, m_polyline.getPoints().size());
@@ -400,8 +422,10 @@ public class PolylineTest extends Draw2dFigureTestCase {
 		// check work setEndpoints() and reset state
 		m_polyline.setEndpoints(new Point(120, -110), new Point(10, 10));
 		//
-		m_expectedLogger.log("repaint(true, 120, -110, 1, 1)");
-		m_expectedLogger.log("repaint(true, 10, -110, 111, 121)");
+		m_expectedLogger.log("invalidate");
+		m_expectedLogger.log("repaint(120, -110, 1, 1)");
+		m_expectedLogger.log("invalidate");
+		m_expectedLogger.log("repaint(10, -110, 111, 121)");
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		assertEquals(2, m_polyline.getPoints().size());
@@ -420,7 +444,8 @@ public class PolylineTest extends Draw2dFigureTestCase {
 		PointList list2 = new PointList();
 		m_polyline.setPoints(list2);
 		//
-		m_expectedLogger.log("repaint(true, 0, 0, 0, 0)");
+		m_expectedLogger.log("invalidate");
+		m_expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		assertNotSame(list1, m_polyline.getPoints());
@@ -529,7 +554,7 @@ public class PolylineTest extends Draw2dFigureTestCase {
 		// check change lineStyle
 		m_polyline.setLineStyle(SWT.LINE_DOT);
 		//
-		m_expectedLogger.log("repaint(false, 0, 0, 0, 0)");
+		m_expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		assertEquals(SWT.LINE_DOT, m_polyline.getLineStyle());
@@ -543,7 +568,8 @@ public class PolylineTest extends Draw2dFigureTestCase {
 		// check change lineWidth and reset state
 		m_polyline.setLineWidth(3);
 		//
-		m_expectedLogger.log("repaint(true, -1, -1, 2, 2)");
+		m_expectedLogger.log("invalidate");
+		m_expectedLogger.log("repaint(-1, -1, 2, 2)");
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		assertEquals(3, m_polyline.getLineWidth());
@@ -562,7 +588,7 @@ public class PolylineTest extends Draw2dFigureTestCase {
 		// check change xor mode
 		m_polyline.setXorMode(true);
 		//
-		m_expectedLogger.log("repaint(false, 0, 0, 0, 0)");
+		m_expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		assertTrue(m_polyline.isXorMode());
@@ -575,7 +601,7 @@ public class PolylineTest extends Draw2dFigureTestCase {
 		// check change xor mode
 		m_polyline.setXorMode(false);
 		//
-		m_expectedLogger.log("repaint(false, 0, 0, 0, 0)");
+		m_expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		assertFalse(m_polyline.isXorMode());

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/RootFigureTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/RootFigureTest.java
@@ -92,7 +92,8 @@ public class RootFigureTest extends Draw2dFigureTestCase {
 		assertSame(preferredSize, testRoot.getPreferredSize());
 		//
 		// check work resetState()
-		figure0.resetState();
+		figure0.revalidate();
+		figure0.repaint();
 		waitEventLoop(10);
 		//
 		expectedLogger.log("refreshRequest(10, 10, 100, 200)");
@@ -145,7 +146,7 @@ public class RootFigureTest extends Draw2dFigureTestCase {
 		//
 		RootFigure testRoot = new RootFigure(null) {
 			@Override
-			protected void repaint(boolean reset, int x, int y, int width, int height) {
+			public void repaint(int x, int y, int width, int height) {
 			}
 
 			@Override
@@ -195,7 +196,8 @@ public class RootFigureTest extends Draw2dFigureTestCase {
 		Layer layer0 = new Layer("Main");
 		testRoot.addLayer(layer0);
 		//
-		expectedLogger.log("repaint(true, 0, 0, 0, 0)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(0, 0, 0, 0)");
 		actualLogger.assertEquals(expectedLogger);
 		//
 		assertSame(testRoot, layer0.getParent());
@@ -205,7 +207,8 @@ public class RootFigureTest extends Draw2dFigureTestCase {
 		Layer layer1 = new Layer("Feedback");
 		testRoot.addLayer(layer1);
 		//
-		expectedLogger.log("repaint(true, 0, 0, 0, 0)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(0, 0, 0, 0)");
 		actualLogger.assertEquals(expectedLogger);
 		//
 		assertSame(testRoot, layer1.getParent());
@@ -255,7 +258,8 @@ public class RootFigureTest extends Draw2dFigureTestCase {
 		// check work removeLayer(Layer)
 		testRoot.removeLayer(layer0);
 		//
-		expectedLogger.log("repaint(true, 0, 0, 0, 0)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(0, 0, 0, 0)");
 		actualLogger.assertEquals(expectedLogger);
 		//
 		assertNull(layer0.getParent());
@@ -265,7 +269,8 @@ public class RootFigureTest extends Draw2dFigureTestCase {
 		// check work removeLayer(String)
 		testRoot.removeLayer("feedback");
 		//
-		expectedLogger.log("repaint(true, 0, 0, 0, 0)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(0, 0, 0, 0)");
 		actualLogger.assertEquals(expectedLogger);
 		//
 		assertNull(layer0.getParent());
@@ -294,7 +299,8 @@ public class RootFigureTest extends Draw2dFigureTestCase {
 		// check reset state during removeAll()
 		testRoot.removeAll();
 		//
-		expectedLogger.log("repaint(true, 0, 0, 0, 0)");
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(0, 0, 0, 0)");
 		actualLogger.assertEquals(expectedLogger);
 		//
 		assertNull(layer0.getParent());

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/TestCaseRootFigure.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/TestCaseRootFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -36,9 +36,16 @@ public class TestCaseRootFigure extends RootFigure {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void repaint(boolean reset, int x, int y, int width, int height) {
+	public void repaint(int x, int y, int width, int height) {
 		if (m_logger != null) {
-			m_logger.log("repaint(" + reset + ", " + x + ", " + y + ", " + width + ", " + height + ")");
+			m_logger.log("repaint(" + x + ", " + y + ", " + width + ", " + height + ")");
+		}
+	}
+
+	@Override
+	public void invalidate() {
+		if (m_logger != null) {
+			m_logger.log("invalidate");
 		}
 	}
 


### PR DESCRIPTION
The reset method performs two tasks: revalidation and repaining.
In downstream GEF, this is split in two methods. Revalidation is done if
and only if the reset flag in our
implementation is set to true.

With this change, we ditch our implementation in favor of the intended
approach.