### PR TITLE
Fix: Error when trying to delete selected tab item

### DIFF
--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/AbstractTabItemInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/AbstractTabItemInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -75,6 +75,7 @@ public abstract class AbstractTabItemInfo extends ItemInfo {
 			@Override
 			public void before(ObjectInfo parent, ObjectInfo child) throws Exception {
 				if (child == m_this) {
+					getFolder().m_selectedItem = null;
 					ControlInfo ourControl = getControl();
 					if (ourControl != null) {
 						ourControl.delete();

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/widgets/CTabFolderTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/widgets/CTabFolderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -250,6 +250,35 @@ public class CTabFolderTest extends RcpModelTest {
 			Assertions.assertThat(refresh[0]).isTrue();
 			Assertions.assertThat(tabFolder.getSelectedItem()).isSameAs(item_1);
 		}
+	}
+
+	/**
+	 * Test whether the selection is removed when the tab item is deleted.
+	 *
+	 * @see <a href=
+	 *      "https://github.com/eclipse-windowbuilder/windowbuilder/issues/556">here</a>
+	 */
+	@Test
+	public void test_deleteSelectedTabItem() throws Exception {
+		CompositeInfo shell = parseComposite(
+				"public class Test extends Shell {",
+				"  public Test() {",
+				"    setLayout(new FillLayout());",
+				"    CTabFolder tabFolder = new CTabFolder(this, SWT.NONE);",
+				"    CTabItem item_1 = new CTabItem(tabFolder, SWT.NONE);",
+				"    CTabItem item_2 = new CTabItem(tabFolder, SWT.NONE);",
+				"  }",
+				"}");
+		shell.refresh();
+		CTabFolderInfo tabFolder = (CTabFolderInfo) shell.getChildrenControls().get(0);
+		CTabItemInfo item_1 = tabFolder.getItems2().get(0);
+		CTabItemInfo item_2 = tabFolder.getItems2().get(1);
+
+		item_2.doSelect();
+		assertEquals(tabFolder.getSelectedItem(), item_2);
+
+		item_2.delete();
+		assertEquals(tabFolder.getSelectedItem(), item_1);
 	}
 
 	/**

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/widgets/TabFolderTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/widgets/TabFolderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -254,6 +254,35 @@ public class TabFolderTest extends RcpModelTest {
 			Assertions.assertThat(refresh[0]).isTrue();
 			Assertions.assertThat(tabFolder.getSelectedItem()).isSameAs(item_1);
 		}
+	}
+
+	/**
+	 * Test whether the selection is removed when the tab item is deleted.
+	 *
+	 * @see <a href=
+	 *      "https://github.com/eclipse-windowbuilder/windowbuilder/issues/556">here</a>
+	 */
+	@Test
+	public void test_deleteSelectedTabItem() throws Exception {
+		CompositeInfo shell = parseComposite(
+				"public class Test extends Shell {",
+				"  public Test() {",
+				"    setLayout(new FillLayout());",
+				"    TabFolder tabFolder = new TabFolder(this, SWT.NONE);",
+				"    TabItem item_1 = new TabItem(tabFolder, SWT.NONE);",
+				"    TabItem item_2 = new TabItem(tabFolder, SWT.NONE);",
+				"  }",
+				"}");
+		shell.refresh();
+		TabFolderInfo tabFolder = (TabFolderInfo) shell.getChildrenControls().get(0);
+		TabItemInfo item_1 = tabFolder.getItems2().get(0);
+		TabItemInfo item_2 = tabFolder.getItems2().get(1);
+
+		item_2.doSelect();
+		assertEquals(tabFolder.getSelectedItem(), item_2);
+
+		item_2.delete();
+		assertEquals(tabFolder.getSelectedItem(), item_1);
 	}
 
 	/**


### PR DESCRIPTION
The selection is not cleared when a tab item has been deleted. When updating the widget, we then run into an unhandled exception because the item we try to select no longer exists.