### PR TITLE
 Update documentation to aligh with removal of SWTResourceManager. 

### DIFF
--- a/org.eclipse.wb.doc.user/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.doc.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.doc.user; singleton:=true
-Bundle-Version: 1.9.3.qualifier
+Bundle-Version: 1.9.400.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.wb.doc.user/html/features/custom_composites.html
+++ b/org.eclipse.wb.doc.user/html/features/custom_composites.html
@@ -232,8 +232,6 @@
 				</font><font SIZE="2" COLOR="#7f0055"><b>
 				<dd><font face="Courier">import</font></b></font><font SIZE="2" face="Courier"> org.eclipse.swt.layout.*;</dd>
 				</font><font SIZE="2" COLOR="#7f0055"><b>
-				<dd><font face="Courier">import</font></b></font><font SIZE="2" face="Courier"> 
-				com.swtdesigner.SWTResourceManager;</dd>
 				</font><font SIZE="2" COLOR="#7f0055"><b>
 				<dd><font face="Courier">import</font></b></font><font SIZE="2" face="Courier"> 
 				org.eclipse.swt.layout.GridLayout;<br>
@@ -325,7 +323,7 @@
 						<dd><font face="Courier"><span style="background-color: #FFFF99">
 						customComposite.setBrowseButtonText(</span></font></font><font SIZE="2" COLOR="#2a00ff" face="Courier"><span style="background-color: #FFFF99">&quot;Find...&quot;</span></font><font SIZE="2"><font face="Courier"><span style="background-color: #FFFF99">);</span></font></dd>
 						<dd><font face="Courier"><span style="background-color: #FFFF99">
-						customComposite.setFirstFieldBackground(SWTResourceManager.<i>getColor</i>(SWT.</span></font></font><font SIZE="2" COLOR="#0000c0" face="Courier"><i><span style="background-color: #FFFF99">COLOR_YELLOW</span></i></font><font SIZE="2"><font face="Courier"><span style="background-color: #FFFF99">));</span><br>
+						customComposite.setFirstFieldBackground(shell.getDisplay().<i>getSystemColor</i>(SWT.</span></font></font><font SIZE="2" COLOR="#0000c0" face="Courier"><i><span style="background-color: #FFFF99">COLOR_YELLOW</span></i></font><font SIZE="2"><font face="Courier"><span style="background-color: #FFFF99">));</span><br>
 &nbsp;</font></dd>
 						<dd></font><font face="Courier"><font SIZE="2" COLOR="#7f0055"><b>final</b></font><font SIZE="2"> 
 						GridLayout gridLayout = </font>


### PR DESCRIPTION
When the "Use ResourceManager for color/font/image access" property is set, we currently copy a static SWTResourceManager class into the user workspace. This class is then used to manage those SWT objects.

Instead, we now simply create an instance object of LocalResourceManager into the currently active class, which those calls are delegated to.

This is part of the slow removal of the SWTResourceManager.