### PR TITLE
Fix: Improper use of FontDescriptor to create bold fonts

### DIFF
--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/ObserveElementsWizardPage.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/ObserveElementsWizardPage.java
@@ -26,6 +26,7 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 
@@ -97,9 +98,11 @@ public class ObserveElementsWizardPage extends WizardPage {
 		// create value bold label
 		Label valueLabel = new Label(titleComposite, SWT.NONE);
 		GridDataFactory.create(valueLabel).fillH().grabH();
-		valueLabel.setFont(FontDescriptor.createFrom(valueLabel.getFont()) //
+		Font boldFont = FontDescriptor.createFrom(valueLabel.getFont()) //
 				.setStyle(SWT.BOLD) //
-				.createFont(null));
+				.createFont(null);
+		valueLabel.setFont(boldFont);
+		valueLabel.addDisposeListener(event -> boldFont.dispose());
 		valueLabel.setText(ExecutionUtils.runObjectLog(new RunnableObjectEx<String>() {
 			@Override
 			public String runObject() throws Exception {

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/editor/contentproviders/LabelUiContentProvider.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/editor/contentproviders/LabelUiContentProvider.java
@@ -15,6 +15,7 @@ import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 
 import org.eclipse.jface.resource.FontDescriptor;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 
@@ -59,9 +60,11 @@ public final class LabelUiContentProvider extends UiContentProviderAdapter {
 		// create value bold label
 		Label valueLabel = new Label(parent, SWT.NONE);
 		GridDataFactory.create(valueLabel).fillH().grabH().spanH(columns - 1);
-		valueLabel.setFont(FontDescriptor.createFrom(valueLabel.getFont()) //
+		Font boldFont = FontDescriptor.createFrom(valueLabel.getFont()) //
 				.setStyle(SWT.BOLD) //
-				.createFont(null));
+				.createFont(null);
+		valueLabel.setFont(boldFont);
+		valueLabel.addDisposeListener(event -> boldFont.dispose());
 		valueLabel.setText(m_value);
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/errors/MultipleConstructorsComposite.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/errors/MultipleConstructorsComposite.java
@@ -40,6 +40,7 @@ import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
@@ -77,11 +78,13 @@ public final class MultipleConstructorsComposite extends Composite {
 				label.setImage(parent.getDisplay().getSystemImage(SWT.ICON_INFORMATION));
 			}
 			{
-				m_titleLabel = new Label(titleComposite, SWT.NONE);
-				m_titleLabel.setFont(FontDescriptor.createFrom(getFont()) //
+				Font boldFont = FontDescriptor.createFrom(getFont()) //
 						.setHeight(14) //
 						.setStyle(SWT.BOLD) //
-						.createFont(null));
+						.createFont(null);
+				m_titleLabel = new Label(titleComposite, SWT.NONE);
+				m_titleLabel.setFont(boldFont);
+				m_titleLabel.addDisposeListener(event -> boldFont.dispose());
 			}
 		}
 		// Browser

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/errors/NoEntryPointComposite.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/errors/NoEntryPointComposite.java
@@ -42,6 +42,7 @@ import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
@@ -81,11 +82,13 @@ public final class NoEntryPointComposite extends Composite {
 				label.setImage(parent.getDisplay().getSystemImage(SWT.ICON_INFORMATION));
 			}
 			{
-				m_titleLabel = new Label(titleComposite, SWT.NONE);
-				m_titleLabel.setFont(FontDescriptor.createFrom(getFont()) //
+				Font boldFont = FontDescriptor.createFrom(getFont()) //
 						.setHeight(14) //
 						.setStyle(SWT.BOLD) //
-						.createFont(null));
+						.createFont(null);
+				m_titleLabel = new Label(titleComposite, SWT.NONE);
+				m_titleLabel.setFont(boldFont);
+				m_titleLabel.addDisposeListener(event -> boldFont.dispose());
 			}
 		}
 		// Browser

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/hierarchy/ComponentClassPropertyEditor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/hierarchy/ComponentClassPropertyEditor.java
@@ -250,6 +250,11 @@ public final class ComponentClassPropertyEditor extends TextDisplayPropertyEdito
 			return JavaUI.getSharedImages().getImage(ISharedImages.IMG_OBJS_CLASS);
 		}
 
+		@Override
+		public void dispose() {
+			m_treeFont.dispose();
+		}
+
 		////////////////////////////////////////////////////////////////////////////
 		//
 		// IFontProvider

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/CustomTooltipProvider.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/CustomTooltipProvider.java
@@ -25,6 +25,8 @@ import org.eclipse.swt.widgets.Shell;
  * @coverage gef.draw2d
  */
 public abstract class CustomTooltipProvider implements ICustomTooltipProvider {
+	protected FigureCanvas m_canvas;
+
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// ICustomTooltipProvider
@@ -32,12 +34,12 @@ public abstract class CustomTooltipProvider implements ICustomTooltipProvider {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public final Control createTooltipControl(Composite parent, ICustomTooltipSite site, Figure figure) {
-		FigureCanvas canvas = new FigureCanvas(parent, SWT.NONE);
-		GridDataFactory.create(canvas).fill().grab();
-		canvas.addListener(SWT.MouseDown, site.getHideListener());
-		canvas.addListener(SWT.MouseExit, site.getHideListener());
+		m_canvas = new FigureCanvas(parent, SWT.NONE);
+		GridDataFactory.create(m_canvas).fill().grab();
+		m_canvas.addListener(SWT.MouseDown, site.getHideListener());
+		m_canvas.addListener(SWT.MouseExit, site.getHideListener());
 		//
-		RootFigure rootFigure = canvas.getRootFigure();
+		RootFigure rootFigure = m_canvas.getRootFigure();
 		rootFigure.setForegroundColor(parent.getForeground());
 		rootFigure.setBackgroundColor(parent.getBackground());
 		//
@@ -45,7 +47,7 @@ public abstract class CustomTooltipProvider implements ICustomTooltipProvider {
 		layer.add(createTooltipFigure(figure));
 		rootFigure.addLayer(layer);
 		//
-		return canvas;
+		return m_canvas;
 	}
 
 	@Override

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/JustifyPaletteTooltipProvider.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/JustifyPaletteTooltipProvider.java
@@ -21,6 +21,7 @@ import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.jface.resource.FontDescriptor;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Font;
 
 /**
  * Standard palette tooltip: bold header and multi line details.
@@ -53,9 +54,11 @@ public final class JustifyPaletteTooltipProvider extends CustomTooltipProvider {
 	protected Figure createTooltipFigure(Figure hostFigure) {
 		// header figure
 		Label headerFigure = new Label(m_header);
-		headerFigure.setFont(FontDescriptor.createFrom(headerFigure.getFont()) //
+		Font boldFont = FontDescriptor.createFrom(headerFigure.getFont()) //
 				.setStyle(SWT.BOLD) //
-				.createFont(null));
+				.createFont(null);
+		m_canvas.addDisposeListener(event -> boldFont.dispose());
+		headerFigure.setFont(boldFont);
 		// details figure
 		JustifyLabel detailsFigure = new JustifyLabel();
 		detailsFigure.setBorder(new MarginBorder(new Insets(0, 2, 2, 2)));

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/selection/TopResizeFigure.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/selection/TopResizeFigure.java
@@ -20,6 +20,7 @@ import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.jface.resource.FontDescriptor;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Font;
 
 import org.apache.commons.lang.StringUtils;
 
@@ -62,14 +63,18 @@ public class TopResizeFigure extends SemiTransparentFigure {
 		super.paintClientArea(graphics);
 		if (!StringUtils.isEmpty(m_sizeText)) {
 			Rectangle area = getClientArea();
-			graphics.setFont(FontDescriptor.createFrom(graphics.getFont()) //
+			Font oldFont = graphics.getFont();
+			Font newFont = FontDescriptor.createFrom(oldFont) //
 					.setHeight(16) //
 					.setStyle(SWT.NONE) //
-					.createFont(null));
+					.createFont(null);
+			graphics.setFont(newFont);
 			Dimension textExtent = TextUtilities.INSTANCE.getTextExtents(m_sizeText, graphics.getFont());
 			int x = area.x + (area.width - textExtent.width) / 2;
 			int y = area.y + (area.height - textExtent.height) / 2;
 			graphics.drawString(m_sizeText, x, y);
+			graphics.setFont(oldFont);
+			newFont.dispose();
 		}
 	}
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/errors/WarningComposite.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/errors/WarningComposite.java
@@ -25,6 +25,7 @@ import org.eclipse.jface.resource.FontDescriptor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
@@ -65,11 +66,13 @@ public abstract class WarningComposite extends Composite {
 				label.setImage(parent.getDisplay().getSystemImage(SWT.ICON_WARNING));
 			}
 			{
-				m_titleLabel = new Label(titleComposite, SWT.NONE);
-				m_titleLabel.setFont(FontDescriptor.createFrom(getFont()) //
+				Font boldFont = FontDescriptor.createFrom(getFont()) //
 						.setHeight(14) //
 						.setStyle(SWT.BOLD) //
-						.createFont(null));
+						.createFont(null);
+				m_titleLabel = new Label(titleComposite, SWT.NONE);
+				m_titleLabel.setFont(boldFont);
+				m_titleLabel.addDisposeListener(event -> boldFont.dispose());
 			}
 		}
 		{

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/contentproviders/el/KeywordsRule.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/contentproviders/el/KeywordsRule.java
@@ -18,6 +18,8 @@ import org.eclipse.jface.text.rules.IToken;
 import org.eclipse.jface.text.rules.Token;
 import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.graphics.Font;
 
 /**
  * {@link IRule} for detect {@code EL} keywords.
@@ -44,13 +46,15 @@ public class KeywordsRule implements IRule {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	public KeywordsRule(ISourceViewer sourceViewer, ElPropertyUiConfiguration configuration) {
-		m_token =
-				new Token(new TextAttribute(configuration.getKeywordsColor(),
+		StyledText control = sourceViewer.getTextWidget();
+		Font boldFont = FontDescriptor.createFrom(control.getFont()) //
+			.setStyle(SWT.BOLD) //
+			.createFont(null);
+		control.addDisposeListener(event -> boldFont.dispose());
+		m_token = new Token(new TextAttribute(configuration.getKeywordsColor(),
 						null,
 						SWT.NORMAL,
-						FontDescriptor.createFrom(sourceViewer.getTextWidget().getFont()) //
-								.setStyle(SWT.BOLD) //
-								.createFont(null)));
+						boldFont));
 	}
 
 	////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
We use the original font to create its bold variant. However, we never actually dispose this new instance, resulting in WidgetIsDisposed exceptions. The lifetime of those new fonts are now bound to its closest widget.

Amends e3f251258d6dae9939064edbd299bdc363691e9d