### PR TITLE
[GEF] Use downstream repaint methods in Figure class

### DIFF
--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
@@ -320,33 +320,6 @@ public class Figure extends org.eclipse.draw2d.Figure {
 	}
 
 	/**
-	 * Repaints this Figure.
-	 */
-	@Override
-	public final void repaint() {
-		if (isVisible()) {
-			Rectangle bounds = getBounds();
-			repaint(bounds.x, bounds.y, bounds.width, bounds.height);
-		}
-	}
-
-	/**
-	 * Repaints the rectangular area within this Figure whose upper-left corner is located at the
-	 * point <code>(x,y)</code> and whose width and height are <code>w</code> and <code>h</code>,
-	 * respectively. If parameter <code>reset</code> is <code>true</code> then request of change
-	 * bounds and reconfigure scrolling.
-	 */
-	@Override
-	public void repaint(int x, int y, int width, int height) {
-		Figure parent = getParent();
-		if (parent != null) {
-			Rectangle bounds = parent.getBounds();
-			Insets insets = parent.getInsets();
-			parent.repaint(bounds.x + insets.left + x, bounds.y + insets.top + y, width, height);
-		}
-	}
-
-	/**
 	 * Paints this Figure and its children.
 	 *
 	 * @noreference @nooverride

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/RootFigure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/RootFigure.java
@@ -106,7 +106,7 @@ public class RootFigure extends Figure implements IRootFigure {
 	}
 
 	@Override
-	public final UpdateManager getUpdateManager() {
+	public UpdateManager getUpdateManager() {
 		return m_updateManager;
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigurePaintingTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigurePaintingTest.java
@@ -105,7 +105,7 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		// check reset state during add(Figure, Rectangle) child figure with not empty bounds
 		testFigure.add(new Figure(), new Rectangle(1, 2, 3, 4));
 		expectedLogger.log("invalidate");
-		expectedLogger.log("repaint(10, 11, 4, 6)");
+		expectedLogger.log("repaint(0, 0, 4, 6)");
 		expectedLogger.log("invalidate");
 		expectedLogger.log("repaint(11, 13, 3, 4)");
 		m_actualLogger.assertEquals(expectedLogger);
@@ -113,7 +113,7 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		// check reset state during add(Figure, Rectangle, int) child figure with not empty bounds
 		testFigure.add(new Figure(), new Rectangle(1, 2, 3, 4), -1);
 		expectedLogger.log("invalidate");
-		expectedLogger.log("repaint(10, 11, 4, 6)");
+		expectedLogger.log("repaint(0, 0, 4, 6)");
 		expectedLogger.log("invalidate");
 		expectedLogger.log("repaint(11, 13, 3, 4)");
 		m_actualLogger.assertEquals(expectedLogger);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/TestCaseRootFigure.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/TestCaseRootFigure.java
@@ -13,11 +13,17 @@ package org.eclipse.wb.tests.draw2d;
 import org.eclipse.wb.internal.draw2d.RootFigure;
 import org.eclipse.wb.tests.gef.TestLogger;
 
+import org.eclipse.draw2d.GraphicsSource;
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.UpdateManager;
+import org.eclipse.draw2d.geometry.Rectangle;
+
 /**
  * @author lobas_av
  *
  */
 public class TestCaseRootFigure extends RootFigure {
+	private final UpdateManager m_testManager;
 	private final TestLogger m_logger;
 
 	////////////////////////////////////////////////////////////////////////////
@@ -28,6 +34,39 @@ public class TestCaseRootFigure extends RootFigure {
 	public TestCaseRootFigure(TestLogger logger) {
 		super(null);
 		m_logger = logger;
+		m_testManager = new UpdateManager() {
+			@Override
+			public void addDirtyRegion(IFigure figure, int x, int y, int w, int h) {
+				if (m_logger != null) {
+					m_logger.log("repaint(" + x + ", " + y + ", " + w + ", " + h + ")");
+				}
+			}
+
+			@Override
+			public void addInvalidFigure(IFigure figure) {
+				// Not relevant for testing...
+			}
+
+			@Override
+			public void performUpdate() {
+				// Not relevant for testing...
+			}
+
+			@Override
+			public void performUpdate(Rectangle exposed) {
+				// Not relevant for testing...
+			}
+
+			@Override
+			public void setGraphicsSource(GraphicsSource gs) {
+				// Not relevant for testing...
+			}
+
+			@Override
+			public void setRoot(IFigure figure) {
+				// Not relevant for testing...
+			}
+		};
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -54,5 +93,10 @@ public class TestCaseRootFigure extends RootFigure {
 		if (m_logger != null) {
 			m_logger.log("updateCursor");
 		}
+	}
+
+	@Override
+	public UpdateManager getUpdateManager() {
+		return m_testManager;
 	}
 }


### PR DESCRIPTION
In downstream GEF, painting is done by forwarding a request to the update manager. We implicitly do this already by calling parent.repaint() until we get to the root figure, meaning both implementation should be effectively identical.