### PR TITLE
Fix: Unable to open design page for view page

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/reflect/ReflectionUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/reflect/ReflectionUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -685,8 +685,11 @@ public class ReflectionUtils {
 			for (Method method : c.getDeclaredMethods()) {
 				String signature = getMethodSignature(method);
 				if (!methods.containsKey(signature)) {
-					method.setAccessible(true);
-					methods.put(signature, method);
+					// InaccessibleObjectException thrown by methods hidden by strong encapsulation
+					ExecutionUtils.runIgnore(() -> {
+						method.setAccessible(true);
+						methods.put(signature, method);
+					});
 				}
 			}
 		}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/wizards/project/NewProjectWizard.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/wizards/project/NewProjectWizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -66,5 +66,8 @@ public class NewProjectWizard extends DesignerJavaProjectWizard {
 		ProjectUtils.addPluginLibraries(javaProject, "org.eclipse.ui.workbench");
 		ProjectUtils.addPluginLibraries(javaProject, "com.ibm.icu");
 		ProjectUtils.addPluginLibraries(javaProject, "org.eclipse.ui.forms");
+		// E4 support
+		ProjectUtils.addPluginLibraries(javaProject, "javax.annotation");
+		ProjectUtils.addPluginLibraries(javaProject, "org.eclipse.e4.ui.di");
 	}
 }

--- a/org.eclipse.wb.rcp/templates/rcp/IPageBookViewPage.jvt
+++ b/org.eclipse.wb.rcp/templates/rcp/IPageBookViewPage.jvt
@@ -57,7 +57,8 @@ method
 	public void init(IPageSite pageSite) {
 		%this%%field-prefix%site = pageSite;
 		createActions();
-		initializeToolBar();
+		// Uncomment if you wish to add code to initialize the toolbar
+		// initializeToolBar();
 		initializeMenu();
 	}
 

--- a/org.eclipse.wb.rcp/templates/rcp/Page.jvt
+++ b/org.eclipse.wb.rcp/templates/rcp/Page.jvt
@@ -39,7 +39,8 @@ method
 	public void init(IPageSite pageSite) {
 		super.init(pageSite);
 		createActions();
-		initializeToolBar();
+		// Uncomment if you wish to add code to initialize the toolbar
+		// initializeToolBar();
 		initializeMenu();
 	}
 

--- a/org.eclipse.wb.rcp/templates/rcp/PageIContentOutlinePage.jvt
+++ b/org.eclipse.wb.rcp/templates/rcp/PageIContentOutlinePage.jvt
@@ -42,7 +42,8 @@ method
 	public void init(IPageSite pageSite) {
 		super.init(pageSite);
 		createActions();
-		initializeToolBar();
+		// Uncomment if you wish to add code to initialize the toolbar
+		// initializeToolBar();
 		initializeMenu();
 	}
 

--- a/org.eclipse.wb.rcp/templates/rcp/PageIPropertySheetPage.jvt
+++ b/org.eclipse.wb.rcp/templates/rcp/PageIPropertySheetPage.jvt
@@ -42,7 +42,8 @@ method
 	public void init(IPageSite pageSite) {
 		super.init(pageSite);
 		createActions();
-		initializeToolBar();
+		// Uncomment if you wish to add code to initialize the toolbar
+		// initializeToolBar();
 		initializeMenu();
 	}
 

--- a/org.eclipse.wb.swing/templates/JDialog.jvt
+++ b/org.eclipse.wb.swing/templates/JDialog.jvt
@@ -3,6 +3,9 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import javax.swing.JDialog;
 
+field
+	private static final long serialVersionUID = 1L;
+
 method
 	/**
 	 * Launch the application.

--- a/org.eclipse.wb.swing/templates/JDialog_buttons.jvt
+++ b/org.eclipse.wb.swing/templates/JDialog_buttons.jvt
@@ -6,6 +6,9 @@ import javax.swing.JPanel;
 import javax.swing.border.EmptyBorder;
 
 field
+	private static final long serialVersionUID = 1L;
+
+field
 	private final JPanel %field-prefix%contentPanel = new JPanel();
 
 method

--- a/org.eclipse.wb.swing/templates/JFrame.jvt
+++ b/org.eclipse.wb.swing/templates/JFrame.jvt
@@ -1,6 +1,9 @@
 import java.awt.EventQueue;
 import javax.swing.JFrame;
 
+field
+	private static final long serialVersionUID = 1L;
+
 method
 	/**
 	 * Launch the application.

--- a/org.eclipse.wb.swing/templates/JFrame_advanced.jvt
+++ b/org.eclipse.wb.swing/templates/JFrame_advanced.jvt
@@ -5,6 +5,9 @@ import javax.swing.JFrame;
 import javax.swing.JPanel;
 
 field
+	private static final long serialVersionUID = 1L;
+
+field
 	private JPanel %field-prefix%contentPane;
 
 method

--- a/org.eclipse.wb.swing/templates/JInternalFrame.jvt
+++ b/org.eclipse.wb.swing/templates/JInternalFrame.jvt
@@ -1,6 +1,9 @@
 import java.awt.EventQueue;
 import javax.swing.JInternalFrame;
 
+field
+	private static final long serialVersionUID = 1L;
+
 method
 	/**
 	 * Launch the application.

--- a/org.eclipse.wb.swing/templates/JPanel.jvt
+++ b/org.eclipse.wb.swing/templates/JPanel.jvt
@@ -1,5 +1,8 @@
 import javax.swing.JPanel;
 
+field
+	private static final long serialVersionUID = 1L;
+
 method
 	/**
 	 * Create the panel.

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/DesignerEditorTestCase.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/DesignerEditorTestCase.java
@@ -46,10 +46,13 @@ import org.eclipse.wb.tests.gef.UiContext;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.jface.wizard.IWizard;
 import org.eclipse.ui.IActionBars;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.actions.ActionFactory;
@@ -141,7 +144,25 @@ public abstract class DesignerEditorTestCase extends AbstractJavaInfoRelatedTest
 	}
 
 	/**
-	 * Opens given {@link ICompilationUnit} in new Designer editor and shows "Design" page.
+	 * Creates new source file using the given wizard, opens resulting
+	 * {@link ICompilationUnit} in new Designer editor and shows "Design" page.
+	 */
+	protected final void openDesign(IWizard wizard, IPackageFragment packageFragment, String fileName)
+			throws Exception {
+		new UiContext().executeAndCheck(
+				context -> TestUtils.runWizard(wizard, new StructuredSelection(packageFragment)), //
+				context -> {
+					context.useShell(wizard.getWindowTitle());
+					context.getTextByLabel("Name:").setText(fileName);
+					context.clickButton("Finish");
+				});
+		ICompilationUnit cu = packageFragment.getCompilationUnit(fileName + ".java");
+		openDesign(cu);
+	}
+
+	/**
+	 * Opens given {@link ICompilationUnit} in new Designer editor and shows
+	 * "Design" page.
 	 */
 	protected final void openDesign(ICompilationUnit unit) throws Exception {
 		openEditor(unit);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/RcpTests.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/RcpTests.java
@@ -17,6 +17,7 @@ import org.eclipse.wb.tests.designer.rcp.model.ModelTests;
 import org.eclipse.wb.tests.designer.rcp.nebula.NebulaTests;
 import org.eclipse.wb.tests.designer.rcp.resource.ResourceTests;
 import org.eclipse.wb.tests.designer.rcp.swing2swt.Swing2SwtTests;
+import org.eclipse.wb.tests.designer.rcp.wizard.WizardTests;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -35,7 +36,8 @@ import org.junit.runners.Suite.SuiteClasses;
 	NebulaTests.class,
 	Swing2SwtTests.class,
 	GefTests.class,
-	BindingTests.class
+	BindingTests.class,
+	WizardTests.class
 })
 public class RcpTests {
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/wizard/AbstractWizardTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/wizard/AbstractWizardTest.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Patrick Ziegler and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.tests.designer.rcp.wizard;
+
+import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
+import org.eclipse.wb.internal.rcp.wizards.project.NewProjectWizard;
+import org.eclipse.wb.tests.designer.editor.DesignerEditorTestCase;
+
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+
+import org.junit.Before;
+
+public abstract class AbstractWizardTest extends DesignerEditorTestCase {
+	protected IPackageFragment m_packageFragment;
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+		if (m_testProject == null) {
+			do_projectCreate();
+			ReflectionUtils.getMethod(NewProjectWizard.class, "addRequiredLibraries", IJavaProject.class) //
+					.invoke(null, m_javaProject);
+		}
+		m_packageFragment = m_testProject.getPackage("test");
+	}
+}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/wizard/Eclipse4WizardTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/wizard/Eclipse4WizardTest.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Patrick Ziegler and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.tests.designer.rcp.wizard;
+
+import org.eclipse.wb.internal.rcp.wizards.rcp.view.ViewPartWizard;
+
+import org.junit.Test;
+
+public class Eclipse4WizardTest extends AbstractWizardTest {
+	@Test
+	public void testCreateNewViewPart() throws Exception {
+		openDesign(new ViewPartWizard(), m_packageFragment, "MyViewPart");
+	}
+}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/wizard/JFaceWizardTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/wizard/JFaceWizardTest.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Patrick Ziegler and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.tests.designer.rcp.wizard;
+
+import org.eclipse.wb.internal.rcp.wizards.jface.application.JFaceApplicationWizard;
+import org.eclipse.wb.internal.rcp.wizards.jface.dialog.DialogWizard;
+import org.eclipse.wb.internal.rcp.wizards.jface.dialog.TitleAreaDialogWizard;
+import org.eclipse.wb.internal.rcp.wizards.jface.wizard.WizardPageWizard;
+import org.eclipse.wb.internal.rcp.wizards.jface.wizard.WizardWizard;
+
+import org.junit.Test;
+
+public class JFaceWizardTest extends AbstractWizardTest {
+	@Test
+	public void testCreateNewApplicationWindow() throws Exception {
+		openDesign(new JFaceApplicationWizard(), m_packageFragment, "MyApplicationWizard");
+	}
+
+	@Test
+	public void testCreateNewDialog() throws Exception {
+		openDesign(new DialogWizard(), m_packageFragment, "MyDialog");
+	}
+
+	@Test
+	public void testCreateNewTitleAreaDialog() throws Exception {
+		openDesign(new TitleAreaDialogWizard(), m_packageFragment, "MyTitleAreaDialog");
+	}
+
+	@Test
+	public void testCreateNewWizard() throws Exception {
+		// Graphical editing is not provided for Wizard classes
+		assertThrows(Exception.class, () -> openDesign(new WizardWizard(), m_packageFragment, "MyWizard"));
+	}
+
+	@Test
+	public void testCreateNewWizardPage() throws Exception {
+		openDesign(new WizardPageWizard(), m_packageFragment, "MyWizardPage");
+	}
+}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/wizard/RcpWizardTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/wizard/RcpWizardTest.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Patrick Ziegler and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.tests.designer.rcp.wizard;
+
+import org.eclipse.wb.internal.rcp.wizards.rcp.advisor.ActionBarAdvisorWizard;
+import org.eclipse.wb.internal.rcp.wizards.rcp.editor.EditorPartWizard;
+import org.eclipse.wb.internal.rcp.wizards.rcp.editor.MultiPageEditorPartWizard;
+import org.eclipse.wb.internal.rcp.wizards.rcp.pagebook.PageBookWizard;
+import org.eclipse.wb.internal.rcp.wizards.rcp.perspective.PerspectiveWizard;
+import org.eclipse.wb.internal.rcp.wizards.rcp.preference.PreferencePageWizard;
+import org.eclipse.wb.internal.rcp.wizards.rcp.property.PropertyPageWizard;
+import org.eclipse.wb.internal.rcp.wizards.rcp.view.ViewPartWizard;
+
+import org.junit.Test;
+
+public class RcpWizardTest extends AbstractWizardTest {
+	@Test
+	public void testCreateNewActionBarAdvisor() throws Exception {
+		openDesign(new ActionBarAdvisorWizard(), m_packageFragment, "MyActionBarAdvisor");
+	}
+
+	@Test
+	public void testCreateNewEditorPart() throws Exception {
+		openDesign(new EditorPartWizard(), m_packageFragment, "MyEditorPart");
+	}
+
+	@Test
+	public void testCreateNewMultiPageEditorPart() throws Exception {
+		// Graphical editing is not provided for MultiPageEditorPart
+		assertThrows(Exception.class,
+				() -> openDesign(new MultiPageEditorPartWizard(), m_packageFragment, "MyMultiPageEditorPart"));
+	}
+
+	@Test
+	public void testCreateNewPageBookViewPage() throws Exception {
+		openDesign(new PageBookWizard(), m_packageFragment, "MyPageBookViewPage");
+	}
+
+	@Test
+	public void testCreateNewPerspective() throws Exception {
+		openDesign(new PerspectiveWizard(), m_packageFragment, "MyPerspective");
+	}
+
+	@Test
+	public void testCreateNewPreferencePage() throws Exception {
+		openDesign(new PreferencePageWizard(), m_packageFragment, "MyPreferencePage");
+	}
+
+	@Test
+	public void testCreateNewPropertyPage() throws Exception {
+		openDesign(new PropertyPageWizard(), m_packageFragment, "MyPropertyPage");
+	}
+
+	@Test
+	public void testCreateNewViewPart() throws Exception {
+		openDesign(new ViewPartWizard(), m_packageFragment, "MyViewPart");
+	}
+}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/wizard/SwtWizardTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/wizard/SwtWizardTest.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Patrick Ziegler and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.tests.designer.rcp.wizard;
+
+import org.eclipse.wb.internal.rcp.wizards.swt.application.SwtApplicationWizard;
+import org.eclipse.wb.internal.rcp.wizards.swt.composite.CompositeWizard;
+import org.eclipse.wb.internal.rcp.wizards.swt.dialog.DialogWizard;
+import org.eclipse.wb.internal.rcp.wizards.swt.shell.ShellWizard;
+
+import org.junit.Test;
+
+public class SwtWizardTest extends AbstractWizardTest {
+	@Test
+	public void testCreateNewApplicationWindow() throws Exception {
+		openDesign(new SwtApplicationWizard(), m_packageFragment, "MyApplicationWindow");
+	}
+
+	@Test
+	public void testCreateNewComposite() throws Exception {
+		openDesign(new CompositeWizard(), m_packageFragment, "MyComposite");
+	}
+
+	@Test
+	public void testCreateNewDialog() throws Exception {
+		openDesign(new DialogWizard(), m_packageFragment, "MyDialog");
+	}
+
+	@Test
+	public void testCreateNewShell() throws Exception {
+		openDesign(new ShellWizard(), m_packageFragment, "MyShell");
+	}
+}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/wizard/WizardTests.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/wizard/WizardTests.java
@@ -1,0 +1,15 @@
+package org.eclipse.wb.tests.designer.rcp.wizard;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+@RunWith(Suite.class)
+@SuiteClasses({
+		Eclipse4WizardTest.class,
+		JFaceWizardTest.class,
+		RcpWizardTest.class,
+		SwtWizardTest.class
+})
+public class WizardTests {
+}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/SwingNewWizardTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/SwingNewWizardTest.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Patrick Ziegler and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.tests.designer.swing;
+
+import org.eclipse.wb.internal.swing.wizards.applet.NewJAppletWizard;
+import org.eclipse.wb.internal.swing.wizards.application.NewSwingApplicationWizard;
+import org.eclipse.wb.internal.swing.wizards.dialog.NewJDialogWizard;
+import org.eclipse.wb.internal.swing.wizards.frame.NewJFrameWizard;
+import org.eclipse.wb.internal.swing.wizards.frame.NewJInternalFrameWizard;
+import org.eclipse.wb.internal.swing.wizards.panel.NewJPanelWizard;
+import org.eclipse.wb.tests.designer.editor.DesignerEditorTestCase;
+
+import org.eclipse.jdt.core.IPackageFragment;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class SwingNewWizardTest extends DesignerEditorTestCase {
+	private IPackageFragment m_packageFragment;
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+		if (m_testProject == null) {
+			do_projectCreate();
+		}
+		m_packageFragment = m_testProject.getPackage("test");
+	}
+
+	@Test
+	public void testCreateNewJFrame() throws Exception {
+		openDesign(new NewJFrameWizard(), m_packageFragment, "MyJFrame");
+	}
+
+	@Test
+	public void testCreateNewJPanel() throws Exception {
+		openDesign(new NewJPanelWizard(), m_packageFragment, "MyJPanel");
+	}
+
+	@Test
+	public void testCreateNewJDialog() throws Exception {
+		openDesign(new NewJDialogWizard(), m_packageFragment, "MyJDialog");
+	}
+
+	@Test
+	public void testCreateNewJApplet() throws Exception {
+		openDesign(new NewJAppletWizard(), m_packageFragment, "MyJApplet");
+	}
+
+	@Test
+	public void testCreateNewJInternalFrame() throws Exception {
+		openDesign(new NewJInternalFrameWizard(), m_packageFragment, "MyJInternalFrame");
+	}
+
+	@Test
+	public void testCreateNewApplicationWindow() throws Exception {
+		openDesign(new NewSwingApplicationWizard(), m_packageFragment, "MyApplicationWindow");
+	}
+}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/SwingTests.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/SwingTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,6 +33,7 @@ import org.junit.runners.Suite.SuiteClasses;
 	SwingXTests.class,
 	ApplicationFrameworkTests.class,
 	//  WaitForMemoryProfilerTest.class,
+	SwingNewWizardTest.class
 })
 public class SwingTests {
 }


### PR DESCRIPTION
An exception is thrown when calling
getSite().getActionBars().getMenuManager(). When trying to resolve those
methods, we internally touch on methods hidden by encapsulation. This
then throws an unhandled InaccessibleObjectException exception.

Note: The problematic class is MethodHandles.Lookup in the Proxy class.

The Swing templates have been adapted to also generated the default
serialVersionUID in order to resolve the corresponding warning.

Test cases have been added to check, whether the design page can be
openened for all templates contributed via the New wizard.

This also resolves the missing serialVersionUID warning when creating
a new Swing widget.