### PR TITLE
Fix: NoClassDefFoundError in MVEL when using Java 21

### DIFF
--- a/target-platform/mvn/wb-mvn.target
+++ b/target-platform/mvn/wb-mvn.target
@@ -37,7 +37,7 @@
 				<dependency>
 					<groupId>org.mvel</groupId>
 					<artifactId>mvel2</artifactId>
-					<version>2.4.15.Final</version>
+					<version>2.5.0.Final</version>
 					<type>jar</type>
 				</dependency>
 			</dependencies>


### PR DESCRIPTION
MVEL is internally referencing java.lang.Compiler, which has been removed with Java 21:
https://bugs.openjdk.org/browse/JDK-8205129

Update MVEL from 2.4.15 to 2.5.0, where this issue has been resolved.

See #579