### PR TITLE
Fix: Potential memory leak due to undisposed resource registries

### DIFF
--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/jface/resource/ColorRegistryInfo.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/jface/resource/ColorRegistryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,9 @@ package org.eclipse.wb.internal.swt.model.jface.resource;
 import org.eclipse.wb.internal.core.model.creation.CreationSupport;
 import org.eclipse.wb.internal.core.model.description.ComponentDescription;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
+import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
+
+import org.eclipse.jface.resource.ColorRegistry;
 
 /**
  * Implementation model for {@link org.eclipse.jface.resource.ColorRegistry}.
@@ -30,5 +33,13 @@ public final class ColorRegistryInfo extends ResourceRegistryInfo {
 			ComponentDescription description,
 			CreationSupport creationSupport) throws Exception {
 		super(editor, description, creationSupport);
+	}
+
+	@Override
+	public Runnable getDisposeRunnable() {
+		if (getObject() instanceof ColorRegistry registry) {
+			return (Runnable) ReflectionUtils.getFieldObject(registry, "displayRunnable");
+		}
+		return null;
 	}
 }

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/jface/resource/FontRegistryInfo.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/jface/resource/FontRegistryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,9 @@ package org.eclipse.wb.internal.swt.model.jface.resource;
 import org.eclipse.wb.internal.core.model.creation.CreationSupport;
 import org.eclipse.wb.internal.core.model.description.ComponentDescription;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
+import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
+
+import org.eclipse.jface.resource.FontRegistry;
 
 /**
  * Implementation model for {@link org.eclipse.jface.resource.FontRegistry}.
@@ -30,5 +33,13 @@ public final class FontRegistryInfo extends ResourceRegistryInfo {
 			ComponentDescription description,
 			CreationSupport creationSupport) throws Exception {
 		super(editor, description, creationSupport);
+	}
+
+	@Override
+	public Runnable getDisposeRunnable() {
+		if (getObject() instanceof FontRegistry registry) {
+			return (Runnable) ReflectionUtils.getFieldObject(registry, "displayRunnable");
+		}
+		return null;
 	}
 }

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/jface/resource/ResourceRegistryInfo.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/jface/resource/ResourceRegistryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,10 @@ import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.core.utils.state.EditorState;
 
+import org.eclipse.jface.resource.ColorRegistry;
+import org.eclipse.jface.resource.ResourceRegistry;
+import org.eclipse.swt.widgets.Display;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -30,7 +34,7 @@ import java.util.List;
  * @author lobas_av
  * @coverage swt.model.jface
  */
-public class ResourceRegistryInfo extends JavaInfo {
+public abstract class ResourceRegistryInfo extends JavaInfo {
 	private final List<KeyFieldInfo> m_fields;
 
 	////////////////////////////////////////////////////////////////////////////
@@ -60,6 +64,19 @@ public class ResourceRegistryInfo extends JavaInfo {
 	public final List<KeyFieldInfo> getKeyFields() {
 		return m_fields;
 	}
+
+	/**
+	 * When we create instances of various {@link ResourceRegistry}'s, for example
+	 * {@link ColorRegistry} , they usually want to be disposed with
+	 * {@link Display}, so they use {@link Display#disposeExec(Runnable)}. But our
+	 * {@link Display} instance lives all time while Eclipse lives. So, practically
+	 * we have memory leak: we keep in memory instance of {@link ResourceRegistry},
+	 * its allocated resources, and what is much worse - instance of
+	 * {@link ClassLoader} that loaded this {@link ResourceRegistry}.
+	 *
+	 * @return the {@link Runnable} that is executed when the registry is disposed.
+	 */
+	public abstract Runnable getDisposeRunnable();
 
 	/**
 	 * Extract all <code>public static</code> field's with type {@link String} for given {@link Class}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ResourceRegistryTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ResourceRegistryTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,7 +21,6 @@ import org.eclipse.wb.tests.designer.rcp.RcpModelTest;
 import org.eclipse.swt.widgets.Display;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.lang.reflect.Array;
@@ -71,7 +70,6 @@ public class ResourceRegistryTest extends RcpModelTest {
 	// Tests
 	//
 	////////////////////////////////////////////////////////////////////////////
-	@Ignore
 	@Test
 	public void test_info() throws Exception {
 		setFileContentSrc(


### PR DESCRIPTION
When we create instances of various ResourceRegistrys, for example ColorRegistry, they usually want to be disposed with Display, so they use Display#disposeExec(Runnable). But our Display instance lives all time while Eclipse lives. So, practically we have memory leak: we keep in memory instance of ResourceRegistry. its allocated resources, and what is much worse - instance of ClassLoader that loaded this ReourceRegistry.

The old implementation that used to explicitly dispose those objects was no longer functional and has been repaired.