### PR TITLE
Ensure forward compatibility by executing the tests with Java 17 & 21

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: [ 17 ]
+        java: [ 17, 21 ]
     runs-on: ${{ matrix.os }}   
     name: OS ${{ matrix.os }} Java ${{ matrix.java }} compile
     timeout-minutes: 90
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
        fetch-depth: 0
-    - name: Set up JDK 11
+    - name: Set up JDK 17/21
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin' # See 'Supported distributions' for available options

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/databinding/rcp/model/beans/BeanBindableTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/databinding/rcp/model/beans/BeanBindableTest.java
@@ -213,7 +213,12 @@ public class BeanBindableTest extends AbstractBindingTest {
 		//
 		List<IObserveInfo> listProperties =
 				observes.get(2).getChildren(ChildrenContext.ChildrenForPropertiesTable);
-		assertEquals(3, listProperties.size());
+
+		if (Runtime.version().feature() >= 21) {
+			assertEquals(5, listProperties.size());
+		} else {
+			assertEquals(3, listProperties.size());
+		}
 		//
 		assertBindable(
 				CollectionPropertyBindableInfo.class,
@@ -235,6 +240,22 @@ public class BeanBindableTest extends AbstractBindingTest {
 				false,
 				"empty|\"empty\"|boolean",
 				listProperties.get(2));
+		//
+		if (Runtime.version().feature() >= 21) {
+			assertBindable(
+					BeanPropertyDescriptorBindableInfo.class,
+					null,
+					true,
+					"first|\"first\"|java.lang.Object",
+					listProperties.get(3));
+			//
+			assertBindable(
+					BeanPropertyDescriptorBindableInfo.class,
+					null,
+					true,
+					"last|\"last\"|java.lang.Object",
+					listProperties.get(4));
+		}
 	}
 
 	@Test

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/databinding/rcp/model/beans/BeanObservableTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/databinding/rcp/model/beans/BeanObservableTest.java
@@ -177,48 +177,69 @@ public class BeanObservableTest extends AbstractBindingTest {
 		//
 		List<IObserveInfo> listProperties =
 				observes.get(2).getChildren(ChildrenContext.ChildrenForPropertiesTable);
-		assertEquals(6, listProperties.size());
+		if (Runtime.version().feature() >= 21) {
+			assertEquals(8, listProperties.size());
+		} else {
+			assertEquals(6, listProperties.size());
+		}
 		//
+		int index = 0;
 		BeanBindableTest.assertBindable(
 				DirectPropertyBindableInfo.class,
 				null,
 				false,
 				"Object as IObservableList||org.eclipse.core.databinding.observable.list.IObservableList",
-				listProperties.get(0));
+				listProperties.get(index++));
 		//
 		BeanBindableTest.assertBindable(
 				BeanPropertyDescriptorBindableInfo.class,
 				null,
 				false,
 				"disposed|\"disposed\"|boolean",
-				listProperties.get(1));
+				listProperties.get(index++));
 		BeanBindableTest.assertBindable(
 				BeanPropertyDescriptorBindableInfo.class,
 				null,
 				true,
 				"elementType|\"elementType\"|java.lang.Object",
-				listProperties.get(2));
+				listProperties.get(index++));
 		//
 		BeanBindableTest.assertBindable(
 				BeanPropertyDescriptorBindableInfo.class,
 				null,
 				false,
 				"empty|\"empty\"|boolean",
-				listProperties.get(3));
+				listProperties.get(index++));
+		//
+		if (Runtime.version().feature() >= 21) {
+			BeanBindableTest.assertBindable(
+					BeanPropertyDescriptorBindableInfo.class,
+					null,
+					true,
+					"first|\"first\"|java.lang.Object",
+					listProperties.get(index++));
+			//
+			BeanBindableTest.assertBindable(
+					BeanPropertyDescriptorBindableInfo.class,
+					null,
+					true,
+					"last|\"last\"|java.lang.Object",
+					listProperties.get(index++));
+		}
 		//
 		BeanBindableTest.assertBindable(
 				BeanPropertyDescriptorBindableInfo.class,
 				null,
 				true,
 				"realm|\"realm\"|org.eclipse.core.databinding.observable.Realm",
-				listProperties.get(4));
+				listProperties.get(index++));
 		//
 		BeanBindableTest.assertBindable(
 				BeanPropertyDescriptorBindableInfo.class,
 				null,
 				false,
 				"stale|\"stale\"|boolean",
-				listProperties.get(5));
+				listProperties.get(index++));
 		// ----------------------------------------------
 		BeanBindableTest.assertBindable(
 				FieldBeanBindableInfo.class,


### PR DESCRIPTION
Note that the goal is not to require Java 21, just to make sure that WindowBuilder that it can be executed with the current LTS.