### PR TITLE
[GEF] Fix: Repaint operation has to consider local coordinates

### DIFF
--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
@@ -631,4 +631,9 @@ public class Figure extends org.eclipse.draw2d.Figure {
 	public void setCustomTooltipProvider(ICustomTooltipProvider provider) {
 		m_customTooltipProvider = provider;
 	}
+
+	@Override
+	protected boolean useLocalCoordinates() {
+		return true;
+	}
 }


### PR DESCRIPTION
The coordinates of the WindowBuilder figures are placed relative to the top-left corner of their parent. The useLocalCoordinates() method has to return true, otherwise the repaint operation will threat those as absolute coordinates and update the wrong area.