### PR TITLE
Try to further stabilize the ProjectClassLoaderTest

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/utils/ProjectClassLoaderTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/utils/ProjectClassLoaderTest.java
@@ -542,10 +542,8 @@ public class ProjectClassLoaderTest extends SwingModelTest {
 		File oldProjectFile = new File(m_project.getLocation().toPortableString());
 		File newProjectFile = new File(newProjectLocation);
 		// move project content
-		if (newProjectFile.exists()) {
-			FileUtils.forceDelete(newProjectFile);
-		}
-		FileUtils.moveDirectory(oldProjectFile, newProjectFile);
+		FileUtils.deleteQuietly(newProjectFile);
+		FileUtils.copyDirectory(oldProjectFile, newProjectFile);
 		// delete old project
 		m_project.delete(true, null);
 		// create new project, in workspace sub-folder


### PR DESCRIPTION
FileUtils.moveDirectory will try to remove the source folder (i.e. the IProject). This may conflict with the workspace resource. Given that we delete this project anyway, we should use copyDirectory() instead, which doesn't touch the source folder.