### PR TITLE
Try to fix sporadic error thrown by ProjectClassLoaderTest

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/utils/ProjectClassLoaderTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/utils/ProjectClassLoaderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -539,11 +539,13 @@ public class ProjectClassLoaderTest extends SwingModelTest {
 	 */
 	public static String moveProjectIntoWorkspaceSubFolder() throws Exception {
 		String newProjectLocation = workspaceLocation + "/subFolder/Test";
+		File oldProjectFile = new File(m_project.getLocation().toPortableString());
+		File newProjectFile = new File(newProjectLocation);
 		// move project content
-		FileUtils.deleteQuietly(new File(newProjectLocation));
-		FileUtils.moveDirectory(
-				new File(m_project.getLocation().toPortableString()),
-				new File(newProjectLocation));
+		if (newProjectFile.exists()) {
+			FileUtils.forceDelete(newProjectFile);
+		}
+		FileUtils.moveDirectory(oldProjectFile, newProjectFile);
 		// delete old project
 		m_project.delete(true, null);
 		// create new project, in workspace sub-folder


### PR DESCRIPTION
Sometimes the test fails because the project location wasn't deleted by FileUtils.deleteQuietly. In order to resolve this problem (and to at least get a proper error message), we should use FileUtils.forceDelete() instead.