### PR TITLE
Replace usage of SWTResourceManager for fonts with LocalResourceManager

### DIFF
--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/property/editor/font/FontPropertyEditor.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/property/editor/font/FontPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,9 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swt.model.property.editor.font;
 
+import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.DesignerPlugin;
+import org.eclipse.wb.internal.core.model.JavaInfoEvaluationHelper;
 import org.eclipse.wb.internal.core.model.clipboard.IClipboardSourceProvider;
 import org.eclipse.wb.internal.core.model.property.GenericProperty;
 import org.eclipse.wb.internal.core.model.property.Property;
@@ -18,19 +20,23 @@ import org.eclipse.wb.internal.core.model.property.editor.PropertyEditor;
 import org.eclipse.wb.internal.core.model.property.editor.TextDialogPropertyEditor;
 import org.eclipse.wb.internal.core.model.util.TemplateUtils;
 import org.eclipse.wb.internal.core.utils.ast.AstNodeUtils;
+import org.eclipse.wb.internal.core.utils.ast.DomGenerics;
 import org.eclipse.wb.internal.swt.model.jface.resource.KeyFieldInfo;
+import org.eclipse.wb.internal.swt.model.jface.resource.ManagerContainerInfo;
 import org.eclipse.wb.internal.swt.model.jface.resource.RegistryContainerInfo;
 import org.eclipse.wb.internal.swt.model.jface.resource.ResourceRegistryInfo;
 import org.eclipse.wb.internal.swt.preferences.IPreferenceConstants;
 import org.eclipse.wb.internal.swt.support.DisplaySupport;
 import org.eclipse.wb.internal.swt.support.FontSupport;
-import org.eclipse.wb.internal.swt.utils.ManagerUtils;
 
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.resource.FontDescriptor;
+import org.eclipse.jface.resource.ResourceManager;
 import org.eclipse.jface.window.Window;
+import org.eclipse.swt.graphics.FontData;
 
 import java.util.List;
 
@@ -53,6 +59,27 @@ IClipboardSourceProvider {
 	private FontPropertyEditor() {
 	}
 
+	/**
+	 * Returns the Java code required for creating a new {@link Font} using a
+	 * {@link ResourceManager}.
+	 *
+	 * @param javaInfo Java info the resource manager belongs to.
+	 * @param name     os-specific font name
+	 * @param height   height (pixels)
+	 * @param style    a bitwise combination of NORMAL, BOLD, ITALIC
+	 * @return {@code LocalResourceManager.create(FontDescriptor.createFrom(<clazz>, <path>))}
+	 * @see FontDescriptor#createFromFile(Class, String)
+	 */
+	public static String getInvocationSource(JavaInfo javaInfo, String name, int height, String style) throws Exception {
+		String resourceManager = ManagerContainerInfo //
+				.getResourceManagerInfo(javaInfo.getRootJava()) //
+				.getVariableSupport() //
+				.getName();
+		return String.format(
+				"%s.create(org.eclipse.jface.resource.FontDescriptor.createFrom(\"%s\", %d, %s))", //
+				resourceManager, name, height, style);
+	}
+
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Presentation
@@ -72,6 +99,10 @@ IClipboardSourceProvider {
 				if (isFontRegistryInvocation(invocation)) {
 					return getTextForRegistry(property, invocation);
 				}
+				// ResourceManager.createFont()
+				if (isResourceManagerInvocation(invocation)) {
+					return getTextForResourceManager(invocation);
+				}
 			}
 			// default font
 			if (value == null) {
@@ -84,7 +115,10 @@ IClipboardSourceProvider {
 	}
 
 	private static String getText(Object font) throws Exception {
-		Object fontData = FontSupport.getFontData(font);
+		return getText((FontData) FontSupport.getFontData(font));
+	}
+
+	private static String getText(FontData fontData) throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append(FontSupport.getFontName(fontData));
 		buffer.append(" ");
@@ -215,12 +249,16 @@ IClipboardSourceProvider {
 			Object fontData = FontSupport.getFontData(fontInfo.getFont());
 			// prepare prefix
 			String prefix;
+			String suffix = "";
 			{
 				IPreferenceStore preferences =
 						property.getJavaInfo().getDescription().getToolkit().getPreferences();
 				if (preferences.getBoolean(IPreferenceConstants.P_USE_RESOURCE_MANAGER)) {
-					ManagerUtils.ensure_SWTResourceManager(property.getJavaInfo());
-					prefix = "org.eclipse.wb.swt.SWTResourceManager.getFont(";
+					String resourceManager = ManagerContainerInfo.getResourceManagerInfo(property.getJavaInfo().getRootJava()) //
+							.getVariableSupport() //
+							.getName();
+					prefix = resourceManager + ".create(org.eclipse.jface.resource.FontDescriptor.createFrom(";
+					suffix = ")";
 				} else {
 					prefix = "new org.eclipse.swt.graphics.Font(null, ";
 				}
@@ -234,7 +272,8 @@ IClipboardSourceProvider {
 					+ FontSupport.getFontSize(fontData)
 					+ ", "
 					+ FontSupport.getFontStyleSource(fontData)
-					+ ")";
+					+ ")"
+					+ suffix;
 		}
 		return source;
 	}
@@ -343,6 +382,32 @@ IClipboardSourceProvider {
 					return new Object[]{registryInfo, keyFieldInfo, selectionIndex, source};
 				}
 			}
+		}
+		return null;
+	}
+
+	////////////////////////////////////////////////////////////////////////////
+	//
+	// ResourceManager
+	//
+	////////////////////////////////////////////////////////////////////////////
+
+	private static boolean isResourceManagerInvocation(Expression expression) {
+		return AstNodeUtils.isMethodInvocation(expression, //
+				"org.eclipse.jface.resource.ResourceManager", //
+				"create(org.eclipse.jface.resource.DeviceResourceDescriptor)");
+	}
+
+	private static String getTextForResourceManager(MethodInvocation methodInvocation) throws Exception {
+		Expression managerExpression = DomGenerics.arguments(methodInvocation).get(0);
+		if (AstNodeUtils.isMethodInvocation(managerExpression, //
+				"org.eclipse.jface.resource.FontDescriptor", //
+				"createFrom(java.lang.String,int,int)")) {
+			MethodInvocation invocation = (MethodInvocation) managerExpression;
+			String name = (String) JavaInfoEvaluationHelper.getValue(DomGenerics.arguments(invocation).get(0));
+			int height = (int) JavaInfoEvaluationHelper.getValue(DomGenerics.arguments(invocation).get(1));
+			int style = (int) JavaInfoEvaluationHelper.getValue(DomGenerics.arguments(invocation).get(2));
+			return getText(new FontData(name, height, style));
 		}
 		return null;
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/FontPropertyEditorTestNoManager.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/FontPropertyEditorTestNoManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,11 +16,13 @@ import org.eclipse.wb.internal.swt.model.property.editor.font.FontPropertyEditor
 import org.eclipse.wb.internal.swt.preferences.IPreferenceConstants;
 import org.eclipse.wb.tests.designer.tests.common.GenericPropertyNoValue;
 
+import org.eclipse.jface.resource.LocalResourceManager;
+
 import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Tests for {@link FontPropertyEditor} without <code>SWTResourceManager</code>.
+ * Tests for {@link FontPropertyEditor} without {@link LocalResourceManager}.
  *
  * @author lobas_av
  */

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/FontPropertyEditorTestRegistry.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/FontPropertyEditorTestRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -115,7 +115,7 @@ public class FontPropertyEditorTestRegistry extends FontPropertyEditorTest {
 				IPreferenceConstants.P_USE_RESOURCE_MANAGER,
 				true);
 		assertEquals(
-				"org.eclipse.wb.swt.SWTResourceManager.getFont(\"Courier New\", 14, org.eclipse.swt.SWT.NORMAL)",
+				FontPropertyEditor.getInvocationSource(shell, "Courier New", 14, "org.eclipse.swt.SWT.NORMAL"),
 				PropertyEditorTestUtils.getClipboardSource(property));
 	}
 


### PR DESCRIPTION
This replaces the static call to our SWTResourceManager with calls to a class-local instance of LocalResourceManager.

Example:
SWTResourceManager.getFont() ->
resourceManager.create(FontDescriptor.createFrom()).

#591 