### PR TITLE
Fix: Deadlock when an exception is thrown inside an UIRunnable.

### DIFF
--- a/org.eclipse.wb.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: WindowBuilder Tests
 Bundle-SymbolicName: org.eclipse.wb.tests;singleton:=true
-Bundle-Version: 1.2.2.qualifier
+Bundle-Version: 1.2.300.qualifier
 Bundle-Activator: org.eclipse.wb.tests.designer.tests.Activator
 Bundle-Vendor: Google
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.wb.tests/pom.xml
+++ b/org.eclipse.wb.tests/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.wb</groupId>
   <artifactId>org.eclipse.wb.tests</artifactId>
-  <version>1.2.2-SNAPSHOT</version>
+  <version>1.2.300-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
  

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/UiContext.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/UiContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -668,6 +668,8 @@ public class UiContext {
 						} catch (Throwable e) {
 							e.printStackTrace();
 							checkException[0] = e;
+							// close any opened shells to avoid deadlocks
+							closeShells();
 						}
 					}
 				});
@@ -706,6 +708,21 @@ public class UiContext {
 			while (m_display.readAndDispatch()) {
 				// do nothing
 			}
+		}
+	}
+
+	////////////////////////////////////////////////////////////////////////////
+	//
+	// Cleanup
+	//
+	////////////////////////////////////////////////////////////////////////////
+
+	private void closeShells() {
+		Shell activeShell = getShell();
+		while (activeShell != null) {
+			popShell();
+			activeShell.dispose();
+			activeShell = getShell();
 		}
 	}
 }


### PR DESCRIPTION
When an exception is thrown while running the executeAndCheck() method, it may happen that some of the created shells remain open. Whenever an exception is thrown (e.g. by a failed assertion), those shells are explicitly disposed to allow the run to continue.