### PR TITLE
Fix: When tab order set, new tabbable controls not recognized

### DIFF
--- a/org.eclipse.wb.swing/resources/1.8/org/eclipse/wb/swing/FocusTraversalOnArray.java
+++ b/org.eclipse.wb.swing/resources/1.8/org/eclipse/wb/swing/FocusTraversalOnArray.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2023 Google, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Google, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.swing;
+
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.FocusTraversalPolicy;
+
+/**
+ * Cyclic focus traversal policy based on array of components.
+ * <p>
+ * This class may be freely distributed as part of any application or plugin.
+ * 
+ * @author scheglov_ke
+ */
+public class FocusTraversalOnArray extends FocusTraversalPolicy {
+	private final Component m_Components[];
+	////////////////////////////////////////////////////////////////////////////
+	//
+	// Constructor
+	//
+	////////////////////////////////////////////////////////////////////////////
+	public FocusTraversalOnArray(Component components[]) {
+		m_Components = components;
+	}
+	////////////////////////////////////////////////////////////////////////////
+	//
+	// Utilities
+	//
+	////////////////////////////////////////////////////////////////////////////
+	private int indexCycle(int index, int delta) {
+		int size = m_Components.length;
+		int next = (index + delta + size) % size;
+		return next;
+	}
+	private Component cycle(Component currentComponent, int delta) {
+		int index = -1;
+		loop : for (int i = 0; i < m_Components.length; i++) {
+			Component component = m_Components[i];
+			for (Component c = currentComponent; c != null; c = c.getParent()) {
+				if (component == c) {
+					index = i;
+					break loop;
+				}
+			}
+		}
+		// try to find enabled component in "delta" direction
+		int initialIndex = index;
+		while (true) {
+			int newIndex = indexCycle(index, delta);
+			if (newIndex == initialIndex) {
+				break;
+			}
+			index = newIndex;
+			//
+			Component component = m_Components[newIndex];
+			if (component.isEnabled() && component.isVisible() && component.isFocusable()) {
+				return component;
+			}
+		}
+		// not found
+		return currentComponent;
+	}
+	////////////////////////////////////////////////////////////////////////////
+	//
+	// FocusTraversalPolicy
+	//
+	////////////////////////////////////////////////////////////////////////////
+	public Component getComponentAfter(Container container, Component component) {
+		return cycle(component, 1);
+	}
+	public Component getComponentBefore(Container container, Component component) {
+		return cycle(component, -1);
+	}
+	public Component getFirstComponent(Container container) {
+		return m_Components[0];
+	}
+	public Component getLastComponent(Container container) {
+		return m_Components[m_Components.length - 1];
+	}
+	public Component getDefaultComponent(Container container) {
+		return getFirstComponent(container);
+	}
+}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/TabOrderProperty.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/TabOrderProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -60,7 +60,7 @@ org.eclipse.wb.internal.core.model.property.order.TabOrderProperty {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	protected ArrayInitializer getOrderedArray() throws Exception {
-		MethodInvocation invocation = m_container.getMethodInvocation(FOCUS_TRAVERSAL_METHOD_SIGNATURE);
+		MethodInvocation invocation = getMethodInvocation();
 		if (invocation != null) {
 			Object traversalPolicy = invocation.arguments().get(0);
 			if (traversalPolicy instanceof ClassInstanceCreation traversalPolicyCreation) {
@@ -86,7 +86,7 @@ org.eclipse.wb.internal.core.model.property.order.TabOrderProperty {
 	protected void setOrderedArraySource(String source) throws Exception {
 		String newSource =
 				"new org.eclipse.wb.swing.FocusTraversalOnArray(new java.awt.Component[]" + source + ")";
-		MethodInvocation invocation = m_container.getMethodInvocation(FOCUS_TRAVERSAL_METHOD_SIGNATURE);
+		MethodInvocation invocation = getMethodInvocation();
 		if (invocation == null) {
 			ProjectUtils.ensureResourceType(
 					m_container.getEditor().getJavaProject(),
@@ -97,6 +97,11 @@ org.eclipse.wb.internal.core.model.property.order.TabOrderProperty {
 			Expression argument = DomGenerics.arguments(invocation).get(0);
 			m_container.replaceExpression(argument, newSource);
 		}
+	}
+
+	@Override
+	protected MethodInvocation getMethodInvocation() {
+		return m_container.getMethodInvocation(FOCUS_TRAVERSAL_METHOD_SIGNATURE);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/property/TabOrderProperty.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/property/TabOrderProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -55,7 +55,7 @@ org.eclipse.wb.internal.core.model.property.order.TabOrderProperty {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	protected ArrayInitializer getOrderedArray() throws Exception {
-		MethodInvocation invocation = getTabListMethod();
+		MethodInvocation invocation = getMethodInvocation();
 		if (invocation != null) {
 			Object expression = invocation.arguments().get(0);
 			if (expression instanceof ArrayCreation creation) {
@@ -73,7 +73,7 @@ org.eclipse.wb.internal.core.model.property.order.TabOrderProperty {
 	@Override
 	protected void setOrderedArraySource(String source) throws Exception {
 		String newSource = "new org.eclipse.swt.widgets.Control[]" + source;
-		MethodInvocation invocation = getTabListMethod();
+		MethodInvocation invocation = getMethodInvocation();
 		if (invocation == null) {
 			m_container.addMethodInvocation(TAB_METHOD_SIGNATURE, newSource);
 		} else {
@@ -82,7 +82,8 @@ org.eclipse.wb.internal.core.model.property.order.TabOrderProperty {
 		}
 	}
 
-	private MethodInvocation getTabListMethod() {
+	@Override
+	protected MethodInvocation getMethodInvocation() {
 		return m_container.getMethodInvocation(TAB_METHOD_SIGNATURE);
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/TabOrderPropertyTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/TabOrderPropertyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -298,6 +298,11 @@ public class TabOrderPropertyTest extends SwingModelTest {
 		@Override
 		protected String getPropertyTooltipText() {
 			return m_tooltip;
+		}
+
+		@Override
+		protected MethodInvocation getMethodInvocation() {
+			return null;
 		}
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/property/TabOrderPropertyTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/property/TabOrderPropertyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,6 @@ import org.eclipse.wb.internal.swing.model.property.TabOrderProperty;
 import org.eclipse.wb.tests.designer.swing.SwingModelTest;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.awt.Container;
@@ -36,7 +35,6 @@ import java.util.List;
  *
  * @author lobas_av
  */
-@Ignore
 public class TabOrderPropertyTest extends SwingModelTest {
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -325,8 +323,47 @@ public class TabOrderPropertyTest extends SwingModelTest {
 	}
 
 	/**
-	 * {@link Container#setFocusTraversalPolicy(FocusTraversalPolicy)} should be last method, this
-	 * should be kept even when we add new component.
+	 * When a new component is added to the list but no focus traversal policy is
+	 * defined, then none should be created.
+	 */
+	@Test
+	public void test_noValue_addNewComponent() throws Exception {
+		ContainerInfo container =
+				parseContainer(
+						"public class Test extends JPanel {",
+						"  public Test() {",
+						"    {",
+						"      JButton button_1 = new JButton();",
+						"      add(button_1);",
+						"    }",
+						"  }",
+						"}");
+		container.refresh();
+		// add new JButton
+		ComponentInfo newButton = createJButton();
+		((FlowLayoutInfo) container.getLayout()).add(newButton, null);
+		//
+		assertEditor(
+				"public class Test extends JPanel {",
+				"  public Test() {",
+				"    {",
+				"      JButton button_1 = new JButton();",
+				"      add(button_1);",
+				"    }",
+				"    {",
+				"      JButton button = new JButton();",
+				"      add(button);",
+				"    }",
+				"  }",
+				"}");
+	}
+
+	/**
+	 * {@link Composite#setFocusTraversalPolicy(FocusTraversalPolicy)} should be
+	 * last method, this should be kept even when we add new component. Note that
+	 * because there already is a focus traversal policy defined for the container,
+	 * the newly created button is appended to the end of the list of active
+	 * components..
 	 */
 	@Test
 	public void test_hasValue_addNewComponent() throws Exception {
@@ -359,6 +396,7 @@ public class TabOrderPropertyTest extends SwingModelTest {
 				"public class Test extends JPanel {",
 				"  private JButton button_1;",
 				"  private JButton button_2;",
+				"  private JButton button;",
 				"  public Test() {",
 				"    {",
 				"      button_1 = new JButton();",
@@ -369,10 +407,10 @@ public class TabOrderPropertyTest extends SwingModelTest {
 				"      add(button_2);",
 				"    }",
 				"    {",
-				"      JButton button = new JButton();",
+				"      button = new JButton();",
 				"      add(button);",
 				"    }",
-				"    setFocusTraversalPolicy(new FocusTraversalOnArray(new Component[]{button_1}));",
+				"    setFocusTraversalPolicy(new FocusTraversalOnArray(new Component[]{button_1, button}));",
 				"  }",
 				"}");
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/TabOrderPropertyTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/TabOrderPropertyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,12 +10,14 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.swt.model.property;
 
+import org.eclipse.wb.internal.core.model.JavaInfoUtils;
 import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.model.property.order.TabOrderInfo;
 import org.eclipse.wb.internal.core.model.property.table.PropertyTooltipProvider;
 import org.eclipse.wb.internal.core.model.property.table.PropertyTooltipTextProvider;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.swt.model.property.TabOrderProperty;
+import org.eclipse.wb.internal.swt.model.widgets.ButtonInfo;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 import org.eclipse.wb.tests.designer.rcp.RcpModelTest;
@@ -67,6 +69,44 @@ public class TabOrderPropertyTest extends RcpModelTest {
 				tooltipProvider,
 				"getText(org.eclipse.wb.internal.core.model.property.Property)",
 				property));
+	}
+
+	/**
+	 * When a new component is added to the list but no focus traversal policy is
+	 * defined, then none should be created.
+	 */
+	@Test
+	public void test_noValue_addNewComponent() throws Exception {
+		CompositeInfo container =
+				parseComposite(
+						"public class Test extends Composite {",
+						"  public Test(Composite parent, int style) {",
+						"    super(parent, style);",
+						"    {",
+						"      Button button_1 = new Button(this, SWT.NONE);",
+						"      button_1.setText('New Button');",
+						"    }",
+						"  }",
+						"}");
+		container.refresh();
+		// add new Button
+		ButtonInfo newButton = createJavaInfo("org.eclipse.swt.widgets.Button");
+		JavaInfoUtils.add(newButton, null, container, null);
+		//
+		assertEditor(
+				"public class Test extends Composite {",
+				"  public Test(Composite parent, int style) {",
+				"    super(parent, style);",
+				"    {",
+				"      Button button_1 = new Button(this, SWT.NONE);",
+				"      button_1.setText('New Button');",
+				"    }",
+				"    {",
+				"      Button button = new Button(this, SWT.NONE);",
+				"      button.setText('New Button');",
+				"    }",
+				"  }",
+				"}");
 	}
 
 	@Test
@@ -279,6 +319,7 @@ public class TabOrderPropertyTest extends RcpModelTest {
 		assertEditor(
 				"public class Test extends Composite {",
 				"  private Combo combo;",
+				"  private Label label;",
 				"  public Test(Composite parent, int style) {",
 				"    super(parent, style);",
 				"    setLayout(new FillLayout());",
@@ -289,10 +330,10 @@ public class TabOrderPropertyTest extends RcpModelTest {
 				"      combo = new Combo(this, SWT.NONE);",
 				"    }",
 				"    {",
-				"      Label label = new Label(this, SWT.NONE);",
+				"      label = new Label(this, SWT.NONE);",
 				"      label.setText('New Label');",
 				"    }",
-				"    setTabList(new Control[]{combo});",
+				"    setTabList(new Control[]{combo, label});",
 				"  }",
 				"}");
 	}


### PR DESCRIPTION
When a tab order is set for a Swing/SWT component, newly added elements should automatically be added to the end of the list.