### PR TITLE
[SimRel] Update versions and target platform for next development cycle

### DIFF
--- a/org.eclipse.wb.core.feature_feature/feature.xml
+++ b/org.eclipse.wb.core.feature_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.core.feature"
       label="%featureName"
-      version="1.13.0.qualifier"
+      version="1.14.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.wb.core">
 

--- a/org.eclipse.wb.core.java.feature_feature/feature.xml
+++ b/org.eclipse.wb.core.java.feature_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.core.java.feature"
       label="%featureName"
-      version="1.13.0.qualifier"
+      version="1.14.0.qualifier"
       provider-name="%providerName">
 
    <description>

--- a/org.eclipse.wb.core.java/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core.java/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.core.java;singleton:=true
-Bundle-Version: 1.10.0.qualifier
+Bundle-Version: 1.10.100.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.core.java.Activator
 Bundle-Vendor: %providerName

--- a/org.eclipse.wb.core.ui.feature_feature/feature.xml
+++ b/org.eclipse.wb.core.ui.feature_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.core.ui.feature"
       label="%featureName"
-      version="1.13.0.qualifier"
+      version="1.14.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.wb.core.ui">
 

--- a/org.eclipse.wb.core.xml.feature_feature/feature.xml
+++ b/org.eclipse.wb.core.xml.feature_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.core.xml.feature"
       label="%featureName"
-      version="1.13.0.qualifier"
+      version="1.14.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.wb.core.xml">
 

--- a/org.eclipse.wb.dependencies.feature_feature/feature.xml
+++ b/org.eclipse.wb.dependencies.feature_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.dependencies.feature"
       label="%featureName"
-      version="1.13.0.qualifier"
+      version="1.14.0.qualifier"
       provider-name="%providerName">
 
    <description>

--- a/org.eclipse.wb.doc.user.feature_feature/feature.xml
+++ b/org.eclipse.wb.doc.user.feature_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.doc.user.feature"
       label="%featureName"
-      version="1.13.0.qualifier"
+      version="1.14.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.wb.doc.user">
 

--- a/org.eclipse.wb.layout.group.feature_feature/feature.xml
+++ b/org.eclipse.wb.layout.group.feature_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.layout.group.feature"
       label="%featureName"
-      version="1.13.0.qualifier"
+      version="1.14.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.wb.layout.group">
 

--- a/org.eclipse.wb.os.feature_feature/feature.xml
+++ b/org.eclipse.wb.os.feature_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.os.feature"
       label="%featureName"
-      version="1.13.0.qualifier"
+      version="1.14.0.qualifier"
       provider-name="%providerName">
 
    <description>

--- a/org.eclipse.wb.rcp.SWT_AWT_support_feature/feature.xml
+++ b/org.eclipse.wb.rcp.SWT_AWT_support_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.rcp.SWT_AWT_support"
       label="%featureName"
-      version="1.13.0.qualifier"
+      version="1.14.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.wb.rcp.SWT_AWT">
 

--- a/org.eclipse.wb.rcp.doc.user.feature_feature/feature.xml
+++ b/org.eclipse.wb.rcp.doc.user.feature_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.rcp.doc.user.feature"
       label="%featureName"
-      version="1.13.0.qualifier"
+      version="1.14.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.wb.rcp.doc.user">
 

--- a/org.eclipse.wb.rcp.feature_feature/feature.xml
+++ b/org.eclipse.wb.rcp.feature_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.rcp.feature"
       label="%featureName"
-      version="1.13.0.qualifier"
+      version="1.14.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.wb.rcp">
 

--- a/org.eclipse.wb.swing.doc.user.feature_feature/feature.xml
+++ b/org.eclipse.wb.swing.doc.user.feature_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.swing.doc.user.feature"
       label="%featureName"
-      version="1.13.0.qualifier"
+      version="1.14.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.wb.swing.doc.user">
 

--- a/org.eclipse.wb.swing.feature_feature/feature.xml
+++ b/org.eclipse.wb.swing.feature_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.swing.feature"
       label="%featureName"
-      version="1.13.0.qualifier"
+      version="1.14.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.wb.swing">
 

--- a/org.eclipse.wb.swing/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swing;singleton:=true
-Bundle-Version: 1.9.3.qualifier
+Bundle-Version: 1.9.400.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.swing.Activator
 Bundle-Vendor: %providerName

--- a/org.eclipse.wb.swt.feature_feature/feature.xml
+++ b/org.eclipse.wb.swt.feature_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.swt.feature"
       label="%featureName"
-      version="1.13.0.qualifier"
+      version="1.14.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.wb.swt">
 

--- a/org.eclipse.wb.xwt.feature_feature/feature.xml
+++ b/org.eclipse.wb.xwt.feature_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.xwt.feature"
       label="%featureName"
-      version="1.13.0.qualifier"
+      version="1.14.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.wb.xwt">
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,29 @@
         </pluginRepository>
       </pluginRepositories>
     </profile>
+    <!-- Minor version increases in required plugins/features require a major
+         version increase in the WindowBuilder feature. We don't want that! -->
+    <profile>
+      <id>skip-feature-baseline-check</id>
+      <activation>
+        <file>
+            <exists>feature.xml</exists>
+        </file>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.eclipse.tycho</groupId>
+              <artifactId>tycho-baseline-plugin</artifactId>
+              <configuration>
+                <skip>true</skip>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
   </profiles>
 
   <build>
@@ -119,8 +142,8 @@
           <version>${tycho.version}</version>
         </plugin>
         <plugin>
-          <groupId>org.eclipse.tycho.extras</groupId>
-          <artifactId>tycho-p2-extras-plugin</artifactId>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-baseline-plugin</artifactId>
           <version>${tycho.version}</version>
         </plugin>
       </plugins>
@@ -217,22 +240,32 @@
       </plugin>
 
       <plugin>
-        <groupId>org.eclipse.tycho.extras</groupId>
-        <artifactId>tycho-p2-extras-plugin</artifactId>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-baseline-plugin</artifactId>
         <executions>
           <execution> 
             <id>compare-version-with-baseline</id>
             <phase>verify</phase>
             <goals>
-              <goal>compare-version-with-baselines</goal>
+              <goal>verify</goal>
             </goals>
-            <configuration>
-              <baselines>
-                <baseline>${baseline.repo}</baseline>
-              </baselines>
-            </configuration>
           </execution>
         </executions>
+        <configuration>
+          <increment>100</increment>
+          <ignores>
+            <ignore>META-INF/ECLIPSE_.RSA</ignore>
+            <ignore>META-INF/ECLIPSE_.SF</ignore>
+            <ignore>META-INF/maven/**/*</ignore>
+          </ignores>
+          <baselines>
+            <repository>
+              <id>wb-releases</id>
+              <url>${baseline.repo}</url>
+              <layout>p2</layout>
+            </repository>
+          </baselines>
+        </configuration>
       </plugin>
 
       <plugin>
@@ -248,6 +281,9 @@
         <configuration>
           <timestampProvider>jgit</timestampProvider>
           <jgit.dirtyWorkingTree>warning</jgit.dirtyWorkingTree>
+          <archive>
+            <addMavenDescriptor>false</addMavenDescriptor>
+          </archive>
         </configuration>
       </plugin>
     </plugins>

--- a/target-platform/wb.target
+++ b/target-platform/wb.target
@@ -3,7 +3,8 @@
 <target name="wb">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/releases/2023-06"/>
+			<repository location="https://download.eclipse.org/releases/2023-09"/>
+			<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.wst.sse.core" version="0.0.0"/>
 			<unit id="org.eclipse.wst.sse.ui" version="0.0.0"/>
@@ -18,13 +19,9 @@
 			<repository location="https://download.eclipse.org/nebula/incubation/latest/"/>
 			<unit id="org.eclipse.nebula.incubation.feature.feature.group" version="0.0.0"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/gef/classic/latest/"/>
-			<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
-		</location>
 		<location type="Target" uri="file:${project_loc:/target-platform}/mvn/wb-mvn.target"/>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/oomph/simrel-maven/release/4.28.0"/>
+			<repository location="https://download.eclipse.org/oomph/simrel-maven/2023-09"/>
 			<unit id="assertj-core" version="0.0.0"/>
 			<unit id="com.google.guava" version="0.0.0"/>
 			<unit id="org.apache.commons.collections" version="0.0.0"/>


### PR DESCRIPTION
- Update features to 1.14.0
- Increase Manifest versions due to changes since the 1.13.0
- Switch to Tycho baseline plugin -> More descriptive error messages and better customization. The Baseline check for features has to be disabled due to unreasonable increment requirements. :(
- Exclude Maven descriptor in bundled jars -> Due to the target-platform update, the pom dependencies might be updated, leading to changes in the binary file even though the bundle hasn't been modified.