### PR TITLE
Second attempt to stabilize the PaletteUITests

### DIFF
--- a/org.eclipse.wb.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: WindowBuilder Tests
 Bundle-SymbolicName: org.eclipse.wb.tests;singleton:=true
-Bundle-Version: 1.2.300.qualifier
+Bundle-Version: 1.2.2.qualifier
 Bundle-Activator: org.eclipse.wb.tests.designer.tests.Activator
 Bundle-Vendor: Google
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.wb.tests/pom.xml
+++ b/org.eclipse.wb.tests/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.wb</groupId>
   <artifactId>org.eclipse.wb.tests</artifactId>
-  <version>1.2.300-SNAPSHOT</version>
+  <version>1.2.2-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
  

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/palette/ui/PaletteUiTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/palette/ui/PaletteUiTest.java
@@ -382,6 +382,12 @@ public class PaletteUiTest extends AbstractPaletteUiTest {
 					context.useShell("Open type");
 					Text filterText = context.findFirstWidget(Text.class);
 					filterText.setText(className);
+					context.waitFor(new UIPredicate() {
+						@Override
+						public boolean check() {
+							return className.equals(filterText.getText());
+						}
+					});
 				}
 				// wait for types
 				{

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/UiContext.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/UiContext.java
@@ -668,8 +668,6 @@ public class UiContext {
 						} catch (Throwable e) {
 							e.printStackTrace();
 							checkException[0] = e;
-							// close any opened shells to avoid deadlocks
-							closeShells();
 						}
 					}
 				});
@@ -693,9 +691,9 @@ public class UiContext {
 	 * Waits until given condition will be satisfied.
 	 */
 	public void waitFor(UIPredicate predicate) throws InterruptedException {
-		while (!predicate.check()) {
+		do {
 			waitEventLoop(10);
-		}
+		} while (!predicate.check());
 	}
 
 	/**
@@ -708,21 +706,6 @@ public class UiContext {
 			while (m_display.readAndDispatch()) {
 				// do nothing
 			}
-		}
-	}
-
-	////////////////////////////////////////////////////////////////////////////
-	//
-	// Cleanup
-	//
-	////////////////////////////////////////////////////////////////////////////
-
-	private void closeShells() {
-		Shell activeShell = getShell();
-		while (activeShell != null) {
-			popShell();
-			activeShell.dispose();
-			activeShell = getShell();
 		}
 	}
 }


### PR DESCRIPTION
Adjust the chooseComponentClass() to wait for the search text to be updated. It seems like the query from an earlier test is carried over. Furthermore, adjust the waitFor() method to always execute at least one cycle, in order to run idle UI events.

Revert "Fix: Deadlock when an exception is thrown inside an UIRunnable." This reverts commit 9d88d576a74534c300b41561f94b960647115f41.