### PR TITLE
Replace usage of SWTResourceManager for images with LocalResourceManager

### DIFF
--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/preferences/IPreferenceConstants.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/preferences/IPreferenceConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,8 @@ package org.eclipse.wb.internal.swt.preferences;
 
 import org.eclipse.wb.internal.swt.model.layout.LayoutDataInfo;
 import org.eclipse.wb.internal.swt.model.layout.LayoutInfo;
+
+import org.eclipse.jface.resource.LocalResourceManager;
 
 /**
  * Contains various preference constants for SWT.
@@ -27,8 +29,8 @@ public interface IPreferenceConstants {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * When <code>true</code>, we automatically add <code>SWTResourceManager</code> and use it for
-	 * color/font/image access. This allows use resources sharing.
+	 * When <code>true</code>, we automatically add {@link LocalResourceManager} and
+	 * use it for color/font/image access. This allows use resources sharing.
 	 */
 	String P_USE_RESOURCE_MANAGER = "useResourceManager";
 	/**

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ImageDescriptorPropertyEditorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ImageDescriptorPropertyEditorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,6 @@ import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.swt.model.property.editor.image.ImageDescriptorPropertyEditor;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
-import org.eclipse.wb.internal.swt.utils.ManagerUtils;
 import org.eclipse.wb.tests.designer.rcp.RcpModelTest;
 
 import org.eclipse.swt.SWT;
@@ -78,9 +77,6 @@ public abstract class ImageDescriptorPropertyEditorTest extends RcpModelTest {
 		ControlInfo control = shell.getChildrenControls().get(0);
 		shell.refresh();
 		assertNoErrors(shell);
-		// ensure SWTResourceManager and ResourceManager
-		ManagerUtils.ensure_SWTResourceManager(shell);
-		ManagerUtils.ensure_ResourceManager(shell);
 		// set property using "source"
 		GenericProperty property = (GenericProperty) control.getPropertyByTitle("imageDescriptor");
 		property.setExpression(source, Property.UNKNOWN_VALUE);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ImageDescriptorPropertyEditorTestNoManager.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ImageDescriptorPropertyEditorTestNoManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,8 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.swt.model.property;
+
+import static org.eclipse.wb.internal.swt.model.property.editor.image.ImageDescriptorPropertyEditor.getInvocationSource;
 
 import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.rcp.ToolkitProvider;
@@ -88,9 +90,9 @@ public class ImageDescriptorPropertyEditorTestNoManager extends ImageDescriptorP
 		try {
 			String path = FilenameUtils.separatorsToUnix(file.getCanonicalPath());
 			assert_getText_getClipboardSource_forSource(
-					"ImageDescriptor.createFromFile(null, \"" + path + "\")",
+					getInvocationSource(null, '"' + path + '"'),
 					"File: " + path,
-					"org.eclipse.jface.resource.ImageDescriptor.createFromFile(null, \"" + path + "\")");
+					getInvocationSource(null, '"' + path + '"'));
 		} finally {
 			file.delete();
 		}
@@ -103,9 +105,9 @@ public class ImageDescriptorPropertyEditorTestNoManager extends ImageDescriptorP
 	@Test
 	public void test_textSource_image_over_classpath() throws Exception {
 		assert_getText_getClipboardSource_forSource(
-				"ImageDescriptor.createFromFile(getClass(), \"/javax/swing/plaf/basic/icons/JavaCup16.png\")",
+				getInvocationSource("getClass()", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""),
 				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
-				"org.eclipse.jface.resource.ImageDescriptor.createFromFile({wbp_classTop}, \"/javax/swing/plaf/basic/icons/JavaCup16.png\")");
+				getInvocationSource("{wbp_classTop}", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""));
 	}
 
 	/**
@@ -115,8 +117,8 @@ public class ImageDescriptorPropertyEditorTestNoManager extends ImageDescriptorP
 	@Test
 	public void test_textSource_image_over_classpath_OtherClass() throws Exception {
 		assert_getText_getClipboardSource_forSource(
-				"ImageDescriptor.createFromFile(String.class, \"/javax/swing/plaf/basic/icons/JavaCup16.png\")",
+				getInvocationSource("String.class", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""),
 				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
-				"org.eclipse.jface.resource.ImageDescriptor.createFromFile({wbp_classTop}, \"/javax/swing/plaf/basic/icons/JavaCup16.png\")");
+				getInvocationSource("{wbp_classTop}", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""));
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ImageDescriptorPropertyEditorTestWithManager.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ImageDescriptorPropertyEditorTestWithManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,8 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.swt.model.property;
+
+import static org.eclipse.wb.internal.swt.model.property.editor.image.ImageDescriptorPropertyEditor.getInvocationSource;
 
 import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.rcp.ToolkitProvider;
@@ -87,11 +89,10 @@ public class ImageDescriptorPropertyEditorTestWithManager extends ImageDescripto
 		File file = createTempImage();
 		try {
 			String path = FilenameUtils.separatorsToUnix(file.getCanonicalPath());
-			String source = "ImageDescriptor.createFromFile(null, \"" + path + "\")";
 			assert_getText_getClipboardSource_forSource(
-					source,
+					getInvocationSource(null, '"' + path + '"'),
 					"File: " + path,
-					"org.eclipse.wb.swt.ResourceManager.getImageDescriptor(\"" + path + "\")");
+					getInvocationSource(null, '"' + path + '"'));
 		} finally {
 			file.delete();
 		}
@@ -104,9 +105,9 @@ public class ImageDescriptorPropertyEditorTestWithManager extends ImageDescripto
 	@Test
 	public void test_textSource_image_over_classpath() throws Exception {
 		assert_getText_getClipboardSource_forSource(
-				"ImageDescriptor.createFromFile(getClass(), \"/javax/swing/plaf/basic/icons/JavaCup16.png\")",
+				getInvocationSource("getClass()", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""),
 				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
-				"org.eclipse.wb.swt.ResourceManager.getImageDescriptor({wbp_classTop}, \"/javax/swing/plaf/basic/icons/JavaCup16.png\")");
+				getInvocationSource("{wbp_classTop}", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""));
 	}
 
 	/**
@@ -116,9 +117,9 @@ public class ImageDescriptorPropertyEditorTestWithManager extends ImageDescripto
 	@Test
 	public void test_textSource_image_over_classpath_OtherClass() throws Exception {
 		assert_getText_getClipboardSource_forSource(
-				"ImageDescriptor.createFromFile(String.class, \"/javax/swing/plaf/basic/icons/JavaCup16.png\")",
+				getInvocationSource("String.class", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""),
 				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
-				"org.eclipse.wb.swt.ResourceManager.getImageDescriptor({wbp_classTop}, \"/javax/swing/plaf/basic/icons/JavaCup16.png\")");
+				getInvocationSource("{wbp_classTop}", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""));
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -127,7 +128,7 @@ public class ImageDescriptorPropertyEditorTestWithManager extends ImageDescripto
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * Test for <code>ResourceManager.getImageDescriptor(absolutePath)</code>.
+	 * Test for <code>ImageDescriptor.createFrom(null, absolutePath)</code>.
 	 */
 	@Test
 	public void test_textSource_absolutePath2() throws Exception {
@@ -135,34 +136,34 @@ public class ImageDescriptorPropertyEditorTestWithManager extends ImageDescripto
 		try {
 			String path = FilenameUtils.separatorsToUnix(file.getCanonicalPath());
 			assert_getText_getClipboardSource_forSource(
-					"org.eclipse.wb.swt.ResourceManager.getImageDescriptor(\"" + path + "\")",
+					getInvocationSource(null, '"' + path + '"'),
 					"File: " + path,
-					"org.eclipse.wb.swt.ResourceManager.getImageDescriptor(\"" + path + "\")");
+					getInvocationSource(null, '"' + path + '"'));
 		} finally {
 			file.delete();
 		}
 	}
 
 	/**
-	 * Test for <code>ResourceManager.getImageDescriptor(Class, resourcePath)</code>.
+	 * Test for <code>ImageDescriptor.createFrom(Class, resourcePath)</code>.
 	 */
 	@Test
 	public void test_textSource_image_over_classpath2() throws Exception {
 		assert_getText_getClipboardSource_forSource(
-				"org.eclipse.wb.swt.ResourceManager.getImageDescriptor(getClass(), \"/javax/swing/plaf/basic/icons/JavaCup16.png\")",
+				getInvocationSource("getClass()", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""),
 				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
-				"org.eclipse.wb.swt.ResourceManager.getImageDescriptor({wbp_classTop}, \"/javax/swing/plaf/basic/icons/JavaCup16.png\")");
+				getInvocationSource("{wbp_classTop}", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""));
 	}
 
 	/**
-	 * Test for <code>ResourceManager.getImageDescriptor(Class, resourcePath)</code>, some other
+	 * Test for <code>ImageDescriptor.createFrom(Class, resourcePath)</code>, some other
 	 * {@link Class} as location.
 	 */
 	@Test
 	public void test_textSource_image_over_classpath_OtherClass2() throws Exception {
 		assert_getText_getClipboardSource_forSource(
-				"org.eclipse.wb.swt.ResourceManager.getImageDescriptor(String.class, \"/javax/swing/plaf/basic/icons/JavaCup16.png\")",
+				getInvocationSource("String.class", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""),
 				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
-				"org.eclipse.wb.swt.ResourceManager.getImageDescriptor({wbp_classTop}, \"/javax/swing/plaf/basic/icons/JavaCup16.png\")");
+				getInvocationSource("{wbp_classTop}", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""));
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ImagePropertyEditorTestNoManager.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ImagePropertyEditorTestNoManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,8 @@ import org.eclipse.wb.internal.swt.model.property.editor.image.ImagePropertyEdit
 import org.eclipse.wb.internal.swt.preferences.IPreferenceConstants;
 import org.eclipse.wb.tests.designer.tests.common.GenericPropertyNoValue;
 
+import org.eclipse.jface.resource.LocalResourceManager;
+
 import org.apache.commons.io.FilenameUtils;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -24,7 +26,7 @@ import org.junit.Test;
 import java.io.File;
 
 /**
- * Tests for {@link ImagePropertyEditor} without <code>SWTResourceManager</code>.
+ * Tests for {@link ImagePropertyEditor} without {@link LocalResourceManager}.
  *
  * @author lobas_av
  */

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ImagePropertyEditorTestWithManager.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ImagePropertyEditorTestWithManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,13 +10,17 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.swt.model.property;
 
+import static org.eclipse.wb.internal.swt.model.property.editor.image.ImagePropertyEditor.getInvocationSource;
+
 import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.rcp.ToolkitProvider;
+import org.eclipse.wb.internal.swt.model.jface.resource.ManagerContainerInfo;
 import org.eclipse.wb.internal.swt.model.property.editor.image.ImagePropertyEditor;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 import org.eclipse.wb.internal.swt.preferences.IPreferenceConstants;
-import org.eclipse.wb.internal.swt.utils.ManagerUtils;
 import org.eclipse.wb.tests.designer.tests.common.GenericPropertyNoValue;
+
+import org.eclipse.jface.resource.LocalResourceManager;
 
 import org.apache.commons.io.FilenameUtils;
 import org.junit.Before;
@@ -26,7 +30,7 @@ import org.junit.Test;
 import java.io.File;
 
 /**
- * Tests for {@link ImagePropertyEditor} with <code>SWTResourceManager</code>.
+ * Tests for {@link ImagePropertyEditor} with {@link LocalResourceManager}.
  *
  * @author lobas_av
  */
@@ -85,8 +89,10 @@ public class ImagePropertyEditorTestWithManager extends ImagePropertyEditorTest 
 		File file = createTempImage();
 		try {
 			String path = FilenameUtils.separatorsToUnix(file.getCanonicalPath());
-			assert_getText_getClipboardSource_forSource("new Image(null, \"" + path + "\")", "File: "
-					+ path, "org.eclipse.wb.swt.SWTResourceManager.getImage(\"" + path + "\")");
+			assert_getText_getClipboardSource_forSource(
+					"new Image(null, \"" + path + "\")",
+					"File: " + path,
+					getInvocationSource(shell(), null, '"' + path + '"'));
 		} finally {
 			file.delete();
 		}
@@ -101,7 +107,7 @@ public class ImagePropertyEditorTestWithManager extends ImagePropertyEditorTest 
 		assert_getText_getClipboardSource_forSource(
 				"new Image(null, getClass().getResourceAsStream(\"/javax/swing/plaf/basic/icons/JavaCup16.png\"))",
 				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
-				"org.eclipse.wb.swt.SWTResourceManager.getImage({wbp_classTop}, \"/javax/swing/plaf/basic/icons/JavaCup16.png\")");
+				getInvocationSource(shell(), "{wbp_classTop}", "/javax/swing/plaf/basic/icons/JavaCup16.png"));
 	}
 
 	/**
@@ -113,12 +119,12 @@ public class ImagePropertyEditorTestWithManager extends ImagePropertyEditorTest 
 		assert_getText_getClipboardSource_forSource(
 				"new Image(null, java.lang.String.class.getResourceAsStream(\"/javax/swing/plaf/basic/icons/JavaCup16.png\"))",
 				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
-				"org.eclipse.wb.swt.SWTResourceManager.getImage({wbp_classTop}, \"/javax/swing/plaf/basic/icons/JavaCup16.png\")");
+				getInvocationSource(shell(), "{wbp_classTop}", "/javax/swing/plaf/basic/icons/JavaCup16.png"));
 	}
 
 	////////////////////////////////////////////////////////////////////////////
 	//
-	// Code with SWTResourceManager
+	// Code with LocalResourceManager
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
@@ -127,11 +133,13 @@ public class ImagePropertyEditorTestWithManager extends ImagePropertyEditorTest 
 	@Test
 	public void test_textSource_absolutePath2() throws Exception {
 		File file = createTempImage();
+		CompositeInfo shell = shell();
 		try {
 			String path = FilenameUtils.separatorsToUnix(file.getCanonicalPath());
-			assert_getText_getClipboardSource_forSource2("org.eclipse.wb.swt.SWTResourceManager.getImage(\""
-					+ path
-					+ "\")", "File: " + path, "org.eclipse.wb.swt.SWTResourceManager.getImage(\"" + path + "\")");
+			assert_getText_getClipboardSource_forSource2(
+					getInvocationSource(shell, null, '"' + path + '"'),
+					"File: " + path,
+					getInvocationSource(shell, null, '"' + path + '"'));
 		} finally {
 			file.delete();
 		}
@@ -142,10 +150,11 @@ public class ImagePropertyEditorTestWithManager extends ImagePropertyEditorTest 
 	 */
 	@Test
 	public void test_textSource_image_over_classpath2() throws Exception {
+		CompositeInfo shell = shell();
 		assert_getText_getClipboardSource_forSource2(
-				"org.eclipse.wb.swt.SWTResourceManager.getImage(getClass(), \"/javax/swing/plaf/basic/icons/JavaCup16.png\")",
+				getInvocationSource(shell, "getClass()", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""),
 				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
-				"org.eclipse.wb.swt.SWTResourceManager.getImage({wbp_classTop}, \"/javax/swing/plaf/basic/icons/JavaCup16.png\")");
+				getInvocationSource(shell, "{wbp_classTop}", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""));
 	}
 
 	/**
@@ -153,10 +162,11 @@ public class ImagePropertyEditorTestWithManager extends ImagePropertyEditorTest 
 	 */
 	@Test
 	public void test_textSource_image_over_classpath_OtherClass2() throws Exception {
+		CompositeInfo shell = shell();
 		assert_getText_getClipboardSource_forSource2(
-				"org.eclipse.wb.swt.SWTResourceManager.getImage(java.lang.String.class, \"/javax/swing/plaf/basic/icons/JavaCup16.png\")",
+				getInvocationSource(shell, "java.lang.String.class", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""),
 				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
-				"org.eclipse.wb.swt.SWTResourceManager.getImage({wbp_classTop}, \"/javax/swing/plaf/basic/icons/JavaCup16.png\")");
+				getInvocationSource(shell, "{wbp_classTop}", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""));
 	}
 
 	/**
@@ -173,8 +183,8 @@ public class ImagePropertyEditorTestWithManager extends ImagePropertyEditorTest 
 						"  public Test() {",
 						"  }",
 						"}");
-		// add SWTResourceManager
-		ManagerUtils.ensure_SWTResourceManager(shell);
+		// add ResourceManager
+		ManagerContainerInfo.getResourceManagerInfo(shell);
 		// set "image" property
 		shell.addMethodInvocation("setImage(org.eclipse.swt.graphics.Image)", imageSource);
 		shell.refresh();
@@ -182,5 +192,38 @@ public class ImagePropertyEditorTestWithManager extends ImagePropertyEditorTest 
 		Property property = shell.getPropertyByTitle("image");
 		assertEquals(expectedText, PropertyEditorTestUtils.getText(property));
 		assertEquals(expectedClipboardSource, PropertyEditorTestUtils.getClipboardSource(property));
+	}
+
+	/**
+	 * The call to setImage() must occur AFTER the resource manager was created.
+	 */
+	@Test
+	public void test_textSource_order() throws Exception {
+		CompositeInfo shell = parseComposite(
+				"// filler filler filler",
+				"public class Test extends Shell {",
+				"  public Test() {",
+				"  }",
+				"}");
+		ManagerContainerInfo.getResourceManagerInfo(shell);
+		shell.addMethodInvocation("setImage(org.eclipse.swt.graphics.Image)",
+				getInvocationSource(shell, "java.lang.String.class", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""));
+		shell.refresh();
+		assertEditor(
+				"// filler filler filler",
+				"public class Test extends Shell {",
+				"  private LocalResourceManager localResourceManager;",
+				"  public Test() {",
+				"    createResourceManager();",
+				"    setImage(localResourceManager.create(ImageDescriptor.createFromFile(String.class, \"/javax/swing/plaf/basic/icons/JavaCup16.png\")));",
+				"  }",
+				"  private void createResourceManager() {",
+				"    localResourceManager = new LocalResourceManager(JFaceResources.getResources(),this);",
+				"  }",
+				"}");
+	}
+
+	private CompositeInfo shell() throws Exception {
+		return parseComposite("public class Test extends Shell {}");
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/LocalResourceManagerTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/LocalResourceManagerTest.java
@@ -61,6 +61,9 @@ public class LocalResourceManagerTest extends RcpModelTest {
 				"public class Test extends Shell {",
 				"  private LocalResourceManager localResourceManager;",
 				"  public Test() {",
+				"    createResourceManager();",
+				"  }",
+				"  private void createResourceManager() {",
 				"    localResourceManager = new LocalResourceManager(JFaceResources.getResources(),this);",
 				"  }",
 				"}");
@@ -83,6 +86,9 @@ public class LocalResourceManagerTest extends RcpModelTest {
 				"  private LocalResourceManager localResourceManager;",
 				"  public Test() {",
 				"    shell = new Shell();",
+				"    createResourceManager();",
+				"  }",
+				"  private void createResourceManager() {",
 				"    localResourceManager = new LocalResourceManager(JFaceResources.getResources(),shell);",
 				"  }",
 				"}");
@@ -106,8 +112,11 @@ public class LocalResourceManagerTest extends RcpModelTest {
 				"  private LocalResourceManager localResourceManager;",
 				"  public Test() {",
 				"    shell = new Shell();",
-				"    localResourceManager = new LocalResourceManager(JFaceResources.getResources(),shell);",
+				"    createResourceManager();",
 				"    new Composite(shell, SWT.NONE);",
+				"  }",
+				"  private void createResourceManager() {",
+				"    localResourceManager = new LocalResourceManager(JFaceResources.getResources(),shell);",
 				"  }",
 				"}");
 	}
@@ -126,8 +135,34 @@ public class LocalResourceManagerTest extends RcpModelTest {
 				"public class Test extends Shell {",
 				"  private LocalResourceManager localResourceManager;",
 				"  public Test() {",
-				"    localResourceManager = new LocalResourceManager(JFaceResources.getResources(),this);",
+				"    createResourceManager();",
 				"    new Composite(this, SWT.NONE);",
+				"  }",
+				"  private void createResourceManager() {",
+				"    localResourceManager = new LocalResourceManager(JFaceResources.getResources(),this);",
+				"  }",
+				"}");
+	}
+
+	@Test
+	public void test_createResourceManager5() throws Exception {
+		CompositeInfo shell = parseComposite(
+				"public class Test extends Shell {",
+				"  public Test() {",
+				"    super(SWT.NONE);",
+				"  }",
+				"}");
+		ManagerContainerInfo.getResourceManagerInfo(shell);
+		shell.refresh();
+		assertEditor(
+				"public class Test extends Shell {",
+				"  private LocalResourceManager localResourceManager;",
+				"  public Test() {",
+				"    super(SWT.NONE);",
+				"    createResourceManager();",
+				"  }",
+				"  private void createResourceManager() {",
+				"    localResourceManager = new LocalResourceManager(JFaceResources.getResources(),this);",
 				"  }",
 				"}");
 	}


### PR DESCRIPTION
This replaces the static call to our SWTResourceManager with calls to a
class-local instance of LocalResourceManager.

Example:
SWTResourceManager.getImage() ->
resourceManager.createImage(ImageDescriptor.createFrom()).

The usage of ResourceManager.getImageDescriptor() is removed completely,
with no replacement function. If users require custom image descriptor,
they need to create a subclass instead.

#591 