### PR TITLE
[GEF] Reuse bounds variable inherited from parent Figure class

### DIFF
--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/AbstractRelativeLocator.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/AbstractRelativeLocator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,7 @@
 package org.eclipse.wb.draw2d;
 
 import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 
 /**
@@ -89,7 +90,7 @@ public abstract class AbstractRelativeLocator implements ILocator, IPositionCons
 		int x = reference.x + (int) (reference.width * m_relativeX) - (targetSize.width + 1) / 2;
 		int y = reference.y + (int) (reference.height * m_relativeY) - (targetSize.height + 1) / 2;
 		// set target location
-		target.setLocation(x, y);
+		target.setLocation(new Point(x, y));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
@@ -19,7 +19,6 @@ import org.eclipse.draw2d.FigureListener;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Insets;
-import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.swt.graphics.Cursor;
 
@@ -37,7 +36,6 @@ import java.util.List;
  */
 public class Figure extends org.eclipse.draw2d.Figure {
 	private Figure m_parent;
-	private final Rectangle m_bounds = new Rectangle();
 	private List<Figure> m_children;
 	private Border m_border;
 	private Cursor m_cursor;
@@ -408,52 +406,17 @@ public class Figure extends org.eclipse.draw2d.Figure {
 	//
 	////////////////////////////////////////////////////////////////////////////
 
-	/**
-	 * Returns the smallest rectangle completely enclosing the figure. Returns Reactangle by
-	 * reference. DO NOT Modify returned value.
-	 */
-	@Override
-	public Rectangle getBounds() {
-		return m_bounds;
-	}
-
-	/**
-	 * Sets the location of this Figure.
-	 */
-	public void setLocation(int x, int y) {
-		if (m_bounds.x != x || m_bounds.y != y) {
-			setBounds(new Rectangle(getBounds()).setLocation(x, y));
-		}
-	}
-
-	/**
-	 * Sets the location of this Figure.
-	 */
-	@Override
-	public void setLocation(Point location) {
-		setLocation(location.x, location.y);
-	}
-
-	/**
-	 * Sets this Figure's size.
-	 */
-	@Override
-	public void setSize(int width, int height) {
-		if (m_bounds.width != width || m_bounds.height != height) {
-			setBounds(new Rectangle(getBounds()).setSize(width, height));
-		}
-	}
 
 	/**
 	 * Sets the bounds of this Figure to the Rectangle <i>rect</i>.
 	 */
 	@Override
 	public void setBounds(Rectangle bounds) {
-		if (!m_bounds.equals(bounds)) {
+		if (!this.bounds.equals(bounds)) {
 			// calc repaint rectangle
-			Rectangle dirtyArea = m_bounds.getUnion(bounds);
+			Rectangle dirtyArea = this.bounds.getUnion(bounds);
 			// change bounds
-			m_bounds.setBounds(bounds);
+			this.bounds.setBounds(bounds);
 			// send move event
 			fireMoved();
 			// reset state
@@ -472,36 +435,6 @@ public class Figure extends org.eclipse.draw2d.Figure {
 			return IFigure.NO_INSETS;
 		}
 		return m_border.getInsets(this);
-	}
-
-	/**
-	 * Copies the client area into the specified {@link Rectangle}, and returns that rectangle for
-	 * convenience.
-	 */
-	@Override
-	public Rectangle getClientArea(Rectangle rectangle) {
-		rectangle.setBounds(getBounds());
-		rectangle.crop(getInsets());
-		rectangle.setLocation(0, 0);
-		return rectangle;
-	}
-
-	/**
-	 * Returns <code>true</code> if this Figure's bounds intersect with the given Rectangle. Figure is
-	 * asked so that non-rectangular Figures can reduce the frequency of paints.
-	 */
-	@Override
-	public boolean intersects(Rectangle rectangle) {
-		return getBounds().intersects(rectangle);
-	}
-
-	/**
-	 * Returns <code>true</code> if the point <code>(x, y)</code> is contained within this
-	 * {@link Figure}'s bounds.
-	 */
-	@Override
-	public boolean containsPoint(int x, int y) {
-		return getBounds().contains(x, y);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/figure/TextFeedback.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/figure/TextFeedback.java
@@ -132,7 +132,7 @@ public final class TextFeedback {
 		int x = target.x + (target.width - m_size.width) / 2;
 		int y = target.y - m_size.height - shift;
 		y = Math.max(y, 1);
-		m_label.setLocation(x, y);
+		m_label.setLocation(new Point(x, y));
 	}
 
 	/**
@@ -142,7 +142,7 @@ public final class TextFeedback {
 	public void moveRightOuter(Rectangle target, int shift) {
 		int x = target.right() + shift;
 		int y = target.bottom() - m_size.height;
-		m_label.setLocation(x, y);
+		m_label.setLocation(new Point(x, y));
 	}
 
 	/**
@@ -151,6 +151,6 @@ public final class TextFeedback {
 	public void moveTopLeftCenter(Point location) {
 		int x = location.x - m_size.width / 2;
 		int y = location.y - m_size.height / 2;
-		m_label.setLocation(x, y);
+		m_label.setLocation(new Point(x, y));
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigurePaintingTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigurePaintingTest.java
@@ -182,11 +182,11 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		m_actualLogger.assertEmpty();
 		//
 		// check no reset state during setLocation(int, int) if bounds not change
-		testFigure.setLocation(1, 2);
+		testFigure.setLocation(new Point(1, 2));
 		m_actualLogger.assertEmpty();
 		//
 		// check reset state during setLocation(int, int)
-		testFigure.setLocation(3, 7);
+		testFigure.setLocation(new Point(3, 7));
 		expectedLogger.log("invalidate");
 		expectedLogger.log("repaint(1, 2, 13, 17)");
 		m_actualLogger.assertEquals(expectedLogger);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigureTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigureTest.java
@@ -523,7 +523,7 @@ public class FigureTest extends Draw2dFigureTestCase {
 		assertEquals(new Rectangle(20, 40, 120, 57), testFigure.getBounds());
 		//
 		// check work setLocation(int, int)
-		testFigure.setLocation(90, 40);
+		testFigure.setLocation(new Point(90, 40));
 		assertEquals(new Rectangle(90, 40, 120, 57), testFigure.getBounds());
 	}
 
@@ -1038,7 +1038,7 @@ public class FigureTest extends Draw2dFigureTestCase {
 		actualLogger.assertEquals(expectedLogger);
 		//
 		// check invoke figure move during setLocation()
-		testFigure.setLocation(10, 20);
+		testFigure.setLocation(new Point(10, 20));
 		//
 		expectedLogger.log("figureMoved(__testFigure_)");
 		actualLogger.assertEquals(expectedLogger);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/LayerTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/LayerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -59,7 +59,7 @@ public class LayerTest extends Draw2dFigureTestCase {
 		assertEquals(new Rectangle(1, 2, 3, 4), layer.getBounds());
 		//
 		// check work setLocation(int, int) and not reset state
-		layer.setLocation(5, 5);
+		layer.setLocation(new Point(5, 5));
 		actualLogger.assertEmpty();
 		assertEquals(new Rectangle(5, 5, 3, 4), layer.getBounds());
 		//


### PR DESCRIPTION
Our Designer figure currently has the local field "m_bounds" and "bounds", inherited from its parent class. The setBounds() method only updates the local field, which may lead to confusion when
 a) debugging the application and
 b) calling GEF methods, which may access the parent field directly

Given that both fields serve the same purpose, we might as well reuse the parent variable to avoid this problem. Note that this change also removes the setLocation(int, int) method, with its replacement being setLocation(Point). We only really use it in the TextFeedback class, so I don't think it's worth pushing this additional method to the downstream project.