### PR TITLE
Fix: Failure in tycho-baseline-plugin due to byte-code changes

### DIFF
--- a/org.eclipse.wb.core.databinding.xml/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core.databinding.xml/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.core.databinding.xml;singleton:=true
-Bundle-Version: 1.9.2.qualifier
+Bundle-Version: 1.9.300.qualifier
 Bundle-Activator: org.eclipse.wb.internal.core.databinding.xml.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wb.core.databinding/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core.databinding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.core.databinding;singleton:=true
-Bundle-Version: 1.9.3.qualifier
+Bundle-Version: 1.9.400.qualifier
 Bundle-Activator: org.eclipse.wb.internal.core.databinding.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wb.core.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.core.ui;singleton:=true
-Bundle-Version: 1.10.2.qualifier
+Bundle-Version: 1.10.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wb.core.xml/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core.xml/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.core.xml;singleton:=true
-Bundle-Version: 1.9.2.qualifier
+Bundle-Version: 1.9.300.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.core.xml.Activator
 Bundle-Vendor: %providerName

--- a/org.eclipse.wb.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.core;singleton:=true
-Bundle-Version: 1.13.0.qualifier
+Bundle-Version: 1.13.100.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.core.DesignerPlugin

--- a/org.eclipse.wb.layout.group/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.layout.group/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.layout.group;singleton:=true
-Bundle-Version: 1.9.3.qualifier
+Bundle-Version: 1.9.400.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.wb.os.linux/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.os.linux/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.os.linux;singleton:=true
-Bundle-Version: 1.9.4.qualifier
+Bundle-Version: 1.9.500.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-PlatformFilter: (& (osgi.ws=gtk) (osgi.os=linux))

--- a/org.eclipse.wb.os.linux/pom.xml
+++ b/org.eclipse.wb.os.linux/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.eclipse.wb</groupId>
     <artifactId>org.eclipse.wb.os.linux</artifactId>
-    <version>1.9.4-SNAPSHOT</version>
+    <version>1.9.500-SNAPSHOT</version>
     <packaging>eclipse-plugin</packaging>
 
     <build>

--- a/org.eclipse.wb.rcp.SWT_AWT/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp.SWT_AWT/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.rcp.SWT_AWT;singleton:=true
-Bundle-Version: 1.9.3.qualifier
+Bundle-Version: 1.9.400.qualifier
 Bundle-Activator: org.eclipse.wb.internal.rcp.swtawt.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/org.eclipse.wb.rcp.databinding.emf/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp.databinding.emf/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.rcp.databinding.emf;singleton:=true
-Bundle-Version: 1.9.3.qualifier
+Bundle-Version: 1.9.400.qualifier
 Bundle-Activator: org.eclipse.wb.internal.rcp.databinding.emf.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wb.rcp.databinding.xwt/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp.databinding.xwt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.rcp.databinding.xwt;singleton:=true
-Bundle-Version: 1.9.2.qualifier
+Bundle-Version: 1.9.300.qualifier
 Bundle-Activator: org.eclipse.wb.internal.rcp.databinding.xwt.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wb.rcp.databinding/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp.databinding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.rcp.databinding;singleton:=true
-Bundle-Version: 1.9.3.qualifier
+Bundle-Version: 1.9.400.qualifier
 Bundle-Activator: org.eclipse.wb.internal.rcp.databinding.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wb.rcp.swing2swt/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp.swing2swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.rcp.swing2swt;singleton:=true
-Bundle-Version: 1.9.3.qualifier
+Bundle-Version: 1.9.400.qualifier
 Bundle-Activator: org.eclipse.wb.internal.rcp.swing2swt.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wb.rcp/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.rcp;singleton:=true
-Bundle-Version: 1.9.3.qualifier
+Bundle-Version: 1.9.400.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.rcp.Activator
 Bundle-Vendor: %providerName

--- a/org.eclipse.wb.swing.FormLayout/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing.FormLayout/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swing.FormLayout;singleton:=true
-Bundle-Version: 1.9.3.qualifier
+Bundle-Version: 1.9.400.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.swing.FormLayout.Activator
 Bundle-Vendor: %providerName

--- a/org.eclipse.wb.swing.MigLayout/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing.MigLayout/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swing.MigLayout;singleton:=true
-Bundle-Version: 1.9.3.qualifier
+Bundle-Version: 1.9.400.qualifier
 Bundle-Activator: org.eclipse.wb.internal.swing.MigLayout.Activator
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.wb.swing.databinding/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing.databinding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swing.databinding;singleton:=true
-Bundle-Version: 1.9.3.qualifier
+Bundle-Version: 1.9.400.qualifier
 Bundle-Activator: org.eclipse.wb.internal.swing.databinding.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wb.swing.java6/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing.java6/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swing.java6;singleton:=true
-Bundle-Version: 1.9.3.qualifier
+Bundle-Version: 1.9.400.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.wb.swing.jsr296/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing.jsr296/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swing.jsr296;singleton:=true
-Bundle-Version: 1.9.3.qualifier
+Bundle-Version: 1.9.400.qualifier
 Bundle-Activator: org.eclipse.wb.internal.swing.jsr296.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wb.swt.widgets.baseline/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swt.widgets.baseline/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swt.widgets.baseline;singleton:=true
-Bundle-Version: 1.9.3.qualifier
+Bundle-Version: 1.9.400.qualifier
 Bundle-Activator: org.eclipse.wb.swt.widgets.baseline.BaselineActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.wb.swt/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swt;singleton:=true
-Bundle-Version: 1.9.3.qualifier
+Bundle-Version: 1.9.400.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.swt.Activator
 Bundle-Vendor: %providerName

--- a/org.eclipse.wb.xwt/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.xwt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.xwt;singleton:=true
-Bundle-Version: 1.9.2.qualifier
+Bundle-Version: 1.9.300.qualifier
 Bundle-Activator: org.eclipse.wb.internal.xwt.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin


### PR DESCRIPTION
Tycho recently updated to a new JDT version, which implements JEP-280.
This results in different byte-code for most of our classes, which is
detected by the baseline check. Increase the micro version of all
affected bundles to accommodate for this.