### PR TITLE
Replace usage of SWTResourceManager for colors with LocalResourceManager

### DIFF
--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/jface/resource/ResourceManagerRootProcessor.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/jface/resource/ResourceManagerRootProcessor.java
@@ -13,6 +13,7 @@ package org.eclipse.wb.internal.swt.model.jface.resource;
 import org.eclipse.wb.core.model.IRootProcessor;
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.association.EmptyAssociation;
+import org.eclipse.wb.internal.core.model.order.MethodOrder;
 
 import java.util.List;
 
@@ -33,6 +34,8 @@ public final class ResourceManagerRootProcessor implements IRootProcessor {
 			if (javaInfo instanceof ResourceManagerInfo resourceManagerInfo) {
 				javaInfo.setAssociation(new EmptyAssociation());
 				ManagerContainerInfo.get(root).addChild(resourceManagerInfo);
+				MethodOrder methodOrder = new LocalResourceManagerInfo.MethodOrderAfterResourceManager();
+				root.getDescription().setDefaultMethodOrder(methodOrder);
 			}
 		}
 	}

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/jface/resource/ResourceManagerRootProcessor.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/jface/resource/ResourceManagerRootProcessor.java
@@ -12,6 +12,7 @@ package org.eclipse.wb.internal.swt.model.jface.resource;
 
 import org.eclipse.wb.core.model.IRootProcessor;
 import org.eclipse.wb.core.model.JavaInfo;
+import org.eclipse.wb.core.model.association.EmptyAssociation;
 
 import java.util.List;
 
@@ -30,6 +31,7 @@ public final class ResourceManagerRootProcessor implements IRootProcessor {
 		// bind {@link ResourceManagerInfo}'s into hierarchy.
 		for (JavaInfo javaInfo : components) {
 			if (javaInfo instanceof ResourceManagerInfo resourceManagerInfo) {
+				javaInfo.setAssociation(new EmptyAssociation());
 				ManagerContainerInfo.get(root).addChild(resourceManagerInfo);
 			}
 		}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ColorPropertyEditorTestNoManager.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ColorPropertyEditorTestNoManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,11 +16,13 @@ import org.eclipse.wb.internal.swt.model.property.editor.color.ColorPropertyEdit
 import org.eclipse.wb.internal.swt.preferences.IPreferenceConstants;
 import org.eclipse.wb.tests.designer.tests.common.GenericPropertyNoValue;
 
+import org.eclipse.jface.resource.LocalResourceManager;
+
 import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Tests for {@link ColorPropertyEditor} without <code>SWTResourceManager</code>.
+ * Tests for {@link ColorPropertyEditor} without {@link LocalResourceManager}.
  *
  * @author scheglov_ke
  */

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ColorPropertyEditorTestRegistry.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ColorPropertyEditorTestRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -123,7 +123,7 @@ public class ColorPropertyEditorTestRegistry extends ColorPropertyEditorTest {
 				IPreferenceConstants.P_USE_RESOURCE_MANAGER,
 				true);
 		assertEquals(
-				"org.eclipse.wb.swt.SWTResourceManager.getColor(10, 10, 10)",
+				ColorPropertyEditor.getInvocationSource(shell, 10, 10, 10),
 				PropertyEditorTestUtils.getClipboardSource(property));
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/LocalResourceManagerTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/LocalResourceManagerTest.java
@@ -166,4 +166,119 @@ public class LocalResourceManagerTest extends RcpModelTest {
 				"  }",
 				"}");
 	}
+
+	////////////////////////////////////////////////////////////////////////////
+	//
+	// Check whether the new method call is added AFTER
+	// the resource manager has been created
+	//
+	////////////////////////////////////////////////////////////////////////////
+
+	@Test
+	public void test_useResourceManager1() throws Exception {
+		CompositeInfo shell = parseComposite(
+				"public class Test extends Shell {",
+				"  private LocalResourceManager resourceManager;",
+				"  public Test() {",
+				"    super(SWT.NONE);",
+				"    createResourceManager();",
+				"  }",
+				"  private void createResourceManager() {",
+				"    resourceManager = new LocalResourceManager(JFaceResources.getResources(),this);",
+				"  }",
+				"}");
+		shell.addMethodInvocation("setBackground(Color)", "resourceManager.create(new RGB(1,1,1))");
+		shell.refresh();
+		assertEditor(
+				"public class Test extends Shell {",
+				"  private LocalResourceManager resourceManager;",
+				"  public Test() {",
+				"    super(SWT.NONE);",
+				"    createResourceManager();",
+				"    setBackground(resourceManager.create(new RGB(1,1,1)));",
+				"  }",
+				"  private void createResourceManager() {",
+				"    resourceManager = new LocalResourceManager(JFaceResources.getResources(),this);",
+				"  }",
+				"}");
+	}
+
+	@Test
+	public void test_useResourceManager2() throws Exception {
+		CompositeInfo shell = parseComposite(
+				"public class Test extends Shell {",
+				"  private LocalResourceManager resourceManager;",
+				"  public Test() {",
+				"    super(SWT.NONE);",
+				"    createResourceManager1();",
+				"  }",
+				"  private void createResourceManager1() {",
+				"    createResourceManager();",
+				"  }",
+				"  private void createResourceManager() {",
+				"    resourceManager = new LocalResourceManager(JFaceResources.getResources(),this);",
+				"  }",
+				"}");
+		shell.addMethodInvocation("setBackground(Color)", "resourceManager.create(new RGB(1,1,1))");
+		shell.refresh();
+		assertEditor(
+				"public class Test extends Shell {",
+				"  private LocalResourceManager resourceManager;",
+				"  public Test() {",
+				"    super(SWT.NONE);",
+				"    createResourceManager1();",
+				"    setBackground(resourceManager.create(new RGB(1,1,1)));",
+				"  }",
+				"  private void createResourceManager1() {",
+				"    createResourceManager();",
+				"  }",
+				"  private void createResourceManager() {",
+				"    resourceManager = new LocalResourceManager(JFaceResources.getResources(),this);",
+				"  }",
+				"}");
+	}
+
+	@Test
+	public void test_useResourceManager3() throws Exception {
+		CompositeInfo shell = parseComposite(
+				"public class Test extends Shell {",
+				"  private LocalResourceManager resourceManager;",
+				"  public Test() {",
+				"    super(SWT.NONE);",
+				"    resourceManager = new LocalResourceManager(JFaceResources.getResources(),this);",
+				"  }",
+				"}");
+		shell.addMethodInvocation("setBackground(Color)", "resourceManager.create(new RGB(1,1,1))");
+		shell.refresh();
+		assertEditor(
+				"public class Test extends Shell {",
+				"  private LocalResourceManager resourceManager;",
+				"  public Test() {",
+				"    super(SWT.NONE);",
+				"    resourceManager = new LocalResourceManager(JFaceResources.getResources(),this);",
+				"    setBackground(resourceManager.create(new RGB(1,1,1)));",
+				"  }",
+				"}");
+	}
+
+	@Test
+	public void test_useResourceManager4() throws Exception {
+		CompositeInfo shell = parseComposite(
+				"public class Test extends Shell {",
+				"  private LocalResourceManager resourceManager = new LocalResourceManager(JFaceResources.getResources(),this);",
+				"  public Test() {",
+				"    super(SWT.NONE);",
+				"  }",
+				"}");
+		shell.addMethodInvocation("setBackground(Color)", "resourceManager.create(new RGB(1,1,1))");
+		shell.refresh();
+		assertEditor(
+				"public class Test extends Shell {",
+				"  private LocalResourceManager resourceManager = new LocalResourceManager(JFaceResources.getResources(),this);",
+				"  public Test() {",
+				"    super(SWT.NONE);",
+				"    setBackground(resourceManager.create(new RGB(1,1,1)));",
+				"  }",
+				"}");
+	}
 }


### PR DESCRIPTION
This replaces the static call to our SWTResourceManager with calls to a
class-local instance of LocalResourceManager.

This also resolves several issues that I noticed while testing, where the resource manager was wrongfully created _after_ it was used inside a method call.

#591 