### PR TITLE
Use JDK classes instead of Guava to create immutable collections

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/core/editor/palette/model/entry/ComponentEntryInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/core/editor/palette/model/entry/ComponentEntryInfo.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.core.editor.palette.model.entry;
 
-import com.google.common.collect.ImmutableMap;
-
 import org.eclipse.wb.core.editor.palette.model.CategoryInfo;
 import org.eclipse.wb.core.editor.palette.model.EntryInfo;
 import org.eclipse.wb.core.editor.palette.model.IPaletteSite;
@@ -55,6 +53,7 @@ import org.apache.commons.lang.StringUtils;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -450,7 +449,7 @@ public final class ComponentEntryInfo extends ToolEntryInfo {
 	private Map<String, String> getTypeArguments() throws JavaModelException {
 		Map<String, TypeParameterDescription> typeParameters = m_creation.getTypeParameters();
 		if (typeParameters.isEmpty()) {
-			return ImmutableMap.of();
+			return Collections.emptyMap();
 		}
 		// open dialog
 		TypeParametersDialog dialog =

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/core/eval/ExecutionFlowUtils.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/core/eval/ExecutionFlowUtils.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.core.eval;
 
-import com.google.common.collect.ImmutableList;
-
 import static org.eclipse.wb.internal.core.utils.ast.AstNodeUtils.getBinding;
 import static org.eclipse.wb.internal.core.utils.ast.AstNodeUtils.getConstructor;
 import static org.eclipse.wb.internal.core.utils.ast.AstNodeUtils.getCreationBinding;
@@ -83,6 +81,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -638,7 +637,7 @@ public final class ExecutionFlowUtils {
 			String key) {
 		List<T> result = (List<T>) getVariableCachedValue(flowDescription, variable, key);
 		if (result == null) {
-			return ImmutableList.of();
+			return Collections.emptyList();
 		} else {
 			return result;
 		}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/DesignPage.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/DesignPage.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.editor;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.controls.PageBook;
 import org.eclipse.wb.core.editor.DesignerEditorListener;
 import org.eclipse.wb.core.editor.DesignerState;
@@ -410,7 +408,7 @@ public final class DesignPage implements IDesignPage {
 		// notify listeners
 		{
 			List<DesignerEditorListener> designPageListeners =
-					ImmutableList.copyOf(m_designerEditor.getDesignPageListeners());
+					List.copyOf(m_designerEditor.getDesignPageListeners());
 			for (DesignerEditorListener listener : designPageListeners) {
 				listener.reparsed();
 			}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPalette.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPalette.java
@@ -11,7 +11,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.editor.palette;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.controls.palette.ICategory;
@@ -70,6 +69,7 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -192,7 +192,7 @@ public class DesignerPalette {
 	 * Adds given {@link Command} to the list and writes commands.
 	 */
 	private void commands_addWrite(Command command) {
-		commands_addWrite(ImmutableList.of(command));
+		commands_addWrite(List.of(command));
 	}
 
 	/**
@@ -405,7 +405,7 @@ public class DesignerPalette {
 			public List<ICategory> getCategories() {
 				// check for skipping palette during tests
 				if (System.getProperty(FLAG_NO_PALETTE) != null) {
-					return ImmutableList.of();
+					return Collections.emptyList();
 				}
 				// get categories for palette model
 				final List<CategoryInfo> categoryInfoList;

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/JavaInfoUtils.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/JavaInfoUtils.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.editor.IDesignPageSite;
@@ -1002,7 +1001,8 @@ public class JavaInfoUtils {
 	 * Binds any not bound yet components to the given root {@link JavaInfo} or any of its children.
 	 */
 	public static void bindBinaryComponents(List<JavaInfo> components) throws Exception {
-		List<JavaInfo> reverseComponents = ImmutableList.copyOf(components).reverse();
+		List<JavaInfo> reverseComponents = new ArrayList<>(components);
+		Collections.reverse(reverseComponents);
 		// prepare map (object -> JavaInfo)
 		final Map<Object, JavaInfo> objectToModel;
 		{
@@ -2041,7 +2041,7 @@ public class JavaInfoUtils {
 	 */
 	public static void deleteJavaInfo(JavaInfo javaInfo, boolean removeFromParent) throws Exception {
 		// delete children
-		List<ObjectInfo> children = ImmutableList.copyOf(javaInfo.getChildren());
+		List<ObjectInfo> children = List.copyOf(javaInfo.getChildren());
 		for (ObjectInfo child : children) {
 			// There are cases when children of some parent are "linked", so one deletes other on delete.
 			// So, we should check, may be child is already deleted.

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/creation/ThisCreationSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/creation/ThisCreationSupport.java
@@ -12,8 +12,6 @@ package org.eclipse.wb.internal.core.model.creation;
 
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 
 import org.eclipse.wb.core.eval.AstEvaluationEngine;
 import org.eclipse.wb.core.eval.EvaluationContext;
@@ -461,7 +459,7 @@ public final class ThisCreationSupport extends CreationSupport {
 				ExcludedPackage excludedPackage = new ExcludedPackage();
 				String exceptionMethodsString = entry.getValue();
 				String[] exceptionMethodsSignatures = StringUtils.split(exceptionMethodsString);
-				excludedPackage.exceptions = ImmutableSet.copyOf(exceptionMethodsSignatures);
+				excludedPackage.exceptions = Set.of(exceptionMethodsSignatures);
 				excludedPackages.put(packageName, excludedPackage);
 			}
 		}
@@ -599,7 +597,7 @@ public final class ThisCreationSupport extends CreationSupport {
 				m_editorState.getTmp_visitingContext(),
 				flowDescription,
 				visitor,
-				ImmutableList.of(methodDeclaration));
+				List.of(methodDeclaration));
 		// during execution we remember "return value", so return it here to binary
 		return JavaInfoEvaluationHelper.getReturnValue(methodDeclaration);
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/CreationDescription.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/CreationDescription.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description;
 
-import com.google.common.collect.ImmutableMap;
-
 import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.core.utils.jdt.core.CodeUtils;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
@@ -217,7 +215,7 @@ public final class CreationDescription extends AbstractDescription {
 	public Map<String, TypeParameterDescription> getTypeParameters() {
 		return m_typeArguments != null
 				? m_typeArguments
-						: ImmutableMap.<String, TypeParameterDescription>of();
+						: Collections.emptyMap();
 	}
 
 	/**

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/ComponentDescriptionHelper.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/ComponentDescriptionHelper.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description.helpers;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import org.eclipse.wb.internal.core.model.description.AbstractInvocationDescription;
@@ -104,6 +103,7 @@ import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -278,7 +278,7 @@ public final class ComponentDescriptionHelper {
 		}
 		// OK, get description
 		ComponentDescriptionKey key = new ComponentDescriptionKey(componentClass);
-		return getDescription0(editor, key, ImmutableList.<ClassResourceInfo>of());
+		return getDescription0(editor, key, Collections.emptyList());
 	}
 
 	/**
@@ -317,7 +317,7 @@ public final class ComponentDescriptionHelper {
 		}
 		// OK, get key-specific description
 		ClassResourceInfo descriptionInfo = new ClassResourceInfo(componentClass, resourceInfo);
-		return getDescription0(editor, key, ImmutableList.of(descriptionInfo));
+		return getDescription0(editor, key, List.of(descriptionInfo));
 	}
 
 	/**

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/resource/EmptyDescriptionVersionsProvider.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/resource/EmptyDescriptionVersionsProvider.java
@@ -10,10 +10,9 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description.resource;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.jdt.core.IJavaProject;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -42,6 +41,6 @@ public final class EmptyDescriptionVersionsProvider implements IDescriptionVersi
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public List<String> getVersions(Class<?> componentClass) throws Exception {
-		return ImmutableList.of();
+		return Collections.emptyList();
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/resource/FromListDescriptionVersionsProvider.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/resource/FromListDescriptionVersionsProvider.java
@@ -10,11 +10,10 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description.resource;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.internal.core.utils.check.Assert;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -57,7 +56,7 @@ public abstract class FromListDescriptionVersionsProvider implements IDescriptio
 		if (validate(componentClass)) {
 			return m_versions;
 		}
-		return ImmutableList.of();
+		return Collections.emptyList();
 	}
 
 	protected abstract boolean validate(Class<?> componentClass) throws Exception;

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/generation/statement/block/BlockStatementGenerator.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/generation/statement/block/BlockStatementGenerator.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.generation.statement.block;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.association.Association;
 import org.eclipse.wb.internal.core.model.generation.statement.AbstractInsideStatementGenerator;
@@ -20,6 +18,8 @@ import org.eclipse.wb.internal.core.utils.ast.StatementTarget;
 
 import org.eclipse.jdt.core.dom.Block;
 import org.eclipse.jdt.core.dom.Statement;
+
+import java.util.List;
 
 /**
  * Implementation of {@link StatementGenerator} that adds {@link Statement}'s in new {@link Block}
@@ -47,7 +47,7 @@ public final class BlockStatementGenerator extends AbstractInsideStatementGenera
 	@Override
 	public void add(JavaInfo child, StatementTarget target, Association association) throws Exception {
 		// prepare block
-		Block block = (Block) child.getEditor().addStatement(ImmutableList.of("{", "}"), target);
+		Block block = (Block) child.getEditor().addStatement(List.of("{", "}"), target);
 		// add statements in block
 		target = new StatementTarget(block, true);
 		add(child, target, null, association);

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/MethodInvocationAccessor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/MethodInvocationAccessor.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.property.accessor;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.model.property.table.PropertyTooltipProvider;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
@@ -23,6 +21,7 @@ import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 
 import java.lang.reflect.Method;
+import java.util.List;
 
 /**
  * The implementation of {@link ExpressionAccessor} for accessing {@link MethodInvocation} of some
@@ -77,7 +76,7 @@ public final class MethodInvocationAccessor extends ExpressionAccessor {
 				ExecutionUtils.run(javaInfo, new RunnableEx() {
 					@Override
 					public void run() throws Exception {
-						editor.replaceInvocationArguments(invocation, ImmutableList.of(source));
+						editor.replaceInvocationArguments(invocation, List.of(source));
 					}
 				});
 			}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/InnerClassPropertyEditor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/InnerClassPropertyEditor.java
@@ -10,9 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.property.editor;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-
 import org.eclipse.wb.core.editor.IDesignPageSite;
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.DesignerPlugin;
@@ -45,6 +42,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.apache.commons.lang.StringUtils;
 
 import java.lang.reflect.Constructor;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -197,7 +195,7 @@ IConfigurablePropertyObject {
 	 */
 	private void newClass_ANONYMOUS(GenericProperty genericProperty) throws Exception {
 		JavaInfo javaInfo = genericProperty.getJavaInfo();
-		String source = TemplateUtils.evaluate(m_source, javaInfo, ImmutableMap.<String, String>of());
+		String source = TemplateUtils.evaluate(m_source, javaInfo, Collections.emptyMap());
 		genericProperty.setExpression(source, Property.UNKNOWN_VALUE);
 	}
 
@@ -213,8 +211,8 @@ IConfigurablePropertyObject {
 		{
 			newName = editor.getUniqueTypeName(m_baseName);
 			String newSource =
-					TemplateUtils.evaluate(m_source, javaInfo, ImmutableMap.of("name", newName));
-			newLines = ImmutableList.copyOf(StringUtils.split(newSource, "\r\n"));
+					TemplateUtils.evaluate(m_source, javaInfo, Map.of("name", newName));
+			newLines = List.of(StringUtils.split(newSource, "\r\n"));
 		}
 		// add type
 		{

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/ObjectPropertyEditor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/ObjectPropertyEditor.java
@@ -11,7 +11,6 @@
 package org.eclipse.wb.internal.core.model.property.editor;
 
 import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
 
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
@@ -202,7 +201,7 @@ IComplexPropertyEditor {
 						property.setExpression(TemplateUtils.getExpression(component), component);
 						return;
 					}
-					List<JavaInfo> allComponents = ImmutableList.of(thisComponent, component);
+					List<JavaInfo> allComponents = List.of(thisComponent, component);
 					target = JavaInfoUtils.getStatementTarget_whenAllCreated(allComponents);
 				}
 				String source =

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/complex/InstanceObjectPropertyEditor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/complex/InstanceObjectPropertyEditor.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.property.editor.complex;
 
-import com.google.common.collect.ImmutableMap;
-
 import org.eclipse.wb.core.editor.IDesignPageSite;
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.association.InvocationChildAssociation;
@@ -56,6 +54,7 @@ import org.eclipse.ui.dialogs.SelectionDialog;
 
 import org.apache.commons.lang.StringUtils;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -276,7 +275,7 @@ IConfigurablePropertyObject {
 				}
 				// evaluate new expression
 				String evaluateSource =
-						TemplateUtils.evaluate(source, javaInfo, ImmutableMap.<String, String>of());
+						TemplateUtils.evaluate(source, javaInfo, Collections.emptyMap());
 				property.setExpression(evaluateSource, Property.UNKNOWN_VALUE);
 				// create new instance info
 				{

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/event/ListenerMethodProperty.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/event/ListenerMethodProperty.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.property.event;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.eval.ExecutionFlowDescription;
 import org.eclipse.wb.core.eval.ExecutionFlowUtils;
 import org.eclipse.wb.core.model.JavaInfo;
@@ -69,6 +67,7 @@ import org.apache.commons.lang.text.StrSubstitutor;
 import java.lang.reflect.Type;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -438,7 +437,7 @@ IListenerMethodProperty {
 		}
 		// add inner class
 		List<String> lines =
-				ImmutableList.of("private class " + createInnerClassName() + headerSource + " {", "}");
+				List.of("private class " + createInnerClassName() + headerSource + " {", "}");
 		return m_javaInfo.getEditor().addTypeDeclaration(lines, target);
 	}
 
@@ -645,10 +644,10 @@ IListenerMethodProperty {
 	private static List<String> getListenerMethodBody(ListenerMethodInfo methodInfo) {
 		Class<?> returnType = methodInfo.getMethod().getReturnType();
 		if (returnType == Void.TYPE) {
-			return ImmutableList.of();
+			return Collections.emptyList();
 		} else {
 			String defaultValue = AstParser.getDefaultValue(returnType.getName());
-			return ImmutableList.of("return " + defaultValue + ";");
+			return List.of("return " + defaultValue + ";");
 		}
 	}
 
@@ -807,7 +806,7 @@ IListenerMethodProperty {
 				// add stub method
 				stubMethod = editor.addMethodDeclaration(
 						header,
-						ImmutableList.<String>of(),
+						Collections.emptyList(),
 						new BodyDeclarationTarget(typeDeclaration, false));
 			}
 		}
@@ -822,7 +821,7 @@ IListenerMethodProperty {
 			if (m_preferences.getInt(P_CODE_TYPE) == V_CODE_INTERFACE) {
 				lines = getConditionalStubInvocationSource(listenerMethod, editor, lineInvoke);
 			} else {
-				lines = ImmutableList.of(lineInvoke);
+				lines = List.of(lineInvoke);
 			}
 			// add Statement that invokes stub
 			if (lines != null) {
@@ -871,7 +870,7 @@ IListenerMethodProperty {
 							parameter.getName().getIdentifier(),
 							componentAccess,
 							m_javaInfo);
-					return ImmutableList.of(lineIf, "\t" + lineInvoke, "}");
+					return List.of(lineIf, "\t" + lineInvoke, "}");
 				}
 			}
 		}
@@ -974,7 +973,7 @@ IListenerMethodProperty {
 		if (listenerStatement instanceof Block) {
 			statements = DomGenerics.statements((Block) listenerStatement);
 		} else {
-			statements = ImmutableList.of(listenerStatement);
+			statements = List.of(listenerStatement);
 		}
 		// analyze statements
 		if (statements.size() == 1) {

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/ExposeComponentSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/ExposeComponentSupport.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.util;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.editor.IContextMenuConstants;
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.DesignerPlugin;
@@ -138,7 +136,7 @@ public final class ExposeComponentSupport {
 						component.getDescription().getComponentClass().getName(),
 						methodName);
 		String returnSource = TemplateUtils.resolve(methodTarget, "return {0};", component);
-		editor.addMethodDeclaration(headerSource, ImmutableList.of(returnSource), methodTarget);
+		editor.addMethodDeclaration(headerSource, List.of(returnSource), methodTarget);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/ExposePropertySupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/ExposePropertySupport.java
@@ -1,7 +1,6 @@
 package org.eclipse.wb.internal.core.model.util;
 
 import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
 
 import org.eclipse.wb.core.model.AbstractComponentInfo;
 import org.eclipse.wb.core.model.JavaInfo;
@@ -274,7 +273,7 @@ public final class ExposePropertySupport implements IPropertiesMenuContributor {
 								"return {0}.{1};",
 								m_javaInfo,
 								m_exposableAccessor.getGetterCode(m_javaInfo));
-				m_editor.addMethodDeclaration(header, ImmutableList.of(body), methodTarget);
+				m_editor.addMethodDeclaration(header, List.of(body), methodTarget);
 			}
 			// setter
 			{
@@ -291,7 +290,7 @@ public final class ExposePropertySupport implements IPropertiesMenuContributor {
 								"{0}.{1};",
 								m_javaInfo,
 								m_exposableAccessor.getSetterCode(m_javaInfo, m_exposedSetterParameter));
-				m_editor.addMethodDeclaration(header, ImmutableList.of(body), methodTarget);
+				m_editor.addMethodDeclaration(header, List.of(body), methodTarget);
 			}
 		}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/PlaceholderUtils.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/PlaceholderUtils.java
@@ -10,13 +10,12 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.util;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.JavaInfo;
 
 import org.eclipse.jdt.core.dom.ASTNode;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -69,7 +68,7 @@ public final class PlaceholderUtils {
 	 */
 	public static List<Throwable> getExceptions(ASTNode node) {
 		List<Throwable> exceptions = getExceptions0(node);
-		return exceptions != null ? exceptions : ImmutableList.<Throwable>of();
+		return exceptions != null ? exceptions : Collections.emptyList();
 	}
 
 	/**

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/generic/LocalStaticFactoriesRootProcessor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/generic/LocalStaticFactoriesRootProcessor.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.util.generic;
 
-import com.google.common.collect.ImmutableMap;
-
 import org.eclipse.wb.core.editor.palette.PaletteEventListener;
 import org.eclipse.wb.core.editor.palette.model.CategoryInfo;
 import org.eclipse.wb.core.model.IRootProcessor;
@@ -26,6 +24,7 @@ import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -91,7 +90,7 @@ public final class LocalStaticFactoriesRootProcessor implements IRootProcessor {
 		AstEditor editor = rootJavaInfo.getEditor();
 		// quick check
 		if (!editor.getSource().contains("@wbp.factory")) {
-			return ImmutableMap.of();
+			return Collections.emptyMap();
 		}
 		// analyze
 		String editorTypeName = editor.getModelUnit().findPrimaryType().getFullyQualifiedName();
@@ -113,7 +112,7 @@ public final class LocalStaticFactoriesRootProcessor implements IRootProcessor {
 		for (FactoryMethodDescription methodDescription : descriptionsMap.values()) {
 			String factoryClassName = methodDescription.getDeclaringClass().getName();
 			AttributesProvider attributes =
-					AttributesProviders.get(ImmutableMap.of("signature", methodDescription.getSignature()));
+					AttributesProviders.get(Map.of("signature", methodDescription.getSignature()));
 			StaticFactoryEntryInfo entry =
 					new StaticFactoryEntryInfo(category, factoryClassName, attributes);
 			category.addEntry(entry);

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/live/AbstractLiveManager.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/live/AbstractLiveManager.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.util.live;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.eval.ExecutionFlowDescription;
 import org.eclipse.wb.core.model.AbstractComponentInfo;
 import org.eclipse.wb.core.model.JavaInfo;
@@ -41,6 +39,7 @@ import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -179,12 +178,12 @@ public abstract class AbstractLiveManager {
 		// create method
 		m_tmpType =
 				m_editor.addTypeDeclaration(
-						ImmutableList.of("private static class __Tmp {", "}"),
+						List.of("private static class __Tmp {", "}"),
 						new BodyDeclarationTarget(typeDeclaration, false));
 		m_method =
 				m_editor.addMethodDeclaration(
 						"private static void __tmp()",
-						ImmutableList.copyOf(sourceLines),
+						List.of(sourceLines),
 						new BodyDeclarationTarget(m_tmpType, false));
 		m_editorState.setFlowDescription(new ExecutionFlowDescription(m_method));
 		// parse created method

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/surround/SurroundSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/surround/SurroundSupport.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.util.surround;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.editor.IContextMenuConstants;
 import org.eclipse.wb.core.model.AbstractComponentInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
@@ -200,7 +198,7 @@ public abstract class SurroundSupport<C extends AbstractComponentInfo, T extends
 			ExecutionUtils.runLogLater(new RunnableEx() {
 				@Override
 				public void run() throws Exception {
-					container.getBroadcastObject().select(ImmutableList.of(container));
+					container.getBroadcastObject().select(List.of(container));
 				}
 			});
 		}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/nls/edit/EditableSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/nls/edit/EditableSupport.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.nls.edit;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.model.JavaInfo;
@@ -125,7 +124,7 @@ public final class EditableSupport implements IEditableSupport, ICommandQueue {
 			m_componentToPropertyList.put(component, componentProperties);
 			// prepare list of properties
 			List<Property> properties = Lists.newArrayList(component.getProperties());
-			for (Property property : ImmutableList.copyOf(properties)) {
+			for (Property property : List.copyOf(properties)) {
 				PropertyEditor editor = property.getEditor();
 				if (editor instanceof INlsPropertyContributor) {
 					((INlsPropertyContributor) editor).contributeNlsProperties(property, properties);

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/parser/AbstractParseFactory.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/parser/AbstractParseFactory.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.parser;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.eval.ExecutionFlowUtils;
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.WrapperMethodInfo;
@@ -788,7 +786,7 @@ public abstract class AbstractParseFactory implements IParseFactory {
 	private static List<String> getBundleClassLoaderNamespaces(IConfigurationElement contributorElement) {
 		String namespacesString = contributorElement.getAttribute("namespaces");
 		if (namespacesString != null) {
-			return ImmutableList.copyOf(StringUtils.split(namespacesString));
+			return List.of(StringUtils.split(namespacesString));
 		}
 		return null;
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/AstEditor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/AstEditor.java
@@ -11,7 +11,6 @@
 package org.eclipse.wb.internal.core.utils.ast;
 
 import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import org.eclipse.wb.internal.core.utils.GenericsUtils;
@@ -1460,7 +1459,7 @@ public final class AstEditor {
 			String line_3 = "}";
 			tryStatement =
 					(TryStatement) addStatement(
-							ImmutableList.of(line_1, line_2, line_3),
+							List.of(line_1, line_2, line_3),
 							new StatementTarget(statement, true));
 		}
 		moveStatement(statement, new StatementTarget(tryStatement.getBody(), true));
@@ -1494,7 +1493,7 @@ public final class AstEditor {
 	public Block encloseInBlock(Statement statement) throws Exception {
 		// add new Block
 		Block block =
-				(Block) addStatement(ImmutableList.of("{", "}"), new StatementTarget(statement, true));
+				(Block) addStatement(List.of("{", "}"), new StatementTarget(statement, true));
 		// move Statement into Block
 		moveStatement(statement, new StatementTarget(block, true));
 		// OK, return Block
@@ -2068,7 +2067,7 @@ public final class AstEditor {
 	 */
 	public FieldDeclaration addFieldDeclaration(String source, BodyDeclarationTarget target)
 			throws Exception {
-		return addFieldDeclaration(ImmutableList.of(source), target);
+		return addFieldDeclaration(List.of(source), target);
 	}
 
 	/**
@@ -2098,7 +2097,7 @@ public final class AstEditor {
 	public MethodDeclaration addMethodDeclaration(String header,
 			List<String> bodyLines,
 			BodyDeclarationTarget target) throws Exception {
-		return addMethodDeclaration(ImmutableList.<String>of(), header, bodyLines, target);
+		return addMethodDeclaration(Collections.emptyList(), header, bodyLines, target);
 	}
 
 	/**
@@ -2149,7 +2148,7 @@ public final class AstEditor {
 	 */
 	public MethodDeclaration addInterfaceMethodDeclaration(String header, BodyDeclarationTarget target)
 			throws Exception {
-		List<String> lines = ImmutableList.of(header + ";");
+		List<String> lines = List.of(header + ";");
 		return (MethodDeclaration) addBodyDeclaration(lines, target);
 	}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/DomGenerics.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/DomGenerics.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.utils.ast;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.internal.core.utils.GenericsUtils;
 
 import org.eclipse.jdt.core.dom.ASTNode;
@@ -51,6 +49,7 @@ import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -168,11 +167,11 @@ public class DomGenerics {
 
 	public static List<Statement> statements(MethodDeclaration method) {
 		if (method == null) {
-			return ImmutableList.of();
+			return Collections.emptyList();
 		}
 		Block body = method.getBody();
 		if (body == null) {
-			return ImmutableList.of();
+			return Collections.emptyList();
 		}
 		return statements(body);
 	}

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/editor/palette/DesignerPalette.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/editor/palette/DesignerPalette.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.xml.editor.palette;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.controls.palette.ICategory;
@@ -59,6 +58,7 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -176,7 +176,7 @@ public class DesignerPalette {
 	 * Adds given {@link Command} to the list and writes commands.
 	 */
 	private void commands_addWrite(Command command) {
-		commands_addWrite(ImmutableList.of(command));
+		commands_addWrite(List.of(command));
 	}
 
 	/**
@@ -377,7 +377,7 @@ public class DesignerPalette {
 			public List<ICategory> getCategories() {
 				// check for skipping palette during tests
 				if (System.getProperty(FLAG_NO_PALETTE) != null) {
-					return ImmutableList.of();
+					return Collections.emptyList();
 				}
 				// get categories for palette model
 				final List<CategoryInfo> categoryInfoList;

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/gef/EditPartFactory.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/gef/EditPartFactory.java
@@ -10,11 +10,11 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.xml.gef;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.gef.MatchingEditPartFactory;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartFactory;
+
+import java.util.List;
 
 /**
  * {@link IEditPartFactory} for XML.
@@ -24,8 +24,8 @@ import org.eclipse.wb.gef.core.IEditPartFactory;
  */
 public final class EditPartFactory implements IEditPartFactory {
 	private final static IEditPartFactory MATCHING_FACTORY =
-			new MatchingEditPartFactory(ImmutableList.of("org.eclipse.wb.internal.core.xml.model"),
-					ImmutableList.of("org.eclipse.wb.internal.core.xml.gef.part"));
+			new MatchingEditPartFactory(List.of("org.eclipse.wb.internal.core.xml.model"),
+					List.of("org.eclipse.wb.internal.core.xml.gef.part"));
 
 	////////////////////////////////////////////////////////////////////////////
 	//

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/gefTree/EditPartFactory.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/gefTree/EditPartFactory.java
@@ -10,11 +10,11 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.xml.gefTree;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.gef.MatchingEditPartFactory;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartFactory;
+
+import java.util.List;
 
 /**
  * {@link IEditPartFactory} for XML.
@@ -24,8 +24,8 @@ import org.eclipse.wb.gef.core.IEditPartFactory;
  */
 public final class EditPartFactory implements IEditPartFactory {
 	private final static IEditPartFactory MATCHING_FACTORY =
-			new MatchingEditPartFactory(ImmutableList.of("org.eclipse.wb.internal.core.xml.model"),
-					ImmutableList.of("org.eclipse.wb.internal.core.xml.gefTree.part"));
+			new MatchingEditPartFactory(List.of("org.eclipse.wb.internal.core.xml.model"),
+					List.of("org.eclipse.wb.internal.core.xml.gefTree.part"));
 
 	////////////////////////////////////////////////////////////////////////////
 	//

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/EditorContext.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/EditorContext.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.xml.model;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.broadcast.BroadcastSupport;
 import org.eclipse.wb.internal.core.model.description.ToolkitDescription;
 import org.eclipse.wb.internal.core.model.description.helpers.DescriptionHelper;
@@ -185,7 +183,7 @@ public abstract class EditorContext {
 	private static List<String> getBundleClassLoaderNamespaces(IConfigurationElement contributorElement) {
 		String namespacesString = contributorElement.getAttribute("namespaces");
 		if (namespacesString != null) {
-			return ImmutableList.copyOf(StringUtils.split(namespacesString));
+			return List.of(StringUtils.split(namespacesString));
 		}
 		return null;
 	}

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/creation/ElementCreationSupport.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/creation/ElementCreationSupport.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.xml.model.creation;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.xml.DocumentElement;
@@ -135,7 +133,7 @@ public class ElementCreationSupport extends CreationSupport implements ILiveCrea
 	@Override
 	public void delete() throws Exception {
 		// delete children
-		List<ObjectInfo> children = ImmutableList.copyOf(m_object.getChildren());
+		List<ObjectInfo> children = List.copyOf(m_object.getChildren());
 		for (ObjectInfo child : children) {
 			child.delete();
 		}

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/creation/TagCreationSupport.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/creation/TagCreationSupport.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.xml.model.creation;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.utils.xml.DocumentElement;
 import org.eclipse.wb.internal.core.xml.model.XmlObjectInfo;
@@ -103,7 +101,7 @@ public final class TagCreationSupport extends CreationSupport {
 	@Override
 	public void delete() throws Exception {
 		// delete children
-		List<ObjectInfo> children = ImmutableList.copyOf(m_object.getChildren());
+		List<ObjectInfo> children = List.copyOf(m_object.getChildren());
 		for (ObjectInfo child : children) {
 			child.delete();
 		}

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/description/ComponentDescription.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/description/ComponentDescription.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.xml.model.description;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.model.description.ComponentPresentation;
 import org.eclipse.wb.internal.core.model.description.IComponentDescription;
@@ -211,7 +209,7 @@ IComponentDescription {
 	 * @return all {@link CreationDescription}'s.
 	 */
 	public List<CreationDescription> getCreations() {
-		return ImmutableList.copyOf(m_creations.values());
+		return List.copyOf(m_creations.values());
 	}
 
 	/**

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/utils/GlobalStateXml.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/utils/GlobalStateXml.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.xml.model.utils;
 
-import com.google.common.collect.ImmutableMap;
-
 import org.eclipse.wb.core.gef.command.EditCommand;
 import org.eclipse.wb.core.model.IObjectInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
@@ -42,6 +40,7 @@ import org.eclipse.gef.commands.Command;
 import org.eclipse.jdt.core.IJavaProject;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -139,7 +138,7 @@ public final class GlobalStateXml {
 			if (object instanceof ComponentDescription) {
 				return ((ComponentDescription) object).getParameters();
 			}
-			return ImmutableMap.of();
+			return Collections.emptyMap();
 		}
 
 		@Override

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/model/ObjectInfo.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/model/ObjectInfo.java
@@ -10,9 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.core.model;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-
 import org.eclipse.wb.core.model.broadcast.BroadcastSupport;
 import org.eclipse.wb.core.model.broadcast.ObjectEventListener;
 import org.eclipse.wb.core.model.broadcast.ObjectInfoAllProperties;
@@ -622,7 +619,7 @@ public abstract class ObjectInfo implements IObjectInfo {
 	 */
 	protected void refresh_finish() throws Exception {
 		List<ObjectInfo> children = getChildren();
-		children = ImmutableList.copyOf(getChildren());
+		children = List.copyOf(getChildren());
 		for (ObjectInfo child : children) {
 			child.refresh_finish();
 		}
@@ -672,7 +669,7 @@ public abstract class ObjectInfo implements IObjectInfo {
 		if (m_arbitraryMap != null) {
 			arbitraries = new HashMap<>(m_arbitraryMap);
 		} else {
-			arbitraries = ImmutableMap.of();
+			arbitraries = Collections.emptyMap();
 		}
 		return arbitraries;
 	}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/AbsoluteBasedLayoutEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/AbsoluteBasedLayoutEditPolicy.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.gef.policy.layout.absolute;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.gef.command.CompoundEditCommand;
 import org.eclipse.wb.core.gef.command.EditCommand;
 import org.eclipse.wb.core.gef.figure.OutlineImageFigure;
@@ -437,9 +435,9 @@ IPreferenceConstants {
 		// do drag
 		placementsSupport.drag(
 				moveLocation,
-				ImmutableList.copyOf(modelList),
+				List.copyOf(modelList),
 				widgetBounds,
-				ImmutableList.copyOf(relativeBounds));
+				List.of(relativeBounds));
 		widgetBounds = placementsSupport.getBounds();
 		// Store new "model" location to be shown in TextFeedback if enabled
 		int newX = widgetBounds.x;
@@ -536,9 +534,9 @@ IPreferenceConstants {
 		// do drag
 		getPlacementsSupport().drag(
 				moveLocation,
-				ImmutableList.copyOf(modelList),
+				List.copyOf(modelList),
 				widgetBounds,
-				ImmutableList.copyOf(relativeBounds),
+				List.of(relativeBounds),
 				request.getResizeDirection());
 		//
 		widgetBounds = getPlacementsSupport().getBounds();
@@ -781,9 +779,9 @@ IPreferenceConstants {
 			}
 			placementsSupport.drag(
 					request.getLocation(),
-					ImmutableList.copyOf(pastedModels),
+					List.copyOf(pastedModels),
 					widgetBounds,
-					ImmutableList.copyOf(relativeBounds));
+					List.of(relativeBounds));
 			widgetBounds = placementsSupport.getBounds();
 			m_pasteLocation = widgetBounds.getLocation();
 			translateModelToFeedback(widgetBounds);
@@ -861,7 +859,7 @@ IPreferenceConstants {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	protected void onDelete(ObjectInfo child) throws Exception {
-		placementsSupport.delete(ImmutableList.of((IAbstractComponentInfo) child));
+		placementsSupport.delete(List.of((IAbstractComponentInfo) child));
 	}
 
 	@Override

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/snapping/PlacementsSupport.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/snapping/PlacementsSupport.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.gef.policy.snapping;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.model.IAbstractComponentInfo;
@@ -86,7 +85,7 @@ public final class PlacementsSupport {
 			IAbsoluteLayoutCommands layoutCommands, List<? extends IAbstractComponentInfo> remainingWidgets) {
 		this(visualDataProvider, null, layoutCommands, remainingWidgets);
 		m_bounds = PlacementUtils.getTranslatedBounds(visualDataProvider, widget);
-		m_operatingWidgets = ImmutableList.of(widget);
+		m_operatingWidgets = List.of(widget);
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -102,7 +101,7 @@ public final class PlacementsSupport {
 		m_resizeDirection = resizeDirection;
 		m_isCreating = widget.getModelBounds() == null;
 		m_bounds = widgetBounds.getCopy();
-		m_operatingWidgets = ImmutableList.of(widget);
+		m_operatingWidgets = List.of(widget);
 		m_snapPoints.processBounds(this, location, m_operatingWidgets, resizeDirection);
 		m_newModelBounds.put(widget, m_bounds.getCopy());
 	}
@@ -721,7 +720,7 @@ public final class PlacementsSupport {
 	}
 
 	private void setOperatingWidgets(List<? extends IAbstractComponentInfo> widgets) {
-		m_operatingWidgets = ImmutableList.copyOf(widgets);
+		m_operatingWidgets = List.copyOf(widgets);
 	}
 
 	private void addWidgets() {
@@ -829,7 +828,7 @@ public final class PlacementsSupport {
 		}
 		for (int i = 1; i < widgets.size(); i++) {
 			IAbstractComponentInfo widget = widgets.get(i);
-			m_operatingWidgets = ImmutableList.of(widget);
+			m_operatingWidgets = List.of(widget);
 			postprocess();
 		}
 		cleanup();
@@ -856,7 +855,7 @@ public final class PlacementsSupport {
 		int position = (containerSize.width - widgetBounds.width) / 2;
 		Point newPosition = new Point(position, widgetBounds.y);
 		//
-		m_operatingWidgets = ImmutableList.of(widget);
+		m_operatingWidgets = List.of(widget);
 		moveTo(widget, t.t(newPosition));
 	}
 
@@ -903,7 +902,7 @@ public final class PlacementsSupport {
 		for (IAbstractComponentInfo widget : widgets) {
 			Rectangle widgetBounds = t.t(PlacementUtils.getTranslatedBounds(m_visualDataProvider, widget));
 			//
-			m_operatingWidgets = ImmutableList.of(widget);
+			m_operatingWidgets = List.of(widget);
 			moveTo(widget, t.t(new Point(x, widgetBounds.y)));
 			x += widgetBounds.width;
 			x += space;
@@ -930,7 +929,7 @@ public final class PlacementsSupport {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	public void setAlignment(IAbstractComponentInfo widget, int side) throws Exception {
-		setOperatingWidgets(ImmutableList.of(widget));
+		setOperatingWidgets(List.of(widget));
 		preprocess();
 		// proceed
 		boolean isHorizontal = PlacementUtils.isHorizontalSide(side);
@@ -953,7 +952,7 @@ public final class PlacementsSupport {
 	}
 
 	public void setResizeable(IAbstractComponentInfo widget, boolean isHorizontal) throws Exception {
-		setOperatingWidgets(ImmutableList.of(widget));
+		setOperatingWidgets(List.of(widget));
 		preprocess();
 		// proceed
 		int leadingSide = PlacementUtils.getSide(isHorizontal, true);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/menu/IMenuPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/menu/IMenuPolicy.java
@@ -10,8 +10,7 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.menu;
 
-import com.google.common.collect.ImmutableList;
-
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -131,7 +130,7 @@ public interface IMenuPolicy {
 
 		@Override
 		public List<?> commandPaste(Object mementoObject, Object nextObject) throws Exception {
-			return ImmutableList.of();
+			return Collections.emptyList();
 		}
 	};
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/ScriptUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/ScriptUtils.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.util;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.MapMaker;
 import com.google.common.collect.Maps;
 
@@ -24,6 +23,7 @@ import org.mvel2.ParserConfiguration;
 import org.mvel2.ParserContext;
 
 import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -43,7 +43,7 @@ public final class ScriptUtils {
 	 * Evaluates given script.
 	 */
 	public static Object evaluate(ClassLoader contextClassLoader, String script) {
-		Map<String, Object> variables = ImmutableMap.of();
+		Map<String, Object> variables = Collections.emptyMap();
 		return evaluate(contextClassLoader, script, variables);
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/GenericsUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/GenericsUtils.java
@@ -11,7 +11,6 @@
 package org.eclipse.wb.internal.core.utils;
 
 import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
 
 import org.eclipse.wb.internal.core.utils.check.Assert;
 
@@ -23,6 +22,7 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -190,9 +190,9 @@ public final class GenericsUtils {
 	 */
 	public static <T, E extends T> List<T> singletonList(E element) {
 		if (element == null) {
-			return ImmutableList.of();
+			return Collections.emptyList();
 		}
-		return ImmutableList.<T>of(element);
+		return List.of(element);
 	}
 
 	/**

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/ui/dialogs/color/pages/NamedColorsComposite.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/ui/dialogs/color/pages/NamedColorsComposite.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.utils.ui.dialogs.color.pages;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.internal.core.utils.Messages;
 import org.eclipse.wb.internal.core.utils.ui.dialogs.color.AbstractColorDialog;
 import org.eclipse.wb.internal.core.utils.ui.dialogs.color.AbstractColorsGridComposite;
@@ -20,6 +18,8 @@ import org.eclipse.wb.internal.core.utils.ui.dialogs.color.ColorInfoComparator;
 
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Composite;
+
+import java.util.List;
 
 /**
  * Composite for selecting named color (HTML or SVG).
@@ -35,12 +35,12 @@ public final class NamedColorsComposite extends AbstractColorsGridComposite {
 	////////////////////////////////////////////////////////////////////////////
 	public NamedColorsComposite(Composite parent, int style, AbstractColorDialog colorDialog) {
 		super(parent, style, colorDialog);
-		createSortGroup(this, ImmutableList.of(
+		createSortGroup(this, List.of(
 				Messages.NamedColorsComposite_sortTone,
 				Messages.NamedColorsComposite_sortHue,
 				Messages.NamedColorsComposite_sortSaturation,
 				Messages.NamedColorsComposite_sortLightness,
-				Messages.NamedColorsComposite_sortName), ImmutableList.of(
+				Messages.NamedColorsComposite_sortName), List.of(
 						ColorInfoComparator.TONE,
 						ColorInfoComparator.HUE,
 						ColorInfoComparator.SATURATION,

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/ui/dialogs/color/pages/WebSafeColorsComposite.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/ui/dialogs/color/pages/WebSafeColorsComposite.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.utils.ui.dialogs.color.pages;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.internal.core.utils.Messages;
 import org.eclipse.wb.internal.core.utils.ui.dialogs.color.AbstractColorDialog;
 import org.eclipse.wb.internal.core.utils.ui.dialogs.color.AbstractColorsGridComposite;
@@ -21,6 +19,8 @@ import org.eclipse.wb.internal.core.utils.ui.dialogs.color.ColorsGridComposite;
 
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Composite;
+
+import java.util.List;
 
 /**
  * Composite for selecting of of the 216 web safe colors.
@@ -36,11 +36,11 @@ public final class WebSafeColorsComposite extends AbstractColorsGridComposite {
 	////////////////////////////////////////////////////////////////////////////
 	public WebSafeColorsComposite(Composite parent, int style, AbstractColorDialog colorPickerDialog) {
 		super(parent, style, colorPickerDialog);
-		createSortGroup(this, ImmutableList.of(
+		createSortGroup(this, List.of(
 				Messages.WebSafeColorsComposite_sortTone,
 				Messages.WebSafeColorsComposite_sortHue,
 				Messages.WebSafeColorsComposite_sortSaturation,
-				Messages.WebSafeColorsComposite_sortLightness), ImmutableList.of(
+				Messages.WebSafeColorsComposite_sortLightness), List.of(
 						ColorInfoComparator.TONE,
 						ColorInfoComparator.HUE,
 						ColorInfoComparator.SATURATION,

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/xml/DocumentElement.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/xml/DocumentElement.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.utils.xml;
 
-import com.google.common.collect.ImmutableList;
-
 import org.apache.commons.lang.StringUtils;
 
 import java.io.PrintWriter;
@@ -298,7 +296,7 @@ public class DocumentElement extends AbstractDocumentObject {
 	 * @return the {@link DocumentElement} children.
 	 */
 	public List<DocumentElement> getChildren() {
-		return ImmutableList.copyOf(m_children);
+		return List.copyOf(m_children);
 	}
 
 	/**
@@ -492,7 +490,7 @@ public class DocumentElement extends AbstractDocumentObject {
 	 * @return the {@link List} with all attributes.
 	 */
 	public List<DocumentAttribute> getDocumentAttributes() {
-		return ImmutableList.copyOf(m_attributes.values());
+		return List.copyOf(m_attributes.values());
 	}
 
 	/**

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/ControllerSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/ControllerSupport.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.databinding.model;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.databinding.model.IBindingInfo;
@@ -203,7 +201,7 @@ public class ControllerSupport {
 		String header =
 				"public " + javaInfo.getDescription().getComponentClass().getName() + " " + methodName;
 		// prepare method lines
-		List<String> methodLines = ImmutableList.of("return " + reference + ";");
+		List<String> methodLines = List.of("return " + reference + ";");
 		// add method
 		javaInfo.getEditor().addMethodDeclaration(header, methodLines, target);
 		if (commit) {

--- a/org.eclipse.wb.rcp.nebula/src/org/eclipse/wb/internal/rcp/nebula/gef/EditPartFactory.java
+++ b/org.eclipse.wb.rcp.nebula/src/org/eclipse/wb/internal/rcp/nebula/gef/EditPartFactory.java
@@ -10,11 +10,11 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.nebula.gef;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.gef.MatchingEditPartFactory;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartFactory;
+
+import java.util.List;
 
 /**
  * Implementation of {@link IEditPartFactory} for Nebula widgets.
@@ -24,8 +24,8 @@ import org.eclipse.wb.gef.core.IEditPartFactory;
  */
 public final class EditPartFactory implements IEditPartFactory {
 	private final static IEditPartFactory MATCHING_FACTORY =
-			new MatchingEditPartFactory(ImmutableList.of("org.eclipse.wb.internal.rcp.nebula"),
-					ImmutableList.of("org.eclipse.wb.internal.rcp.nebula"));
+			new MatchingEditPartFactory(List.of("org.eclipse.wb.internal.rcp.nebula"),
+					List.of("org.eclipse.wb.internal.rcp.nebula"));
 
 	////////////////////////////////////////////////////////////////////////////
 	//

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/RcpDescriptionVersionsProviderFactory.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/RcpDescriptionVersionsProviderFactory.java
@@ -11,9 +11,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-
 import org.eclipse.wb.internal.core.model.description.resource.FromListDescriptionVersionsProvider;
 import org.eclipse.wb.internal.core.model.description.resource.IDescriptionVersionsProvider;
 import org.eclipse.wb.internal.core.model.description.resource.IDescriptionVersionsProviderFactory;
@@ -22,6 +19,7 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.swt.SWT;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -54,11 +52,11 @@ IDescriptionVersionsProviderFactory {
 	public Map<String, Object> getVersions(IJavaProject javaProject, ClassLoader classLoader)
 			throws Exception {
 		if (!isRCP(javaProject)) {
-			return ImmutableMap.of();
+			return Collections.emptyMap();
 		}
 		// OK, RCP project
 		String version = getSWTVersion();
-		return ImmutableMap.<String, Object>of("rcp_version", version);
+		return Map.of("rcp_version", version);
 	}
 
 	@Override
@@ -69,7 +67,7 @@ IDescriptionVersionsProviderFactory {
 		}
 		// OK, RCP project
 		String version = getSWTVersion();
-		List<String> allVersions = ImmutableList.of(
+		List<String> allVersions = List.of(
 				"3.7",
 				"3.8",
 				"4.2",

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/EditPartFactory.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/EditPartFactory.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.gef;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.gef.MatchingEditPartFactory;
 import org.eclipse.wb.core.gef.part.menu.MenuEditPartFactory;
 import org.eclipse.wb.core.model.AbstractComponentInfo;
@@ -28,6 +26,8 @@ import org.eclipse.wb.internal.rcp.model.jface.DialogInfo;
 import org.eclipse.wb.internal.rcp.model.jface.action.MenuManagerInfo;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 
+import java.util.List;
+
 /**
  * Implementation of {@link IEditPartFactory} for RCP.
  *
@@ -36,8 +36,8 @@ import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
  */
 public final class EditPartFactory implements IEditPartFactory {
 	private final static IEditPartFactory MATCHING_FACTORY =
-			new MatchingEditPartFactory(ImmutableList.of("org.eclipse.wb.internal.rcp.model"),
-					ImmutableList.of("org.eclipse.wb.internal.rcp.gef.part"));
+			new MatchingEditPartFactory(List.of("org.eclipse.wb.internal.rcp.model"),
+					List.of("org.eclipse.wb.internal.rcp.gef.part"));
 
 	////////////////////////////////////////////////////////////////////////////
 	//

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/rcp/perspective/AbstractPartSelectionEditPolicy.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/rcp/perspective/AbstractPartSelectionEditPolicy.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.gef.policy.rcp.perspective;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.gef.command.EditCommand;
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
@@ -33,6 +31,7 @@ import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.commands.Command;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -76,7 +75,7 @@ public final class AbstractPartSelectionEditPolicy extends SelectionEditPolicy {
 	@Override
 	protected List<Handle> createStaticHandles() {
 		if (m_line == null) {
-			return ImmutableList.of();
+			return Collections.emptyList();
 		}
 		// prepare handle
 		Handle resizeHandle = new Handle(getHost(), new ILocator() {
@@ -104,7 +103,7 @@ public final class AbstractPartSelectionEditPolicy extends SelectionEditPolicy {
 		}
 		// single static handle
 		resizeHandle.setDragTrackerTool(new ResizeTracker(getHost(), m_line.getPosition(), REQ_RESIZE));
-		return ImmutableList.of(resizeHandle);
+		return List.of(resizeHandle);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gefTree/EditPartFactory.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gefTree/EditPartFactory.java
@@ -10,14 +10,14 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.gefTree;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.gef.MatchingEditPartFactory;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartFactory;
 import org.eclipse.wb.internal.rcp.gefTree.part.forms.FormHeadEditPart;
 import org.eclipse.wb.internal.rcp.model.forms.FormInfo;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
+
+import java.util.List;
 
 /**
  * Implementation of {@link IEditPartFactory} for RCP.
@@ -27,8 +27,8 @@ import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
  */
 public final class EditPartFactory implements IEditPartFactory {
 	private final static IEditPartFactory MATCHING_FACTORY =
-			new MatchingEditPartFactory(ImmutableList.of("org.eclipse.wb.internal.rcp.model"),
-					ImmutableList.of("org.eclipse.wb.internal.rcp.gefTree.part"));
+			new MatchingEditPartFactory(List.of("org.eclipse.wb.internal.rcp.model"),
+					List.of("org.eclipse.wb.internal.rcp.gefTree.part"));
 
 	////////////////////////////////////////////////////////////////////////////
 	//

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/FieldEditorInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/FieldEditorInfo.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.jface;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.eval.EvaluationContext;
 import org.eclipse.wb.core.model.AbstractComponentInfo;
 import org.eclipse.wb.core.model.JavaInfo;
@@ -50,6 +48,7 @@ import org.apache.commons.lang.StringUtils;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -204,7 +203,7 @@ public final class FieldEditorInfo extends AbstractComponentInfo {
 	private final IObjectPresentation m_presentation = new DefaultJavaInfoPresentation(this) {
 		@Override
 		public List<ObjectInfo> getChildrenGraphical() throws Exception {
-			return ImmutableList.of();
+			return Collections.emptyList();
 		}
 	};
 

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/WindowInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/WindowInfo.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.jface;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.editor.IContextMenuConstants;
 import org.eclipse.wb.core.model.AbstractComponentInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
@@ -94,7 +92,7 @@ public class WindowInfo extends AbstractComponentInfo implements IJavaInfoRender
 					TypeDeclaration typeDeclaration = JavaInfoUtils.getTypeDeclaration(WindowInfo.this);
 					getEditor().addMethodDeclaration(
 							"protected org.eclipse.swt.graphics.Point getInitialSize()",
-							ImmutableList.of("return new org.eclipse.swt.graphics.Point(545, 390);"),
+							List.of("return new org.eclipse.swt.graphics.Point(545, 390);"),
 							new BodyDeclarationTarget(typeDeclaration, false));
 				}
 				Dimension preferredSize = getPreferredSize();

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/ActionContainerInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/ActionContainerInfo.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.jface.action;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.association.AssociationObjects;
@@ -172,7 +170,7 @@ public final class ActionContainerInfo extends ObjectInfo {
 					actionsMethod =
 							editor.addMethodDeclaration(
 									methodHeader,
-									ImmutableList.<String>of(),
+									Collections.emptyList(),
 									new BodyDeclarationTarget(rootMethod, false));
 					// if needed, invoke from constructor
 					if (methodInvocation != null) {
@@ -185,7 +183,7 @@ public final class ActionContainerInfo extends ObjectInfo {
 			{
 				Block targetBlock =
 						(Block) editor.addStatement(
-								ImmutableList.of("{", "}"),
+								List.of("{", "}"),
 								new StatementTarget(actionsMethod, false));
 				actionTarget = new StatementTarget(targetBlock, true);
 			}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/MenuManagerInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/MenuManagerInfo.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.jface.action;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.AbstractComponentInfo;
 import org.eclipse.wb.core.model.broadcast.DisplayEventListener;
 import org.eclipse.wb.internal.core.model.creation.CreationSupport;
@@ -41,6 +39,7 @@ import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -354,7 +353,7 @@ IAdaptable {
 
 		@Override
 		public List<?> commandPaste(Object mementoObject, Object nextObject) throws Exception {
-			return ImmutableList.of();
+			return Collections.emptyList();
 		}
 
 		@Override

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/PdeUtils.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/PdeUtils.java
@@ -11,8 +11,6 @@
 package org.eclipse.wb.internal.rcp.model.rcp;
 
 import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
 import org.eclipse.wb.internal.core.DesignerPlugin;
@@ -506,7 +504,7 @@ public final class PdeUtils {
 		IFile pluginXML = m_project.getFile("plugin.xml");
 		if (!pluginXML.exists()) {
 			List<String> lines =
-					ImmutableList.of(
+					List.of(
 							"<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
 							"<?eclipse version=\"3.2\"?>",
 							"<plugin>",
@@ -919,7 +917,7 @@ public final class PdeUtils {
 	 * Creates new {@link IPluginElement} for Eclipse view category.
 	 */
 	public IPluginElement createViewCategoryElement(String id, String name) throws Exception {
-		Map<String, String> attributes = ImmutableMap.of("id", id, "name", name);
+		Map<String, String> attributes = Map.of("id", id, "name", name);
 		createExtensionElement("org.eclipse.ui.views", "category", attributes);
 		return waitExtensionElementById("org.eclipse.ui.views", "category", id);
 	}
@@ -928,7 +926,7 @@ public final class PdeUtils {
 	 * Creates new {@link IPluginElement} for Eclipse view.
 	 */
 	public void createViewElement(String id, String name, String className) throws Exception {
-		Map<String, String> attributes = ImmutableMap.of("id", id, "name", name, "class", className);
+		Map<String, String> attributes = Map.of("id", id, "name", name, "class", className);
 		createExtensionElement("org.eclipse.ui.views", "view", attributes);
 	}
 
@@ -1067,7 +1065,7 @@ public final class PdeUtils {
 	 * Creates new {@link IPluginElement} for Eclipse perspective.
 	 */
 	public void createPerspectiveElement(String id, String name, String className) throws Exception {
-		Map<String, String> attributes = ImmutableMap.of("id", id, "name", name, "class", className);
+		Map<String, String> attributes = Map.of("id", id, "name", name, "class", className);
 		createExtensionElement("org.eclipse.ui.perspectives", "perspective", attributes);
 	}
 
@@ -1120,7 +1118,7 @@ public final class PdeUtils {
 	 * Creates new {@link IPluginElement} for Eclipse editor.
 	 */
 	public void createEditorElement(String id, String name, String className) throws Exception {
-		Map<String, String> attributes = ImmutableMap.of("id", id, "name", name, "class", className);
+		Map<String, String> attributes = Map.of("id", id, "name", name, "class", className);
 		createExtensionElement("org.eclipse.ui.editors", "editor", attributes);
 	}
 

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/shortcuts/AbstractShortcutContainerInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/shortcuts/AbstractShortcutContainerInfo.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.rcp.perspective.shortcuts;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.draw2d.IColorConstants;
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
@@ -47,6 +45,7 @@ import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.ui.IPageLayout;
 
 import java.lang.reflect.Constructor;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -240,7 +239,7 @@ public abstract class AbstractShortcutContainerInfo extends ObjectInfo {
 					shortcutsMethod =
 							editor.addMethodDeclaration(
 									"private void " + shortcutsMethodName + "(org.eclipse.ui.IPageLayout layout)",
-									ImmutableList.<String>of(),
+									Collections.emptyList(),
 									new BodyDeclarationTarget(typeDeclaration, false));
 					// add shortcuts method invocation into "createInitialLayout"
 					{

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/AbstractTabItemInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/AbstractTabItemInfo.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.widgets;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.broadcast.JavaEventListener;
@@ -37,6 +35,7 @@ import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.swt.custom.CTabItem;
 import org.eclipse.swt.widgets.TabItem;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -155,9 +154,9 @@ public abstract class AbstractTabItemInfo extends ItemInfo {
 		public List<ObjectInfo> getChildrenTree() throws Exception {
 			ControlInfo control = getControl();
 			if (control != null) {
-				return ImmutableList.<ObjectInfo>of(control);
+				return List.of(control);
 			} else {
-				return ImmutableList.of();
+				return Collections.emptyList();
 			}
 		}
 	};

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/CoolItemInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/CoolItemInfo.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.widgets;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.broadcast.JavaEventListener;
@@ -36,6 +34,7 @@ import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.swt.widgets.CoolItem;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -128,9 +127,9 @@ public final class CoolItemInfo extends ItemInfo {
 	public final List<ObjectInfo> getSimpleContainerChildren() {
 		ObjectInfo control = getControl();
 		if (control != null) {
-			return ImmutableList.of(control);
+			return List.of(control);
 		} else {
-			return ImmutableList.of();
+			return Collections.emptyList();
 		}
 	}
 

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/ExpandItemInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/ExpandItemInfo.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.widgets;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.broadcast.JavaEventListener;
@@ -38,6 +36,7 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.ExpandBar;
 import org.eclipse.swt.widgets.ExpandItem;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -121,7 +120,7 @@ public final class ExpandItemInfo extends ItemInfo {
 		@Override
 		public List<ObjectInfo> getChildrenGraphical() throws Exception {
 			if (!isExpanded()) {
-				return ImmutableList.of();
+				return Collections.emptyList();
 			}
 			return getChildrenTree();
 		}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/ToolItemInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/ToolItemInfo.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.widgets;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.broadcast.JavaEventListener;
@@ -38,6 +36,7 @@ import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.ToolItem;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -145,9 +144,9 @@ public final class ToolItemInfo extends ItemInfo {
 	public final List<ObjectInfo> getSimpleContainerChildren() {
 		ObjectInfo control = getControl();
 		if (control != null) {
-			return ImmutableList.of(control);
+			return List.of(control);
 		} else {
-			return ImmutableList.of();
+			return Collections.emptyList();
 		}
 	}
 

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/parser/ParseFactory.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/parser/ParseFactory.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.parser;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.eval.ExecutionFlowDescription;
@@ -161,7 +160,7 @@ public final class ParseFactory extends org.eclipse.wb.internal.swt.parser.Parse
 				javaInfo.setVariableSupport(new MethodParameterVariableSupport(javaInfo,
 						pageLayoutParameter));
 				// prepare root context
-				List<MethodDeclaration> rootMethods = ImmutableList.of(createMethod);
+				List<MethodDeclaration> rootMethods = List.of(createMethod);
 				return new ParseRootContext(javaInfo, new ExecutionFlowDescription(rootMethods));
 			}
 		}
@@ -500,7 +499,7 @@ public final class ParseFactory extends org.eclipse.wb.internal.swt.parser.Parse
 	@Override
 	protected void initializeClassLoader_parent(AstEditor editor,
 			CompositeClassLoader parentClassLoader) throws Exception {
-		parentClassLoader.add(new BundleClassLoader("com.ibm.icu"), ImmutableList.of("com.ibm.icu."));
+		parentClassLoader.add(new BundleClassLoader("com.ibm.icu"), List.of("com.ibm.icu."));
 		parentClassLoader.add(new BundleClassLoader("org.eclipse.ui"), null);
 		parentClassLoader.add(new BundleClassLoader("org.eclipse.ui.forms"), null);
 		parentClassLoader.add(new BundleClassLoader("org.eclipse.jdt.ui"), null);

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/model/FormLayoutInfo.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/model/FormLayoutInfo.java
@@ -12,7 +12,6 @@ package org.eclipse.wb.internal.swing.FormLayout.model;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
-import com.google.common.collect.ImmutableList;
 
 import org.eclipse.wb.core.editor.IContextMenuConstants;
 import org.eclipse.wb.core.editor.actions.assistant.AbstractAssistantPage;
@@ -426,7 +425,7 @@ public final class FormLayoutInfo extends LayoutInfo implements IPreferenceConst
 			//
 			getEditor().replaceCreationArguments(
 					creation,
-					ImmutableList.copyOf(CodeUtils.join(columnsSource, rowsSource)));
+					List.of(CodeUtils.join(columnsSource, rowsSource)));
 		}
 		// write groups
 		writeDimensionsGroups("setColumnGroups", m_columns, m_columnGroups);

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/MigLayoutInfo.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/MigLayoutInfo.java
@@ -12,7 +12,6 @@ package org.eclipse.wb.internal.swing.MigLayout.model;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
-import com.google.common.collect.ImmutableList;
 
 import org.eclipse.wb.core.editor.IContextMenuConstants;
 import org.eclipse.wb.core.editor.actions.assistant.AbstractAssistantPage;
@@ -423,7 +422,7 @@ public final class MigLayoutInfo extends LayoutInfo implements IPreferenceConsta
 			ClassInstanceCreation creation = creationSupport.getCreation();
 			getEditor().replaceCreationArguments(
 					creation,
-					ImmutableList.of(MessageFormat.format(
+					List.of(MessageFormat.format(
 							"{0}, {1}, {2}",
 							layoutConstraintsSource,
 							columnsSource,

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/VirtualObserveInfo.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/beans/VirtualObserveInfo.java
@@ -10,17 +10,16 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.databinding.model.beans;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.internal.core.databinding.model.IObservePresentation;
 import org.eclipse.wb.internal.core.databinding.model.presentation.SimpleObservePresentation;
 import org.eclipse.wb.internal.core.databinding.model.reference.StringReferenceProvider;
 import org.eclipse.wb.internal.swing.databinding.Activator;
 import org.eclipse.wb.internal.swing.databinding.model.ObserveCreationType;
-import org.eclipse.wb.internal.swing.databinding.model.ObserveInfo;
 import org.eclipse.wb.internal.swing.databinding.model.generic.ClassGenericType;
 
 import org.eclipse.jface.viewers.IDecoration;
+
+import java.util.List;
 
 /**
  * @author lobas_av
@@ -39,7 +38,7 @@ public final class VirtualObserveInfo extends BeanObserveInfo {
 		setBindingDecoration(IDecoration.TOP_LEFT);
 		m_presentation =
 				new SimpleObservePresentation("[Virtual]", "[Virtual]", Activator.getImageDescriptor("virtual.png"));
-		setProperties(ImmutableList.<ObserveInfo>of(new ObjectPropertyObserveInfo(getObjectType())));
+		setProperties(List.of(new ObjectPropertyObserveInfo(getObjectType())));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.swing.java6/src/org/eclipse/wb/internal/swing/java6/model/GroupLayoutInfo.java
+++ b/org.eclipse.wb.swing.java6/src/org/eclipse/wb/internal/swing/java6/model/GroupLayoutInfo.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.java6.model;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.IAbstractComponentInfo;
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.broadcast.JavaEventListener;
@@ -180,12 +178,12 @@ public final class GroupLayoutInfo extends LayoutInfo implements IAbsoluteLayout
 	private void saveGroup(String methodName, SpringInfo rootGroup) throws Exception {
 		/*List<ComponentInfo> childrenComponents = getContainer().getChildrenComponents();
     StatementTarget statementTarget =
-    		JavaInfoUtils.getStatementTarget_whenAllCreated(ImmutableList.copyOf(childrenComponents));
+    		JavaInfoUtils.getStatementTarget_whenAllCreated(List.copyOf(childrenComponents));
     String referenceExpression =
     		getVariableSupport().getReferenceExpression(new NodeTarget(statementTarget));*/
 		MethodInvocation invocation = getMethodInvocation(methodName);
 		String groupCode = rootGroup.getCode();
-		getEditor().replaceInvocationArguments(invocation, ImmutableList.of(groupCode));
+		getEditor().replaceInvocationArguments(invocation, List.of(groupCode));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.swing.jsr296/src/org/eclipse/wb/internal/swing/jsr296/gef/EditPartFactory.java
+++ b/org.eclipse.wb.swing.jsr296/src/org/eclipse/wb/internal/swing/jsr296/gef/EditPartFactory.java
@@ -10,11 +10,11 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.jsr296.gef;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.gef.MatchingEditPartFactory;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartFactory;
+
+import java.util.List;
 
 /**
  * {@link IEditPartFactory} for JSR-296.
@@ -24,8 +24,8 @@ import org.eclipse.wb.gef.core.IEditPartFactory;
  */
 public final class EditPartFactory implements IEditPartFactory {
 	private final static IEditPartFactory MATCHING_FACTORY =
-			new MatchingEditPartFactory(ImmutableList.of("org.eclipse.wb.internal.swing.jsr296.model"),
-					ImmutableList.of("org.eclipse.wb.internal.swing.jsr296.gef"));
+			new MatchingEditPartFactory(List.of("org.eclipse.wb.internal.swing.jsr296.model"),
+					List.of("org.eclipse.wb.internal.swing.jsr296.gef"));
 
 	////////////////////////////////////////////////////////////////////////////
 	//

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/EditPartFactory.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/EditPartFactory.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.gef;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.gef.MatchingEditPartFactory;
 import org.eclipse.wb.core.gef.part.menu.MenuEditPartFactory;
 import org.eclipse.wb.gef.core.EditPart;
@@ -44,6 +42,8 @@ import org.eclipse.wb.internal.swing.model.component.menu.JMenuBarInfo;
 import org.eclipse.wb.internal.swing.model.component.menu.JMenuInfo;
 import org.eclipse.wb.internal.swing.model.component.menu.JMenuItemInfo;
 import org.eclipse.wb.internal.swing.model.component.menu.JPopupMenuInfo;
+
+import java.util.List;
 
 import javax.swing.Box;
 
@@ -169,8 +169,8 @@ public final class EditPartFactory implements IEditPartFactory {
 		}
 	};
 	private final static IEditPartFactory MATCHING_FACTORY =
-			new MatchingEditPartFactory(ImmutableList.of("org.eclipse.wb.internal.swing.model.component"),
-					ImmutableList.of("org.eclipse.wb.internal.swing.gef.part"));
+			new MatchingEditPartFactory(List.of("org.eclipse.wb.internal.swing.model.component"),
+					List.of("org.eclipse.wb.internal.swing.gef.part"));
 	private static final IEditPartFactory GENERIC_FACTORY = new IEditPartFactory() {
 		@Override
 		public EditPart createEditPart(EditPart context, Object model) {

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/laf/LafSupport.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/laf/LafSupport.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.laf;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.eval.AstEvaluationEngine;
 import org.eclipse.wb.core.eval.EvaluationContext;
 import org.eclipse.wb.core.eval.ExecutionFlowDescription;
@@ -124,7 +122,7 @@ public final class LafSupport {
 	 */
 	public static List<CategoryInfo> getLAFCategoriesList() {
 		createLAFList();
-		return ImmutableList.copyOf(m_lafList);
+		return List.copyOf(m_lafList);
 	}
 
 	/**

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/bean/ActionInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/bean/ActionInfo.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.model.bean;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.editor.palette.PaletteEventListener;
 import org.eclipse.wb.core.editor.palette.model.CategoryInfo;
 import org.eclipse.wb.core.editor.palette.model.EntryInfo;
@@ -156,7 +154,7 @@ public class ActionInfo extends JavaInfo {
 			}
 			action.addRelatedNodes(invocation);
 			// select component
-			component.getBroadcastObject().select(ImmutableList.of(component));
+			component.getBroadcastObject().select(List.of(component));
 		}
 	}
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/JToolBarInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/JToolBarInfo.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.model.component;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.association.AssociationObject;
 import org.eclipse.wb.core.model.association.AssociationObjects;
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
@@ -24,6 +22,8 @@ import org.eclipse.wb.internal.core.model.variable.VoidInvocationVariableSupport
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.swing.model.bean.ActionContainerInfo;
 import org.eclipse.wb.internal.swing.model.bean.ActionInfo;
+
+import java.util.List;
 
 import javax.swing.JButton;
 import javax.swing.JToolBar;
@@ -93,7 +93,7 @@ public final class JToolBarInfo extends ContainerInfo {
 		ComponentInfo newButton =
 				(ComponentInfo) JavaInfoUtils.createJavaInfo(getEditor(), JButton.class, creationSupport);
 		JavaInfoUtils.add(newButton, AssociationObjects.invocationVoid(), this, nextComponent);
-		getBroadcastObject().select(ImmutableList.of(newButton));
+		getBroadcastObject().select(List.of(newButton));
 		return newButton;
 	}
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/menu/JMenuPolicyImpl.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/menu/JMenuPolicyImpl.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.model.component.menu;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.association.AssociationObject;
 import org.eclipse.wb.core.model.association.AssociationObjects;
@@ -121,7 +119,7 @@ final class JMenuPolicyImpl implements IMenuPolicy {
 							m_menu.getEditor(),
 							JMenuItem.class,
 							creationSupport);
-			m_menu.getBroadcastObject().select(ImmutableList.of(newComponent));
+			m_menu.getBroadcastObject().select(List.of(newComponent));
 			// association is done implicitly during creation
 			association = AssociationObjects.invocationVoid();
 		} else {

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/gbl/AbstractGridBagLayoutInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/gbl/AbstractGridBagLayoutInfo.java
@@ -12,7 +12,6 @@ package org.eclipse.wb.internal.swing.model.layout.gbl;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.editor.actions.assistant.AbstractAssistantPage;
@@ -143,7 +142,7 @@ public abstract class AbstractGridBagLayoutInfo extends LayoutInfo implements IP
 	 * Visits all {@link ComponentInfo} of this {@link ContainerInfo}.
 	 */
 	void visitComponents(IComponentVisitor visitor, IComponentPredicate predicate) throws Exception {
-		List<ComponentInfo> components = ImmutableList.copyOf(getComponents());
+		List<ComponentInfo> components = List.copyOf(getComponents());
 		for (ComponentInfo component : components) {
 			AbstractGridBagConstraintsInfo constraints = getConstraints(component);
 			if (predicate.apply(component, constraints)) {

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/spring/SpringAttachmentInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/spring/SpringAttachmentInfo.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.model.layout.spring;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.controls.CCombo3;
 import org.eclipse.wb.draw2d.IPositionConstants;
 import org.eclipse.wb.internal.core.gef.policy.snapping.PlacementUtils;
@@ -350,7 +348,7 @@ public final class SpringAttachmentInfo {
 	 */
 	private NodeTarget getRequiredNodeTarget() throws Exception {
 		StatementTarget statementTarget =
-				JavaInfoUtils.getStatementTarget_whenAllCreated(ImmutableList.of(
+				JavaInfoUtils.getStatementTarget_whenAllCreated(List.of(
 						m_layout,
 						m_component,
 						m_anchorComponent));

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/swingx/JXTaskPaneInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/swingx/JXTaskPaneInfo.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.swingx;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.association.AssociationObjects;
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
 import org.eclipse.wb.internal.core.model.creation.CreationSupport;
@@ -25,6 +23,7 @@ import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.JPanelInfo;
 
 import java.awt.Component;
+import java.util.List;
 
 /**
  * Model for <code>org.jdesktop.swingx.JXTaskPane</code>.
@@ -70,7 +69,7 @@ public final class JXTaskPaneInfo extends JPanelInfo {
 		ComponentInfo newComponent =
 				(ComponentInfo) JavaInfoUtils.createJavaInfo(getEditor(), Component.class, creationSupport);
 		JavaInfoUtils.add(newComponent, AssociationObjects.invocationVoid(), this, nextComponent);
-		getBroadcastObject().select(ImmutableList.of(newComponent));
+		getBroadcastObject().select(List.of(newComponent));
 		return newComponent;
 	}
 }

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/EditPartFactory.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/EditPartFactory.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swt.gef;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.gef.MatchingEditPartFactory;
 import org.eclipse.wb.core.gef.part.menu.MenuEditPartFactory;
 import org.eclipse.wb.gef.core.EditPart;
@@ -24,6 +22,8 @@ import org.eclipse.wb.internal.core.model.menu.MenuObjectInfoUtils;
 import org.eclipse.wb.internal.swt.model.widgets.menu.MenuInfo;
 import org.eclipse.wb.internal.swt.model.widgets.menu.MenuItemInfo;
 
+import java.util.List;
+
 /**
  * Implementation of {@link IEditPartFactory} for SWT.
  *
@@ -33,9 +33,9 @@ import org.eclipse.wb.internal.swt.model.widgets.menu.MenuItemInfo;
  */
 public final class EditPartFactory implements IEditPartFactory {
 	private final static IEditPartFactory MATCHING_FACTORY =
-			new MatchingEditPartFactory(ImmutableList.of(
+			new MatchingEditPartFactory(List.of(
 					"org.eclipse.wb.internal.swt.model.widgets",
-					"org.eclipse.wb.internal.swt.model.jface.viewer"), ImmutableList.of(
+					"org.eclipse.wb.internal.swt.model.jface.viewer"), List.of(
 							"org.eclipse.wb.internal.swt.gef.part",
 							"org.eclipse.wb.internal.swt.gef.part"));
 

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gefTree/EditPartFactory.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gefTree/EditPartFactory.java
@@ -10,11 +10,11 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swt.gefTree;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.gef.MatchingEditPartFactory;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartFactory;
+
+import java.util.List;
 
 /**
  * Implementation of {@link IEditPartFactory} for SWT.
@@ -24,8 +24,8 @@ import org.eclipse.wb.gef.core.IEditPartFactory;
  */
 public final class EditPartFactory implements IEditPartFactory {
 	private final static IEditPartFactory MATCHING_FACTORY =
-			new MatchingEditPartFactory(ImmutableList.of("org.eclipse.wb.internal.swt.model.widgets"),
-					ImmutableList.of("org.eclipse.wb.internal.swt.gefTree.part"));
+			new MatchingEditPartFactory(List.of("org.eclipse.wb.internal.swt.model.widgets"),
+					List.of("org.eclipse.wb.internal.swt.gefTree.part"));
 
 	////////////////////////////////////////////////////////////////////////////
 	//

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/LayoutDataInfo.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/LayoutDataInfo.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swt.model.layout;
 
-import com.google.common.collect.ImmutableMap;
-
 import org.eclipse.wb.core.eval.AstEvaluationEngine;
 import org.eclipse.wb.core.eval.EvaluationContext;
 import org.eclipse.wb.core.model.JavaInfo;
@@ -309,7 +307,7 @@ public abstract class LayoutDataInfo extends JavaInfo implements ILayoutDataInfo
 			private boolean isDefault(String signature, List<Object> args) throws Exception {
 				String script = JavaInfoUtils.getParameter(m_this, "isDefault");
 				if (script != null) {
-					Map<String, Object> variables = ImmutableMap.of("signature", signature, "args", args);
+					Map<String, Object> variables = Map.of("signature", signature, "args", args);
 					return (Boolean) ScriptUtils.evaluate(
 							JavaInfoUtils.getClassLoader(m_this),
 							script,

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/VirtualLayoutDataStatementGenerator.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/VirtualLayoutDataStatementGenerator.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swt.model.layout;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.association.Association;
 import org.eclipse.wb.internal.core.model.generation.statement.AbstractInsideStatementGenerator;
@@ -19,6 +17,8 @@ import org.eclipse.wb.internal.core.model.generation.statement.StatementGenerato
 import org.eclipse.wb.internal.core.utils.ast.StatementTarget;
 
 import org.eclipse.jdt.core.dom.Block;
+
+import java.util.List;
 
 /**
  * Implementation of {@link StatementGenerator} for virtual {@link LayoutDataInfo}.
@@ -37,7 +37,7 @@ public final class VirtualLayoutDataStatementGenerator extends AbstractInsideSta
 	@Override
 	public void add(JavaInfo child, StatementTarget target, Association association) throws Exception {
 		// prepare block
-		Block block = (Block) child.getEditor().addStatement(ImmutableList.of("{", "}"), target);
+		Block block = (Block) child.getEditor().addStatement(List.of("{", "}"), target);
 		// add statements in block
 		target = new StatementTarget(block, true);
 		add(child, target, null, association);

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/FormAttachmentInfo.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/FormAttachmentInfo.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swt.model.layout.form;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.broadcast.JavaEventListener;
 import org.eclipse.wb.internal.core.gef.policy.snapping.PlacementUtils;
@@ -38,6 +36,7 @@ import org.eclipse.swt.layout.FormAttachment;
 import org.eclipse.swt.layout.FormLayout;
 
 import java.io.Serializable;
+import java.util.List;
 
 /**
  * SWT {@link FormAttachment} model. This is related to {@link FormLayout}.
@@ -324,7 +323,7 @@ public final class FormAttachmentInfo extends JavaInfo implements IFormAttachmen
 	private String getReferenceExpression_ensureFormDataVisible(ControlInfo control) throws Exception {
 		FormDataInfo layoutData = (FormDataInfo) getParent();
 		StatementTarget statementTarget =
-				JavaInfoUtils.getStatementTarget_whenAllCreated(ImmutableList.of(layoutData, control));
+				JavaInfoUtils.getStatementTarget_whenAllCreated(List.of(layoutData, control));
 		String referenceExpression =
 				control.getVariableSupport().getReferenceExpression(new NodeTarget(statementTarget));
 		moveStatement(this, statementTarget);
@@ -341,7 +340,7 @@ public final class FormAttachmentInfo extends JavaInfo implements IFormAttachmen
 	private void setConstructorArguments(final String source, ControlInfo control) throws Exception {
 		ConstructorCreationSupport creationSupport = (ConstructorCreationSupport) getCreationSupport();
 		ClassInstanceCreation cic = creationSupport.getCreation();
-		getEditor().replaceCreationArguments(cic, ImmutableList.of(source));
+		getEditor().replaceCreationArguments(cic, List.of(source));
 		if (control != null) {
 			replaceFormDataQualifier(cic, control);
 		}
@@ -354,7 +353,7 @@ public final class FormAttachmentInfo extends JavaInfo implements IFormAttachmen
 		QualifiedName formDataAssignmentLeft = (QualifiedName) formDataAssignment.getLeftHandSide();
 		FormDataInfo layoutData = (FormDataInfo) getParent();
 		StatementTarget statementTarget =
-				JavaInfoUtils.getStatementTarget_whenAllCreated(ImmutableList.of(layoutData, control));
+				JavaInfoUtils.getStatementTarget_whenAllCreated(List.of(layoutData, control));
 		String referenceExpression =
 				layoutData.getVariableSupport().getReferenceExpression(new NodeTarget(statementTarget));
 		getEditor().replaceExpression(formDataAssignmentLeft.getQualifier(), referenceExpression);

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/widgets/menu/MenuItemInfo.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/widgets/menu/MenuItemInfo.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swt.model.widgets.menu;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.association.AssociationObject;
@@ -45,6 +43,7 @@ import org.eclipse.wb.internal.swt.support.SwtSupport;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.jface.resource.ImageDescriptor;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -370,7 +369,7 @@ org.eclipse.wb.internal.core.utils.IAdaptable {
 
 		@Override
 		public List<?> commandPaste(Object mementoObject, Object nextObject) throws Exception {
-			return ImmutableList.of();
+			return Collections.emptyList();
 		}
 
 		@Override

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/Expectations.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/Expectations.java
@@ -10,9 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-
 import org.eclipse.wb.internal.core.EnvironmentUtils;
 
 import org.eclipse.draw2d.geometry.Dimension;
@@ -79,12 +76,12 @@ public final class Expectations {
 	}
 
 	public static <V> V get(String key_1, V value_1, String key_2, V value_2) {
-		Map<String, V> map = ImmutableMap.of(key_1, value_1, key_2, value_2);
+		Map<String, V> map = Map.of(key_1, value_1, key_2, value_2);
 		return get(map);
 	}
 
 	public static <V> V get(String key_1, V value_1, String key_2, V value_2, String key_3, V value_3) {
-		Map<String, V> map = ImmutableMap.of(key_1, value_1, key_2, value_2, key_3, value_3);
+		Map<String, V> map = Map.of(key_1, value_1, key_2, value_2, key_3, value_3);
 		return get(map);
 	}
 
@@ -94,7 +91,7 @@ public final class Expectations {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	public static int get(String key_1, int value_1, String key_2, int value_2) {
-		Map<String, Integer> map = ImmutableMap.of(key_1, value_1, key_2, value_2);
+		Map<String, Integer> map = Map.of(key_1, value_1, key_2, value_2);
 		return get(map);
 	}
 
@@ -104,7 +101,7 @@ public final class Expectations {
 			int value_2,
 			String key_3,
 			int value_3) {
-		Map<String, Integer> map = ImmutableMap.of(key_1, value_1, key_2, value_2, key_3, value_3);
+		Map<String, Integer> map = Map.of(key_1, value_1, key_2, value_2, key_3, value_3);
 		return get(map);
 	}
 
@@ -114,7 +111,7 @@ public final class Expectations {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	public static double get(String key_1, double value_1, String key_2, double value_2) {
-		Map<String, Double> map = ImmutableMap.of(key_1, value_1, key_2, value_2);
+		Map<String, Double> map = Map.of(key_1, value_1, key_2, value_2);
 		return get(map);
 	}
 
@@ -124,7 +121,7 @@ public final class Expectations {
 			double value_2,
 			String key_3,
 			double value_3) {
-		Map<String, Double> map = ImmutableMap.of(key_1, value_1, key_2, value_2, key_3, value_3);
+		Map<String, Double> map = Map.of(key_1, value_1, key_2, value_2, key_3, value_3);
 		return get(map);
 	}
 
@@ -138,7 +135,7 @@ public final class Expectations {
 		String keyHost = m_hostName;
 		String keyOS = m_OSName;
 		String timeZone = Calendar.getInstance().getTimeZone().getID();
-		return ImmutableList.of(
+		return List.of(
 				keyHostOS,
 				keyHost,
 				keyHost.toLowerCase(Locale.ENGLISH),

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/AbstractXmlObjectTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/AbstractXmlObjectTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.XML;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.controls.CCombo3;
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.model.ObjectInfoVisitor;
@@ -49,6 +47,7 @@ import org.apache.commons.lang.StringUtils;
 import org.junit.Before;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -596,7 +595,7 @@ public abstract class AbstractXmlObjectTest extends AbstractJavaProjectTest {
 	 */
 	public static IMenuManager getContextMenu(ObjectInfo... objectsArray) throws Exception {
 		IMenuManager manager = getDesignerMenuManager();
-		List<ObjectInfo> objects = ImmutableList.copyOf(objectsArray);
+		List<ObjectInfo> objects = List.of(objectsArray);
 		ObjectInfo object = objectsArray[0];
 		object.getBroadcastObject().addContextMenu(objects, object, manager);
 		return manager;
@@ -607,7 +606,7 @@ public abstract class AbstractXmlObjectTest extends AbstractJavaProjectTest {
 	 */
 	public static List<Object> getSelectionActions_noSelection(ObjectInfo root) throws Exception {
 		List<Object> actions = new ArrayList<>();
-		ImmutableList<ObjectInfo> objects = ImmutableList.<ObjectInfo>of();
+		List<ObjectInfo> objects = Collections.emptyList();
 		root.getBroadcastObject().addSelectionActions(objects, actions);
 		return actions;
 	}
@@ -619,7 +618,7 @@ public abstract class AbstractXmlObjectTest extends AbstractJavaProjectTest {
 		List<Object> actions = new ArrayList<>();
 		if (objectsArray.length != 0) {
 			ObjectInfo object = objectsArray[0];
-			List<ObjectInfo> objects = ImmutableList.copyOf(objectsArray);
+			List<ObjectInfo> objects = List.of(objectsArray);
 			object.getBroadcastObject().addSelectionActions(objects, actions);
 		}
 		return actions;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/model/association/IntermediateAssociationTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/model/association/IntermediateAssociationTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.XML.model.association;
 
-import com.google.common.collect.ImmutableMap;
-
 import org.eclipse.wb.internal.core.xml.model.XmlObjectInfo;
 import org.eclipse.wb.internal.core.xml.model.association.Association;
 import org.eclipse.wb.internal.core.xml.model.association.Associations;
@@ -21,6 +19,9 @@ import org.eclipse.wb.internal.core.xml.model.utils.XmlObjectUtils;
 import org.eclipse.wb.tests.designer.XML.model.description.AbstractCoreTest;
 
 import org.junit.Test;
+
+import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Test for {@link IntermediateAssociation}.
@@ -51,7 +52,7 @@ public class IntermediateAssociationTest extends AbstractCoreTest {
 	@Test
 	public void test_toString_withAttributes() throws Exception {
 		Association association =
-				Associations.intermediate("foo", ImmutableMap.of("attrA", "a", "attrB", "b"));
+				Associations.intermediate("foo", new TreeMap<>(Map.of("attrA", "a", "attrB", "b")));
 		assertEquals("inter foo {attrA=a, attrB=b}", association.toString());
 	}
 
@@ -123,7 +124,7 @@ public class IntermediateAssociationTest extends AbstractCoreTest {
 		// add
 		XmlObjectInfo newObject = createButton();
 		Association association =
-				Associations.intermediate("foo", ImmutableMap.of("attrA", "a", "attrB", "b"));
+				Associations.intermediate("foo", new TreeMap<>(Map.of("attrA", "a", "attrB", "b")));
 		XmlObjectUtils.add(newObject, association, container, null);
 		assertXML(
 				"// filler filler filler filler filler",

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/model/generic/SimpleContainerModelTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/model/generic/SimpleContainerModelTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.XML.model.generic;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.model.generic.ContainerObjectValidator;
 import org.eclipse.wb.internal.core.model.generic.ContainerObjectValidators;
@@ -44,6 +42,7 @@ import org.junit.Test;
 import org.mockito.InOrder;
 
 import java.text.MessageFormat;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -339,7 +338,7 @@ public class SimpleContainerModelTest extends AbstractCoreTest {
 		}
 
 		public List<ObjectInfo> getSimpleContainerChildren() {
-			return ImmutableList.of();
+			return Collections.emptyList();
 		}
 
 		public void command_CREATE(Object component) {
@@ -368,7 +367,7 @@ public class SimpleContainerModelTest extends AbstractCoreTest {
 			simpleContainer = new SimpleContainerConfigurable(container, configuration);
 		}
 		// isEmpty() == true, because no existing children
-		when(container.getSimpleContainerChildren()).thenReturn(ImmutableList.<ObjectInfo>of());
+		when(container.getSimpleContainerChildren()).thenReturn(Collections.emptyList());
 		//
 		assertTrue(simpleContainer.isEmpty());
 		//
@@ -378,7 +377,7 @@ public class SimpleContainerModelTest extends AbstractCoreTest {
 		clearInvocations(container);
 		//
 		TestObjectInfo existingChild = new TestObjectInfo();
-		when(container.getSimpleContainerChildren()).thenReturn(ImmutableList.<ObjectInfo>of(existingChild));
+		when(container.getSimpleContainerChildren()).thenReturn(List.of(existingChild));
 		//
 		assertFalse(simpleContainer.isEmpty());
 		//
@@ -387,7 +386,7 @@ public class SimpleContainerModelTest extends AbstractCoreTest {
 		// getChild() == null, because no existing children
 		clearInvocations(container);
 		//
-		when(container.getSimpleContainerChildren()).thenReturn(ImmutableList.<ObjectInfo>of());
+		when(container.getSimpleContainerChildren()).thenReturn(Collections.emptyList());
 		//
 		assertSame(null, simpleContainer.getChild());
 		//
@@ -396,7 +395,7 @@ public class SimpleContainerModelTest extends AbstractCoreTest {
 		// getChild() != null, because return existing child
 		clearInvocations(container);
 		//
-		when(container.getSimpleContainerChildren()).thenReturn(ImmutableList.<ObjectInfo>of(existingChild));
+		when(container.getSimpleContainerChildren()).thenReturn(List.of(existingChild));
 		//
 		assertSame(existingChild, simpleContainer.getChild());
 		//

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/palette/AttributesProvidersTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/palette/AttributesProvidersTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.XML.palette;
 
-import com.google.common.collect.ImmutableMap;
-
 import org.eclipse.wb.internal.core.utils.external.ExternalFactoriesHelper;
 import org.eclipse.wb.internal.core.xml.editor.palette.model.AttributesProvider;
 import org.eclipse.wb.internal.core.xml.editor.palette.model.AttributesProviders;
@@ -97,7 +95,7 @@ public class AttributesProvidersTest extends AbstractPaletteTest {
 	 */
 	@Test
 	public void test_getMap() throws Exception {
-		Map<String, String> attributes = ImmutableMap.of("attr", "someValue");
+		Map<String, String> attributes = Map.of("attr", "someValue");
 		AttributesProvider provider = AttributesProviders.get(attributes);
 		assertEquals("someValue", provider.getAttribute("attr"));
 		assertNull(provider.getAttribute("noSuchAttribute"));

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/palette/PaletteManagerTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/palette/PaletteManagerTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.XML.palette;
 
-import com.google.common.collect.ImmutableMap;
-
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.utils.jdt.core.ProjectUtils;
 import org.eclipse.wb.internal.core.utils.state.EditorWarning;
@@ -39,6 +37,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Tests for {@link PaletteManager}.
@@ -819,7 +818,7 @@ public class PaletteManagerTest extends AbstractPaletteTest {
 		"</category>"});
 		// parse and configure EditorState
 		XmlObjectInfo panel = parseEmptyPanel();
-		m_lastContext.addVersions(ImmutableMap.<String, Object>of("version", "3.5"));
+		m_lastContext.addVersions(Map.of("version", "3.5"));
 		//
 		PaletteInfo palette = loadPalette(panel);
 		assertNoErrors();
@@ -835,7 +834,7 @@ public class PaletteManagerTest extends AbstractPaletteTest {
 		"</category>"});
 		// parse and configure EditorState
 		XmlObjectInfo panel = parseEmptyPanel();
-		m_lastContext.addVersions(ImmutableMap.<String, Object>of("version", "2.1"));
+		m_lastContext.addVersions(Map.of("version", "2.1"));
 		//
 		PaletteInfo palette = loadPalette(panel);
 		assertNoErrors();
@@ -851,7 +850,7 @@ public class PaletteManagerTest extends AbstractPaletteTest {
 		"</category>"});
 		// parse and configure EditorState
 		XmlObjectInfo panel = parseEmptyPanel();
-		m_lastContext.addVersions(ImmutableMap.of("version", "2.1"));
+		m_lastContext.addVersions(Map.of("version", "2.1"));
 		//
 		PaletteInfo palette = loadPalette(panel);
 		assertNoErrors();

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XWT/model/XwtModelTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XWT/model/XwtModelTest.java
@@ -10,11 +10,8 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.XWT.model;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.internal.core.model.description.ToolkitDescription;
 import org.eclipse.wb.internal.core.model.variable.NamesManager;
-import org.eclipse.wb.internal.core.model.variable.NamesManager.ComponentNameDescription;
 import org.eclipse.wb.internal.core.utils.jdt.core.CodeUtils;
 import org.eclipse.wb.internal.core.xml.model.XmlObjectInfo;
 import org.eclipse.wb.internal.core.xml.model.description.ComponentDescription;
@@ -35,6 +32,8 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.junit.After;
 import org.junit.Before;
+
+import java.util.Collections;
 
 /**
  * Abstract super class for XWT tests.
@@ -99,7 +98,7 @@ public abstract class XwtModelTest extends AbstractXmlModelTest {
 		IPreferenceStore preferences = toolkit.getPreferences();
 		preferences.setToDefault(org.eclipse.wb.internal.swt.preferences.IPreferenceConstants.P_LAYOUT_DATA_NAME_TEMPLATE);
 		preferences.setToDefault(org.eclipse.wb.internal.swt.preferences.IPreferenceConstants.P_LAYOUT_NAME_TEMPLATE);
-		NamesManager.setNameDescriptions(toolkit, ImmutableList.<ComponentNameDescription>of());
+		NamesManager.setNameDescriptions(toolkit, Collections.emptyList());
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/description/DescriptionVersionsProvidersTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/description/DescriptionVersionsProvidersTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.model.description;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.internal.core.model.description.ComponentDescription;
 import org.eclipse.wb.internal.core.model.description.factory.FactoryMethodDescription;
 import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper;
@@ -70,7 +68,7 @@ public class DescriptionVersionsProvidersTest extends SwingModelTest {
 	@Test
 	public void test_providerFromList_noCurrentInList() throws Exception {
 		try {
-			new FromListDescriptionVersionsProvider(ImmutableList.of("1.0", "2.0", "3.0"), "2.1") {
+			new FromListDescriptionVersionsProvider(List.of("1.0", "2.0", "3.0"), "2.1") {
 				@Override
 				protected boolean validate(Class<?> componentClass) throws Exception {
 					return false;
@@ -86,7 +84,7 @@ public class DescriptionVersionsProvidersTest extends SwingModelTest {
 	 */
 	@Test
 	public void test_providerFromList_getVersions_middleVersion() throws Exception {
-		List<String> allVersions = ImmutableList.of("1.0", "2.0", "3.0");
+		List<String> allVersions = List.of("1.0", "2.0", "3.0");
 		String currentVersion = "2.0";
 		FromListDescriptionVersionsProvider provider =
 				new FromListDescriptionVersionsProvider(allVersions, currentVersion) {
@@ -103,7 +101,7 @@ public class DescriptionVersionsProvidersTest extends SwingModelTest {
 		// valid Class, "1.0" and "2.0" expected
 		{
 			List<String> versions = provider.getVersions(JButton.class);
-			Assertions.assertThat(versions).isEqualTo(ImmutableList.of("2.0", "1.0"));
+			Assertions.assertThat(versions).isEqualTo(List.of("2.0", "1.0"));
 		}
 	}
 
@@ -112,7 +110,7 @@ public class DescriptionVersionsProvidersTest extends SwingModelTest {
 	 */
 	@Test
 	public void test_providerFromList_getVersions_latestVersion() throws Exception {
-		List<String> allVersions = ImmutableList.of("1.0", "2.0", "3.0");
+		List<String> allVersions = List.of("1.0", "2.0", "3.0");
 		String currentVersion = "3.0";
 		FromListDescriptionVersionsProvider provider =
 				new FromListDescriptionVersionsProvider(allVersions, currentVersion) {
@@ -123,7 +121,7 @@ public class DescriptionVersionsProvidersTest extends SwingModelTest {
 		};
 		//
 		List<String> versions = provider.getVersions(JButton.class);
-		Assertions.assertThat(versions).isEqualTo(ImmutableList.of("3.0", "2.0", "1.0"));
+		Assertions.assertThat(versions).isEqualTo(List.of("3.0", "2.0", "1.0"));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/generic/SimpleContainerModelTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/generic/SimpleContainerModelTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.model.generic;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.association.Association;
@@ -45,6 +43,7 @@ import org.junit.Test;
 import org.mockito.InOrder;
 
 import java.text.MessageFormat;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -380,7 +379,7 @@ public class SimpleContainerModelTest extends SwingModelTest {
 		}
 
 		public List<ObjectInfo> getSimpleContainerChildren() {
-			return ImmutableList.of();
+			return Collections.emptyList();
 		}
 
 		public void command_CREATE(Object component) {
@@ -409,7 +408,7 @@ public class SimpleContainerModelTest extends SwingModelTest {
 		}
 		// isEmpty() == true, because no existing children
 		{
-			when(container.getSimpleContainerChildren()).thenReturn(ImmutableList.<ObjectInfo>of());
+			when(container.getSimpleContainerChildren()).thenReturn(Collections.emptyList());
 			//
 			assertTrue(simpleContainer.isEmpty());
 			//
@@ -421,7 +420,7 @@ public class SimpleContainerModelTest extends SwingModelTest {
 			clearInvocations(container);
 			//
 			final TestObjectInfo existingChild = new TestObjectInfo();
-			when(container.getSimpleContainerChildren()).thenReturn(ImmutableList.<ObjectInfo>of(existingChild));
+			when(container.getSimpleContainerChildren()).thenReturn(List.of(existingChild));
 			//
 			assertFalse(simpleContainer.isEmpty());
 			//
@@ -432,7 +431,7 @@ public class SimpleContainerModelTest extends SwingModelTest {
 		{
 			clearInvocations(container);
 			//
-			when(container.getSimpleContainerChildren()).thenReturn(ImmutableList.<ObjectInfo>of());
+			when(container.getSimpleContainerChildren()).thenReturn(Collections.emptyList());
 			//
 			assertSame(null, simpleContainer.getChild());
 			//
@@ -444,7 +443,7 @@ public class SimpleContainerModelTest extends SwingModelTest {
 			clearInvocations(container);
 			//
 			final TestObjectInfo existingChild = new TestObjectInfo();
-			when(container.getSimpleContainerChildren()).thenReturn(ImmutableList.<ObjectInfo>of(existingChild));
+			when(container.getSimpleContainerChildren()).thenReturn(List.of(existingChild));
 			//
 			assertSame(existingChild, simpleContainer.getChild());
 			//

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/parser/AbstractJavaInfoRelatedTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/parser/AbstractJavaInfoRelatedTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.model.parser;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.controls.CCombo3;
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
@@ -37,7 +35,6 @@ import org.eclipse.wb.internal.core.model.property.table.PropertyTooltipProvider
 import org.eclipse.wb.internal.core.model.property.table.PropertyTooltipTextProvider;
 import org.eclipse.wb.internal.core.model.variable.FieldUniqueVariableSupport;
 import org.eclipse.wb.internal.core.model.variable.NamesManager;
-import org.eclipse.wb.internal.core.model.variable.NamesManager.ComponentNameDescription;
 import org.eclipse.wb.internal.core.model.variable.VariableSupport;
 import org.eclipse.wb.internal.core.model.variable.description.LocalUniqueVariableDescription;
 import org.eclipse.wb.internal.core.preferences.IPreferenceConstants;
@@ -65,6 +62,7 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -92,7 +90,7 @@ public abstract class AbstractJavaInfoRelatedTest extends AbstractJavaTest {
 		preferences.setToDefault(IPreferenceConstants.P_VARIABLE_TEXT_TEMPLATE);
 		preferences.setToDefault(IPreferenceConstants.P_VARIABLE_TEXT_WORDS_LIMIT);
 		preferences.setToDefault(IPreferenceConstants.P_VARIABLE_IN_COMPONENT);
-		NamesManager.setNameDescriptions(toolkit, ImmutableList.<ComponentNameDescription>of());
+		NamesManager.setNameDescriptions(toolkit, Collections.emptyList());
 		// please, always use in tests default settings
 		{
 			GenerationSettings generationSettings = toolkit.getGenerationSettings();

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/parser/ExecuteOnParseTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/parser/ExecuteOnParseTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.model.parser;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.eval.AstEvaluationEngine;
 import org.eclipse.wb.core.eval.EvaluationContext;
 import org.eclipse.wb.core.eval.ExecutionFlowDescription;
@@ -1967,8 +1965,8 @@ public class ExecuteOnParseTest extends SwingModelTest {
 						"  }",
 						"}");
 		// listen for ASTNode evaluation
-		List<String> expectedNodes_before = ImmutableList.of("setEnabled(false)", "setEnabled(false);");
-		List<String> expectedNodes_after = ImmutableList.of("setEnabled(false)", "setEnabled(false);");
+		List<String> expectedNodes_before = List.of("setEnabled(false)", "setEnabled(false);");
+		List<String> expectedNodes_after = List.of("setEnabled(false)", "setEnabled(false);");
 		final Iterator<String> expectedIterator_before = expectedNodes_before.iterator();
 		final Iterator<String> expectedIterator_after = expectedNodes_after.iterator();
 		panel.addBroadcastListener(new EvaluationEventListener() {

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/TabOrderPropertyTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/TabOrderPropertyTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.model.property;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.AbstractComponentInfo;
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.model.property.Property;
@@ -34,6 +32,7 @@ import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -236,7 +235,7 @@ public class TabOrderPropertyTest extends SwingModelTest {
 				ArrayInitializer initializer,
 				String tooltip) {
 			super(container);
-			m_allInfos = allInfos != null ? allInfos : ImmutableList.<AbstractComponentInfo>of();
+			m_allInfos = allInfos != null ? allInfos : Collections.emptyList();
 			m_defaultInfos = defaultInfos;
 			m_initializer = initializer;
 			m_tooltip = tooltip;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/editor/StaticFieldPropertyEditorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/editor/StaticFieldPropertyEditorTest.java
@@ -10,9 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.model.property.editor;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-
 import org.eclipse.wb.internal.core.model.property.GenericProperty;
 import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.model.property.editor.StaticFieldPropertyEditor;
@@ -31,6 +28,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import javax.swing.SwingConstants;
 
@@ -156,7 +154,7 @@ public class StaticFieldPropertyEditorTest extends SwingModelTest {
 				"}");
 		// create StaticFieldPropertyEditor
 		StaticFieldPropertyEditor editor = new StaticFieldPropertyEditor();
-		editor.configure(m_lastState, ImmutableMap.<String, Object>of(
+		editor.configure(m_lastState, Map.of(
 				"class",
 				"javax.swing.SwingConstants",
 				"fields",
@@ -184,11 +182,11 @@ public class StaticFieldPropertyEditorTest extends SwingModelTest {
 				"}");
 		// create StaticFieldPropertyEditor
 		StaticFieldPropertyEditor editor = new StaticFieldPropertyEditor();
-		editor.configure(m_lastState, ImmutableMap.<String, Object>of(
+		editor.configure(m_lastState, Map.of(
 				"class",
 				"javax.swing.SwingConstants",
 				"field",
-				ImmutableList.of("LEFT", "RIGHT")));
+				List.of("LEFT", "RIGHT")));
 		// check state
 		Class<?> e_class = SwingConstants.class;
 		String m_classSourceName = "javax.swing.SwingConstants";
@@ -215,7 +213,7 @@ public class StaticFieldPropertyEditorTest extends SwingModelTest {
 			StaticFieldPropertyEditor editor = new StaticFieldPropertyEditor();
 			editor.configure(
 					m_lastState,
-					ImmutableMap.<String, Object>of("class", "javax.swing.SwingConstants"));
+					Map.of("class", "javax.swing.SwingConstants"));
 			fail();
 		} catch (DesignerException e) {
 		}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/FactoryActionsSupportTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/FactoryActionsSupportTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.model.util;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.model.util.factory.FactoryActionsSupport;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
@@ -26,6 +24,7 @@ import org.eclipse.jface.action.MenuManager;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Tests for {@link FactoryActionsSupport}.
@@ -242,7 +241,7 @@ public class FactoryActionsSupportTest extends SwingModelTest {
 	private IMenuManager getFactoryManager(ComponentInfo component) throws Exception {
 		MenuManager menuManager = getDesignerMenuManager();
 		component.getBroadcastObject().addContextMenu(
-				ImmutableList.of(component),
+				List.of(component),
 				component,
 				menuManager);
 		return findChildMenuManager(menuManager, "Factory");

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/JavaInfoUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/JavaInfoUtilsTest.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.model.util;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.editor.IDesignPageSite;
@@ -82,6 +81,7 @@ import org.mockito.ArgumentCaptor;
 import java.awt.FlowLayout;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -3312,13 +3312,13 @@ public class JavaInfoUtilsTest extends SwingModelTest {
 		ComponentInfo button_2 = panel.getChildrenComponents().get(1);
 		// fail if no components
 		try {
-			JavaInfoUtils.getStatementTarget_whenAllCreated(ImmutableList.<JavaInfo>of());
+			JavaInfoUtils.getStatementTarget_whenAllCreated(Collections.emptyList());
 			fail();
 		} catch (AssertionFailedException e) {
 		}
 		// ask for "button_1" and "button_2"
 		{
-			List<ComponentInfo> components = ImmutableList.of(button_1, button_2);
+			List<ComponentInfo> components = List.of(button_1, button_2);
 			StatementTarget target = JavaInfoUtils.getStatementTarget_whenAllCreated(components);
 			assertTarget(target, null, getStatement(panel, 2), false);
 		}
@@ -3344,7 +3344,7 @@ public class JavaInfoUtilsTest extends SwingModelTest {
 		ComponentInfo button_2 = panel.getChildrenComponents().get(1);
 		// ask for "button_1" and "button_2"
 		{
-			List<ComponentInfo> components = ImmutableList.of(button_1, button_2);
+			List<ComponentInfo> components = List.of(button_1, button_2);
 			StatementTarget target = JavaInfoUtils.getStatementTarget_whenAllCreated(components);
 			assertTarget(target, null, getStatement(panel, 0), false);
 		}
@@ -3370,7 +3370,7 @@ public class JavaInfoUtilsTest extends SwingModelTest {
 		ComponentInfo button_2 = panel.getChildrenComponents().get(1);
 		// ask for "button_1" and "button_2"
 		{
-			List<ComponentInfo> components = ImmutableList.of(button_1, button_2);
+			List<ComponentInfo> components = List.of(button_1, button_2);
 			StatementTarget target = JavaInfoUtils.getStatementTarget_whenAllCreated(components);
 			assertTarget(target, getBlock(panel), null, true);
 		}
@@ -3401,7 +3401,7 @@ public class JavaInfoUtilsTest extends SwingModelTest {
 		ComponentInfo button_2 = panel.getChildrenComponents().get(1);
 		// ask for "button_1" and "button_2"
 		{
-			List<ComponentInfo> components = ImmutableList.of(button_1, button_2);
+			List<ComponentInfo> components = List.of(button_1, button_2);
 			StatementTarget target = JavaInfoUtils.getStatementTarget_whenAllCreated(components);
 			assertTarget(target, null, getStatement(button_2, 0), false);
 		}
@@ -3611,7 +3611,7 @@ public class JavaInfoUtilsTest extends SwingModelTest {
 				"    {implicit-layout: java.awt.FlowLayout} {implicit-layout} {}",
 				"    {method: public test.MyFactory test.MyContainer.getFactory()} {property} {}");
 		// send broadcast to move "getFactory()" into InstanceFactoryContainerInfo
-		InstanceFactoryRootProcessor.INSTANCE.process(panel, ImmutableList.<JavaInfo>of(exposedFactory));
+		InstanceFactoryRootProcessor.INSTANCE.process(panel, List.of(exposedFactory));
 		assertHierarchy(
 				"{this: javax.swing.JPanel} {this} {/add(new MyContainer())/}",
 				"  {implicit-layout: java.awt.FlowLayout} {implicit-layout} {}",

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/MorphingSupportTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/MorphingSupportTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.model.util;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.association.ConstructorParentAssociation;
 import org.eclipse.wb.core.model.association.FactoryParentAssociation;
@@ -933,7 +931,7 @@ public class MorphingSupportTest extends SwingModelTest {
 	private static IMenuManager getMorphManager(JavaInfo component) throws Exception {
 		MenuManager menuManager = getDesignerMenuManager();
 		component.getBroadcastObject().addContextMenu(
-				ImmutableList.of(component),
+				List.of(component),
 				component,
 				menuManager);
 		return findChildMenuManager(menuManager, "Morph");

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/PropertyUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/PropertyUtilsTest.java
@@ -11,7 +11,6 @@
 package org.eclipse.wb.tests.designer.core.model.util;
 
 import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.model.JavaInfo;
@@ -82,8 +81,8 @@ public class PropertyUtilsTest extends SwingModelTest {
 	public void test_getTitles_asList() throws Exception {
 		Property property_1 = new PropertyWithTitle("a");
 		Property property_2 = new PropertyWithTitle("b");
-		List<Property> properties = ImmutableList.of(property_1, property_2);
-		List<String> expectedTitles = ImmutableList.of("a", "b");
+		List<Property> properties = List.of(property_1, property_2);
+		List<String> expectedTitles = List.of("a", "b");
 		Assertions.assertThat(PropertyUtils.getTitles(properties)).isEqualTo(expectedTitles);
 	}
 
@@ -126,7 +125,7 @@ public class PropertyUtilsTest extends SwingModelTest {
 						"  }",
 						"}");
 		ComponentInfo button = panel.getChildrenComponents().get(0);
-		List<Property> properties = ImmutableList.copyOf(button.getProperties());
+		List<Property> properties = List.of(button.getProperties());
 		//
 		assertNotNull(PropertyUtils.getByTitle(properties, "enabled"));
 		assertNull(PropertyUtils.getByTitle(properties, "noSuchProperty"));

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/RenameConvertSupportTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/RenameConvertSupportTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.model.util;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.broadcast.ObjectEventListener;
@@ -92,7 +90,7 @@ public class RenameConvertSupportTest extends SwingModelTest {
 		// ask action using broadcast (good)
 		{
 			MenuManager manager = getDesignerMenuManager();
-			button.getBroadcastObject().addContextMenu(ImmutableList.of(button), button, manager);
+			button.getBroadcastObject().addContextMenu(List.of(button), button, manager);
 			assertNotNull(findChildAction(manager, "Rename..."));
 		}
 	}
@@ -141,7 +139,7 @@ public class RenameConvertSupportTest extends SwingModelTest {
 		assertNotNull(getRenameAction(button, textField));
 		// ask using broadcast
 		{
-			List<ComponentInfo> objects = ImmutableList.of(button, textField);
+			List<ComponentInfo> objects = List.of(button, textField);
 			{
 				MenuManager manager = getDesignerMenuManager();
 				button.getBroadcastObject().addContextMenu(objects, button, manager);
@@ -178,7 +176,7 @@ public class RenameConvertSupportTest extends SwingModelTest {
 		new UiContext().executeAndCheck(new UIRunnable() {
 			@Override
 			public void run(UiContext context) throws Exception {
-				RenameConvertSupport.rename(ImmutableList.of(button));
+				RenameConvertSupport.rename(List.of(button));
 			}
 		}, new UIRunnable() {
 			@Override
@@ -616,7 +614,7 @@ public class RenameConvertSupportTest extends SwingModelTest {
 	 */
 	private RenameConvertSupport getRenameSupport(ObjectInfo... objects) throws Exception {
 		return ReflectionUtils.getConstructor(RenameConvertSupport.class, Iterable.class).newInstance(
-				ImmutableList.copyOf(objects));
+				List.of(objects));
 	}
 
 	/**
@@ -641,7 +639,7 @@ public class RenameConvertSupportTest extends SwingModelTest {
 		// prepare manager
 		MenuManager menuManager = getDesignerMenuManager();
 		// add action
-		RenameConvertSupport.contribute(ImmutableList.copyOf(objects), menuManager);
+		RenameConvertSupport.contribute(List.of(objects), menuManager);
 		return findChildAction(menuManager, "Rename...");
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/ScriptUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/ScriptUtilsTest.java
@@ -10,9 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.model.util;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
 import org.eclipse.wb.internal.core.model.util.ScriptUtils;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
@@ -22,6 +19,7 @@ import org.eclipse.wb.tests.designer.swing.SwingModelTest;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -67,7 +65,7 @@ public class ScriptUtilsTest extends SwingModelTest {
 	 */
 	@Test
 	public void test_evaluate_withContext() throws Exception {
-		assertEquals(3, ScriptUtils.evaluate("size()", ImmutableList.of(1, 2, 3)));
+		assertEquals(3, ScriptUtils.evaluate("size()", List.of(1, 2, 3)));
 	}
 
 	/**
@@ -75,7 +73,7 @@ public class ScriptUtilsTest extends SwingModelTest {
 	 */
 	@Test
 	public void test_evaluate_withVariables() throws Exception {
-		Map<String, Object> variables = ImmutableMap.<String, Object>of("a", 2, "b", 3);
+		Map<String, Object> variables = Map.of("a", 2, "b", 3);
 		assertEquals(6, ScriptUtils.evaluate("a * b", variables));
 		assertEquals(6, ScriptUtils.evaluate("c = a * b; return c;", variables));
 		// variables should not be changed
@@ -189,7 +187,7 @@ public class ScriptUtilsTest extends SwingModelTest {
 				ScriptUtils.evaluate(
 						m_lastLoader,
 						"a + (com.jgoodies.forms.layout.Sizes.DLUX1).value",
-						ImmutableMap.<String, Object>of("a", 5.0));
+						Map.of("a", 5.0));
 		assertEquals(6.0, ((Double) actual).doubleValue(), 0.001);
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/TemplateUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/TemplateUtilsTest.java
@@ -11,7 +11,6 @@
 package org.eclipse.wb.tests.designer.core.model.util;
 
 import com.google.common.collect.ImmutableBiMap;
-import com.google.common.collect.ImmutableList;
 
 import static org.eclipse.wb.internal.core.model.util.TemplateUtils.addStatement;
 import static org.eclipse.wb.internal.core.model.util.TemplateUtils.evaluate;
@@ -203,8 +202,8 @@ public class TemplateUtilsTest extends SwingModelTest {
 						"}");
 		NodeTarget nodeTarget = getNodeStatementTarget(panel, false, 0);
 		// do resolve
-		List<String> lines = ImmutableList.of(getExpression(panel) + " a", getExpression(panel) + " b");
-		List<String> result = ImmutableList.of("this a", "this b");
+		List<String> lines = List.of(getExpression(panel) + " a", getExpression(panel) + " b");
+		List<String> result = List.of("this a", "this b");
 		Assertions.assertThat(resolve(nodeTarget, lines)).isEqualTo(result);
 	}
 
@@ -266,7 +265,7 @@ public class TemplateUtilsTest extends SwingModelTest {
 						"}");
 		StatementTarget target = getBlockTarget(panel, true);
 		// do resolve
-		addStatement(panel, target, ImmutableList.of(TemplateUtils.format("{0}", panel), "\t.setEnabled(false);"));
+		addStatement(panel, target, List.of(TemplateUtils.format("{0}", panel), "\t.setEnabled(false);"));
 		assertEditor(
 				"// filler filler filler",
 				"public class Test extends JPanel {",

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/variables/AbstractNamedTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/variables/AbstractNamedTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.model.variables;
 
-import com.google.common.collect.ImmutableMap;
-
 import org.eclipse.wb.internal.core.model.variable.AbstractNamedVariableSupport;
 import org.eclipse.wb.internal.core.model.variable.AbstractSimpleVariableSupport;
 import org.eclipse.wb.internal.core.model.variable.LocalUniqueVariableSupport;
@@ -33,6 +31,7 @@ import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -296,13 +295,13 @@ public class AbstractNamedTest extends AbstractVariableTest {
 		// invalid identifier
 		{
 			Map<AbstractNamedVariableSupport, String> variablesNames =
-					ImmutableMap.of((AbstractNamedVariableSupport) button.getVariableSupport(), "in-valid");
+					Map.of((AbstractNamedVariableSupport) button.getVariableSupport(), "in-valid");
 			assertTrue(validateVariables(variablesNames).contains("identifier"));
 		}
 		// valid identifier
 		{
 			Map<AbstractNamedVariableSupport, String> variablesNames =
-					ImmutableMap.of((AbstractNamedVariableSupport) button.getVariableSupport(), "myButton");
+					Map.of((AbstractNamedVariableSupport) button.getVariableSupport(), "myButton");
 			validateVariables(true, variablesNames);
 		}
 	}
@@ -332,35 +331,35 @@ public class AbstractNamedTest extends AbstractVariableTest {
 				(AbstractNamedVariableSupport) button2.getVariableSupport();
 		// no conflict: no modifications
 		{
-			Map<AbstractNamedVariableSupport, String> variablesNames = ImmutableMap.of();
+			Map<AbstractNamedVariableSupport, String> variablesNames = Collections.emptyMap();
 			validateVariables(true, variablesNames);
 		}
 		// visible conflict: button2 -> button1
 		{
-			validateVariables(false, ImmutableMap.of(variable2, "button1"));
+			validateVariables(false, Map.of(variable2, "button1"));
 		}
 		// no visible conflict: button2 -> button1, button1 -> button_1
 		{
 			Map<AbstractNamedVariableSupport, String> variablesNames =
-					ImmutableMap.of(variable2, "button1", variable1, "button_1");
+					Map.of(variable2, "button1", variable1, "button_1");
 			validateVariables(true, variablesNames);
 		}
 		// no visible conflict: button2 -> button1, button1 -> button2
 		{
 			Map<AbstractNamedVariableSupport, String> variablesNames =
-					ImmutableMap.of(variable2, "button1", variable1, "button2");
+					Map.of(variable2, "button1", variable1, "button2");
 			validateVariables(true, variablesNames);
 		}
 		// shadow conflict: button1 -> button2
 		{
 			Map<AbstractNamedVariableSupport, String> variablesNames =
-					ImmutableMap.of(variable1, "button2");
+					Map.of(variable1, "button2");
 			validateVariables(false, variablesNames);
 		}
 		// no shadow conflict: button1 -> button2, button2 -> button_2
 		{
 			Map<AbstractNamedVariableSupport, String> variablesNames =
-					ImmutableMap.of(variable1, "button2", variable2, "button_2");
+					Map.of(variable1, "button2", variable2, "button_2");
 			validateVariables(true, variablesNames);
 		}
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/NlsSupportTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/NlsSupportTest.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.nls;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.model.JavaInfo;
@@ -302,7 +301,7 @@ public class NlsSupportTest extends SwingModelTest {
 			preferencesRepairer.setValue(IPreferenceConstants.P_NLS_ALWAYS_VISIBLE_LOCALES, "de, ru_RU");
 			LocaleInfo[] locales = m_support.getLocales();
 			List<String> localeNames =
-					Lists.transform(ImmutableList.copyOf(locales), from -> from.toString());
+					Lists.transform(List.of(locales), from -> from.toString());
 			Assertions.assertThat(localeNames).hasSize(4).containsOnly("(default)", "it", "de", "ru_RU");
 		} finally {
 			preferencesRepairer.restore();

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/palette/AttributesProvidersTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/palette/AttributesProvidersTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.palette;
 
-import com.google.common.collect.ImmutableMap;
-
 import org.eclipse.wb.internal.core.editor.palette.model.entry.AttributesProvider;
 import org.eclipse.wb.internal.core.editor.palette.model.entry.AttributesProviders;
 import org.eclipse.wb.internal.core.utils.external.ExternalFactoriesHelper;
@@ -97,7 +95,7 @@ public class AttributesProvidersTest extends AbstractPaletteTest {
 	 */
 	@Test
 	public void test_getMap() throws Exception {
-		Map<String, String> attributes = ImmutableMap.of("attr", "someValue");
+		Map<String, String> attributes = Map.of("attr", "someValue");
 		AttributesProvider provider = AttributesProviders.get(attributes);
 		assertEquals("someValue", provider.getAttribute("attr"));
 		assertNull(provider.getAttribute("noSuchAttribute"));

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/palette/PaletteManagerTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/palette/PaletteManagerTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.palette;
 
-import com.google.common.collect.ImmutableMap;
-
 import org.eclipse.wb.core.editor.palette.model.CategoryInfo;
 import org.eclipse.wb.core.editor.palette.model.PaletteInfo;
 import org.eclipse.wb.core.editor.palette.model.entry.ComponentEntryInfo;
@@ -39,6 +37,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Tests for {@link PaletteInfo}.
@@ -957,7 +956,7 @@ public class PaletteManagerTest extends AbstractPaletteTest {
 		"</category>"});
 		// parse and configure EditorState
 		JavaInfo panel = parseEmptyPanel();
-		m_lastState.addVersions(ImmutableMap.<String, Object>of("version", "3.5"));
+		m_lastState.addVersions(Map.of("version", "3.5"));
 		//
 		PaletteInfo palette = loadPalette(panel);
 		assertNoErrors(panel);
@@ -973,7 +972,7 @@ public class PaletteManagerTest extends AbstractPaletteTest {
 		"</category>"});
 		// parse and configure EditorState
 		JavaInfo panel = parseEmptyPanel();
-		m_lastState.addVersions(ImmutableMap.<String, Object>of("version", "2.1"));
+		m_lastState.addVersions(Map.of("version", "2.1"));
 		//
 		PaletteInfo palette = loadPalette(panel);
 		assertNoErrors(panel);
@@ -989,7 +988,7 @@ public class PaletteManagerTest extends AbstractPaletteTest {
 		"</category>"});
 		// parse and configure EditorState
 		JavaInfo panel = parseEmptyPanel();
-		m_lastState.addVersions(ImmutableMap.<String, Object>of("version", "2.1"));
+		m_lastState.addVersions(Map.of("version", "2.1"));
 		//
 		PaletteInfo palette = loadPalette(panel);
 		assertNoErrors(panel);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/palette/TabOrderToolEntryInfoTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/palette/TabOrderToolEntryInfoTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.palette;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.editor.palette.model.entry.TabOrderToolEntryInfo;
 import org.eclipse.wb.core.gef.policy.TabOrderContainerEditPolicy;
 import org.eclipse.wb.core.model.JavaInfo;
@@ -29,6 +27,9 @@ import static org.mockito.Mockito.when;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.InOrder;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Test for {@link TabOrderToolEntryInfo}.
@@ -55,7 +56,7 @@ public class TabOrderToolEntryInfoTest extends AbstractPaletteTest {
 		IEditPartViewer viewer;
 		{
 			viewer = mock(IEditPartViewer.class);
-			when(viewer.getSelectedEditParts()).thenReturn(ImmutableList.<EditPart>of());
+			when(viewer.getSelectedEditParts()).thenReturn(Collections.emptyList());
 		}
 		// check tool
 		assertTrue(entry.initialize(viewer, panel));
@@ -88,7 +89,7 @@ public class TabOrderToolEntryInfoTest extends AbstractPaletteTest {
 			//
 			when(selectedEditPart.getViewer()).thenReturn(viewer);
 			when(selectedEditPart.getEditPolicy(TabOrderContainerEditPolicy.TAB_CONTAINER_ROLE)).thenReturn(tabContainerRole);
-			when(viewer.getSelectedEditParts()).thenReturn(ImmutableList.of(selectedEditPart));
+			when(viewer.getSelectedEditParts()).thenReturn(List.of(selectedEditPart));
 		}
 		// check tool
 		assertTrue(entry.initialize(viewer, panel));

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/GenericsUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/GenericsUtilsTest.java
@@ -11,7 +11,6 @@
 package org.eclipse.wb.tests.designer.core.util;
 
 import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
 
 import org.eclipse.wb.internal.core.utils.GenericTypeError;
 import org.eclipse.wb.internal.core.utils.GenericTypeResolver;
@@ -31,6 +30,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -176,7 +176,7 @@ public class GenericsUtilsTest extends DesignerTestCase {
 	 */
 	@Test
 	public void test_get_fromList() throws Exception {
-		List<?> objects = ImmutableList.<Object>of("0", 1, 2.2);
+		List<?> objects = List.of("0", 1, 2.2);
 		assertEquals("0", GenericsUtils.get(String.class, objects));
 		assertEquals(Integer.valueOf(1), GenericsUtils.get(Integer.class, objects));
 		assertEquals(Double.valueOf(2.2), GenericsUtils.get(Double.class, objects));
@@ -287,7 +287,7 @@ public class GenericsUtilsTest extends DesignerTestCase {
 	 */
 	@Test
 	public void test_getPrevOrNull_index() throws Exception {
-		List<String> elements = ImmutableList.of("000", "111", "222");
+		List<String> elements = List.of("000", "111", "222");
 		assertSame(null, GenericsUtils.getPrevOrNull(elements, 0));
 		assertSame("000", GenericsUtils.getPrevOrNull(elements, 1));
 		assertSame("111", GenericsUtils.getPrevOrNull(elements, 2));
@@ -298,7 +298,7 @@ public class GenericsUtilsTest extends DesignerTestCase {
 	 */
 	@Test
 	public void test_getPrevOrNull_element() throws Exception {
-		List<String> elements = ImmutableList.of("000", "111", "222");
+		List<String> elements = List.of("000", "111", "222");
 		// use element
 		assertSame("000", GenericsUtils.getPrevOrNull(elements, "111"));
 		assertSame("111", GenericsUtils.getPrevOrNull(elements, "222"));
@@ -311,9 +311,9 @@ public class GenericsUtilsTest extends DesignerTestCase {
 	 */
 	@Test
 	public void test_getPrevOrLast_element() throws Exception {
-		List<String> elements = ImmutableList.of("000", "111", "222");
+		List<String> elements = List.of("000", "111", "222");
 		// no elements
-		assertNull(GenericsUtils.getPrevOrLast(ImmutableList.of(), "no matter"));
+		assertNull(GenericsUtils.getPrevOrLast(Collections.emptyList(), "no matter"));
 		// use element
 		assertSame("111", GenericsUtils.getPrevOrLast(elements, "222"));
 		assertSame("000", GenericsUtils.getPrevOrLast(elements, "111"));
@@ -331,7 +331,7 @@ public class GenericsUtilsTest extends DesignerTestCase {
 	 */
 	@Test
 	public void test_getNextOrNull_index() throws Exception {
-		List<String> elements = ImmutableList.of("000", "111", "222");
+		List<String> elements = List.of("000", "111", "222");
 		// use index
 		assertSame("111", GenericsUtils.getNextOrNull(elements, 0));
 		assertSame("222", GenericsUtils.getNextOrNull(elements, 1));
@@ -343,7 +343,7 @@ public class GenericsUtilsTest extends DesignerTestCase {
 	 */
 	@Test
 	public void test_getNextOrNull_element() throws Exception {
-		List<String> elements = ImmutableList.of("000", "111", "222");
+		List<String> elements = List.of("000", "111", "222");
 		// use element
 		assertSame("111", GenericsUtils.getNextOrNull(elements, "000"));
 		assertSame("222", GenericsUtils.getNextOrNull(elements, "111"));
@@ -356,9 +356,9 @@ public class GenericsUtilsTest extends DesignerTestCase {
 	 */
 	@Test
 	public void test_getNextOrFirst_element() throws Exception {
-		List<String> elements = ImmutableList.of("000", "111", "222");
+		List<String> elements = List.of("000", "111", "222");
 		// no elements
-		assertNull(GenericsUtils.getNextOrFirst(ImmutableList.of(), "no matter"));
+		assertNull(GenericsUtils.getNextOrFirst(Collections.emptyList(), "no matter"));
 		// use element
 		assertSame("111", GenericsUtils.getNextOrFirst(elements, "000"));
 		assertSame("222", GenericsUtils.getNextOrFirst(elements, "111"));
@@ -371,8 +371,8 @@ public class GenericsUtilsTest extends DesignerTestCase {
 	 */
 	@Test
 	public void test_getFirstOrNull() throws Exception {
-		assertNull(GenericsUtils.getFirstOrNull(ImmutableList.of()));
-		assertSame("000", GenericsUtils.getFirstOrNull(ImmutableList.of("000", "111", "222")));
+		assertNull(GenericsUtils.getFirstOrNull(Collections.emptyList()));
+		assertSame("000", GenericsUtils.getFirstOrNull(List.of("000", "111", "222")));
 	}
 
 	/**
@@ -380,8 +380,8 @@ public class GenericsUtilsTest extends DesignerTestCase {
 	 */
 	@Test
 	public void test_getLastOrNull() throws Exception {
-		assertNull(GenericsUtils.getLastOrNull(ImmutableList.of()));
-		assertSame("222", GenericsUtils.getLastOrNull(ImmutableList.of("000", "111", "222")));
+		assertNull(GenericsUtils.getLastOrNull(Collections.emptyList()));
+		assertSame("222", GenericsUtils.getLastOrNull(List.of("000", "111", "222")));
 	}
 
 	/**
@@ -390,11 +390,11 @@ public class GenericsUtilsTest extends DesignerTestCase {
 	@Test
 	public void test_getLast() throws Exception {
 		try {
-			assertNull(GenericsUtils.getLast(ImmutableList.of()));
+			assertNull(GenericsUtils.getLast(Collections.emptyList()));
 			fail();
 		} catch (IndexOutOfBoundsException e) {
 		}
-		assertSame("222", GenericsUtils.getLast(ImmutableList.of("000", "111", "222")));
+		assertSame("222", GenericsUtils.getLast(List.of("000", "111", "222")));
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -407,18 +407,18 @@ public class GenericsUtilsTest extends DesignerTestCase {
 	 */
 	@Test
 	public void test_areAdjacent() throws Exception {
-		assertTrue(GenericsUtils.areAdjacent(ImmutableList.of(), ImmutableList.of()));
-		assertTrue(GenericsUtils.areAdjacent(ImmutableList.of("a"), ImmutableList.of("a")));
-		assertTrue(GenericsUtils.areAdjacent(ImmutableList.of("a", "b", "c"), ImmutableList.of("a")));
+		assertTrue(GenericsUtils.areAdjacent(Collections.emptyList(), Collections.emptyList()));
+		assertTrue(GenericsUtils.areAdjacent(List.of("a"), List.of("a")));
+		assertTrue(GenericsUtils.areAdjacent(List.of("a", "b", "c"), List.of("a")));
 		assertTrue(GenericsUtils.areAdjacent(
-				ImmutableList.of("a", "b", "c"),
-				ImmutableList.of("a", "b")));
+				List.of("a", "b", "c"),
+				List.of("a", "b")));
 		assertTrue(GenericsUtils.areAdjacent(
-				ImmutableList.of("a", "b", "c"),
-				ImmutableList.of("b", "c")));
+				List.of("a", "b", "c"),
+				List.of("b", "c")));
 		assertFalse(GenericsUtils.areAdjacent(
-				ImmutableList.of("a", "b", "c"),
-				ImmutableList.of("a", "c")));
+				List.of("a", "b", "c"),
+				List.of("a", "c")));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/ast/AstEditorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/ast/AstEditorTest.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.util.ast;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.eval.ExecutionFlowDescription;
@@ -91,6 +90,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
@@ -1841,7 +1841,7 @@ public class AstEditorTest extends AbstractJavaTest {
 		//
 		BodyDeclarationTarget target = new BodyDeclarationTarget(null, targetField, true);
 		MethodDeclaration newMethod =
-				m_lastEditor.addMethodDeclaration("int foo()", ImmutableList.of("return 0;"), target);
+				m_lastEditor.addMethodDeclaration("int foo()", List.of("return 0;"), target);
 		assertAST(m_lastEditor);
 		assertNotNull(newMethod);
 		assertEquals(0, typeDeclaration.bodyDeclarations().indexOf(newMethod));
@@ -1871,7 +1871,7 @@ public class AstEditorTest extends AbstractJavaTest {
 						"}");
 		BodyDeclarationTarget target = new BodyDeclarationTarget(typeDeclaration, null, false);
 		//
-		m_lastEditor.addMethodDeclaration("int foo()", ImmutableList.of("return 0;"), target);
+		m_lastEditor.addMethodDeclaration("int foo()", List.of("return 0;"), target);
 		assertEditor(
 				getSource(
 						"package test;",
@@ -1898,7 +1898,7 @@ public class AstEditorTest extends AbstractJavaTest {
 		//
 		BodyDeclarationTarget target = new BodyDeclarationTarget(null, targetField, true);
 		MethodDeclaration newMethod =
-				m_lastEditor.addMethodDeclaration("int foo()", ImmutableList.of("\t", "return 0;"), target);
+				m_lastEditor.addMethodDeclaration("int foo()", List.of("\t", "return 0;"), target);
 		assertAST(m_lastEditor);
 		assertNotNull(newMethod);
 		assertEquals(0, typeDeclaration.bodyDeclarations().indexOf(newMethod));
@@ -1929,7 +1929,7 @@ public class AstEditorTest extends AbstractJavaTest {
 		MethodDeclaration newMethod =
 				m_lastEditor.addMethodDeclaration(
 						"void foo(int a, String b, String[] c)",
-						ImmutableList.<String>of(),
+						Collections.emptyList(),
 						target);
 		assertAST(m_lastEditor);
 		assertNotNull(newMethod);
@@ -1960,9 +1960,9 @@ public class AstEditorTest extends AbstractJavaTest {
 		BodyDeclarationTarget target = new BodyDeclarationTarget(typeDeclaration, true);
 		MethodDeclaration newMethod =
 				m_lastEditor.addMethodDeclaration(
-						ImmutableList.<String>of("@Override"),
+						List.of("@Override"),
 						"public void fooBar()",
-						ImmutableList.<String>of(),
+						Collections.emptyList(),
 						target);
 		assertNotNull(newMethod);
 		assertEquals(0, typeDeclaration.bodyDeclarations().indexOf(newMethod));
@@ -2021,7 +2021,7 @@ public class AstEditorTest extends AbstractJavaTest {
 						"}");
 		m_lastEditor.addMethodDeclaration(
 				"void testMethod()",
-				ImmutableList.<String>of(),
+				Collections.emptyList(),
 				new BodyDeclarationTarget(typeDeclaration, false));
 	}
 
@@ -2127,7 +2127,7 @@ public class AstEditorTest extends AbstractJavaTest {
 						"}");
 		m_lastEditor.addMethodDeclaration(
 				"void someTestMethod2(TestEnum testEnum)",
-				ImmutableList.<String>of(),
+				Collections.emptyList(),
 				new BodyDeclarationTarget(typeDeclaration, false));
 	}
 
@@ -2152,7 +2152,7 @@ public class AstEditorTest extends AbstractJavaTest {
 		try {
 			m_lastEditor.addMethodDeclaration(
 					"void foo()",
-					ImmutableList.of("somethingBadA();", "somethingBadB();"),
+					List.of("somethingBadA();", "somethingBadB();"),
 					new BodyDeclarationTarget(typeDeclaration, false));
 			fail();
 		} catch (Throwable e) {
@@ -2380,7 +2380,7 @@ public class AstEditorTest extends AbstractJavaTest {
 		//
 		BodyDeclarationTarget target = new BodyDeclarationTarget(typeDeclaration, null, true);
 		TypeDeclaration newType =
-				m_lastEditor.addTypeDeclaration(ImmutableList.of(
+				m_lastEditor.addTypeDeclaration(List.of(
 						"private class Inner {",
 						"\tint a;",
 						"\tint getA() {",
@@ -2426,7 +2426,7 @@ public class AstEditorTest extends AbstractJavaTest {
 		//
 		BodyDeclarationTarget target = new BodyDeclarationTarget(typeDeclaration, null, true);
 		TypeDeclaration newType =
-				m_lastEditor.addTypeDeclaration(ImmutableList.of(
+				m_lastEditor.addTypeDeclaration(List.of(
 						"private class Inner extends ArrayList {",
 						"\tInner() {",
 						"\t\tsuper(5);",
@@ -4110,7 +4110,7 @@ public class AstEditorTest extends AbstractJavaTest {
 				(VariableDeclarationFragment) statement.fragments().get(0);
 		ClassInstanceCreation creation = (ClassInstanceCreation) fragment.getInitializer();
 		// do replace
-		m_lastEditor.replaceCreationArguments(creation, ImmutableList.copyOf(newArgumentsLines));
+		m_lastEditor.replaceCreationArguments(creation, List.of(newArgumentsLines));
 		// check source
 		assertEditor(getSource(expectedSourceLines), m_lastEditor);
 		// check signature
@@ -4146,7 +4146,7 @@ public class AstEditorTest extends AbstractJavaTest {
 				"}");
 		MethodInvocation invocation = (MethodInvocation) m_lastEditor.getEnclosingNode(", ");
 		// do replace
-		m_lastEditor.replaceInvocationArguments(invocation, ImmutableList.of("2, true"));
+		m_lastEditor.replaceInvocationArguments(invocation, List.of("2, true"));
 		assertEditor(
 				getSourceDQ(
 						"public class Test {",
@@ -4177,7 +4177,7 @@ public class AstEditorTest extends AbstractJavaTest {
 				"}");
 		MethodInvocation invocation = (MethodInvocation) m_lastEditor.getEnclosingNode(", ");
 		// do replace
-		m_lastEditor.replaceInvocationArguments(invocation, ImmutableList.of("2, true"));
+		m_lastEditor.replaceInvocationArguments(invocation, List.of("2, true"));
 		assertEditor(
 				getSourceDQ(
 						"public class Test {",
@@ -4583,7 +4583,7 @@ public class AstEditorTest extends AbstractJavaTest {
 		Statement targetStatement = (Statement) targetMethod.getBody().statements().get(1);
 		//
 		m_lastEditor.addStatement(
-				ImmutableList.of("// first comment", "// second comment", "setVisible(false);"),
+				List.of("// first comment", "// second comment", "setVisible(false);"),
 				new StatementTarget(targetStatement, true));
 		assertEquals(
 				getSourceDQ(
@@ -7273,7 +7273,7 @@ public class AstEditorTest extends AbstractJavaTest {
 		Expression newExpression =
 				m_lastEditor.replaceExpression(
 						fragment.getInitializer(),
-						ImmutableList.of("new", "\tjava.util.ArrayList()"));
+						List.of("new", "\tjava.util.ArrayList()"));
 		assertSame(newExpression, fragment.getInitializer());
 		assertEditor(
 				getSourceDQ(
@@ -7399,7 +7399,7 @@ public class AstEditorTest extends AbstractJavaTest {
 		Expression expression = (Expression) getNode("new Object()");
 		m_lastEditor.replaceExpression(
 				expression,
-				ImmutableList.of("test2.Style.Orientation.HORIZONTAL"));
+				List.of("test2.Style.Orientation.HORIZONTAL"));
 		assertEditor(
 				getSource(
 						"// filler filler filler filler filler",

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/ast/AstNodeUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/ast/AstNodeUtilsTest.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.util.ast;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import static org.eclipse.wb.internal.core.utils.ast.AstNodeUtils.getMethodDeclarationSignature;
@@ -68,6 +67,7 @@ import org.junit.Test;
 
 import java.lang.reflect.TypeVariable;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -2365,7 +2365,7 @@ public class AstNodeUtilsTest extends AbstractJavaTest {
 		MethodDeclaration newMethod =
 				m_lastEditor.addMethodDeclaration(
 						"void bar()",
-						ImmutableList.<String>of(),
+						Collections.emptyList(),
 						new BodyDeclarationTarget(typeDeclaration, false));
 		// now new method
 		assertSame(newMethod, AstNodeUtils.getLocalMethodDeclaration(invocation));
@@ -3327,9 +3327,9 @@ public class AstNodeUtilsTest extends AbstractJavaTest {
 		MethodDeclaration[] methods = typeDeclaration.getMethods();
 		//
 		List<String> signatures =
-				AstNodeUtils.getMethodSignatures(ImmutableList.of(methods[0], methods[1]));
+				AstNodeUtils.getMethodSignatures(List.of(methods[0], methods[1]));
 		Assertions.assertThat(signatures).hasSize(2).isEqualTo(
-				ImmutableList.of("foo()", "bar(int,java.lang.String)"));
+				List.of("foo()", "bar(int,java.lang.String)"));
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -3844,9 +3844,9 @@ public class AstNodeUtilsTest extends AbstractJavaTest {
 		assertTrue(AstNodeUtils.isLiteral(qualifiedName));
 		assertFalse(AstNodeUtils.isLiteral(varNode));
 		// List checks
-		assertTrue(AstNodeUtils.areLiterals(ImmutableList.<Expression>of()));
-		assertTrue(AstNodeUtils.areLiterals(ImmutableList.of(booleanLiteral, numberLiteral)));
-		assertFalse(AstNodeUtils.areLiterals(ImmutableList.of(booleanLiteral, varNode)));
+		assertTrue(AstNodeUtils.areLiterals(Collections.emptyList()));
+		assertTrue(AstNodeUtils.areLiterals(List.of(booleanLiteral, numberLiteral)));
+		assertFalse(AstNodeUtils.areLiterals(List.of(booleanLiteral, varNode)));
 	}
 
 	/**

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/jdt/core/CodeUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/jdt/core/CodeUtilsTest.java
@@ -12,7 +12,6 @@ package org.eclipse.wb.tests.designer.core.util.jdt.core;
 
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
-import com.google.common.collect.ImmutableList;
 
 import org.eclipse.wb.internal.core.utils.ast.AstNodeUtils;
 import org.eclipse.wb.internal.core.utils.ast.DomGenerics;
@@ -1097,7 +1096,7 @@ public class CodeUtilsTest extends AbstractJavaTest {
 		IType aType = aUnit.getTypes()[0];
 		//
 		List<IMethod> methods =
-				CodeUtils.findMethods(aType, ImmutableList.of("foo()", "bar()", "baz()"));
+				CodeUtils.findMethods(aType, List.of("foo()", "bar()", "baz()"));
 		Assertions.assertThat(methods).hasSize(3);
 		assertEquals("foo", methods.get(0).getElementName());
 		assertEquals("bar", methods.get(1).getElementName());

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/reflect/ReflectionUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/reflect/ReflectionUtilsTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.util.reflect;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.internal.core.EnvironmentUtils;
 import org.eclipse.wb.internal.core.utils.check.AssertionFailedException;
 import org.eclipse.wb.internal.core.utils.exception.DesignerExceptionUtils;
@@ -796,10 +794,10 @@ public class ReflectionUtilsTest extends DesignerTestCase {
 			Method base = ReflectionUtils.getMethodBySignature(A.class, "foo(java.lang.Object)");
 			Method specific = ReflectionUtils.getMethodBySignature(A.class, "foo(java.lang.String)");
 			Method bar = ReflectionUtils.getMethodBySignature(A.class, "bar(java.lang.String)");
-			assertSame(specific, ReflectionUtils.getMostSpecific(ImmutableList.of(base, specific, bar)));
+			assertSame(specific, ReflectionUtils.getMostSpecific(List.of(base, specific, bar)));
 		}
 		{
-			assertSame(null, ReflectionUtils.getMostSpecific(ImmutableList.<Method>of()));
+			assertSame(null, ReflectionUtils.getMostSpecific(Collections.emptyList()));
 		}
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/ui/MenuIntersectorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/ui/MenuIntersectorTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.util.ui;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.internal.core.utils.ui.IActionSingleton;
 import org.eclipse.wb.internal.core.utils.ui.MenuIntersector;
 import org.eclipse.wb.tests.designer.tests.DesignerTestCase;
@@ -157,7 +155,7 @@ public class MenuIntersectorTest extends DesignerTestCase {
 		manager_2.add(action_2);
 		// merge
 		IMenuManager main = new MenuManager();
-		MenuIntersector.merge(main, ImmutableList.of(manager_1, manager_2));
+		MenuIntersector.merge(main, List.of(manager_1, manager_2));
 		// prepare single IAction that wraps two IAction's
 		IAction wrapperAction;
 		{
@@ -213,7 +211,7 @@ public class MenuIntersectorTest extends DesignerTestCase {
 		manager_2.add(action_2);
 		// merge
 		IMenuManager main = new MenuManager();
-		MenuIntersector.merge(main, ImmutableList.of(manager_1, manager_2));
+		MenuIntersector.merge(main, List.of(manager_1, manager_2));
 		// prepare single IAction that wraps two IAction's
 		IAction wrapperAction;
 		{

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/ComponentsTreePageTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/ComponentsTreePageTest.java
@@ -10,9 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.editor;
 
-import com.google.common.collect.ImmutableList;
-
-import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.broadcast.ObjectEventListener;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.internal.core.DesignerPlugin;
@@ -31,6 +28,9 @@ import org.eclipse.gef.commands.Command;
 import org.eclipse.jface.action.IAction;
 
 import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
 
 import javax.swing.JButton;
 
@@ -74,11 +74,11 @@ public class ComponentsTreePageTest extends SwingGefTest {
 		assertTreeSelectionModels();
 		assertSelectionModels();
 		// use broadcast to select
-		panel.getBroadcastObject().select(ImmutableList.of(button));
+		panel.getBroadcastObject().select(List.of(button));
 		assertTreeSelectionModels(button);
 		assertSelectionModels(button);
 		// set empty selection
-		panel.getBroadcastObject().select(ImmutableList.<ObjectInfo>of());
+		panel.getBroadcastObject().select(Collections.emptyList());
 		assertTreeSelectionModels();
 		assertSelectionModels();
 	}
@@ -106,14 +106,14 @@ public class ComponentsTreePageTest extends SwingGefTest {
 				// add new JButton
 				((FlowLayoutInfo) panel.getLayout()).add(newButton, null);
 				// use broadcast to select
-				panel.getBroadcastObject().select(ImmutableList.of(newButton));
+				panel.getBroadcastObject().select(List.of(newButton));
 			}
 		});
 		// assert selection
 		assertTreeSelectionModels(newButton);
 		assertSelectionModels(newButton);
 		// set empty selection
-		panel.getBroadcastObject().select(ImmutableList.<ObjectInfo>of());
+		panel.getBroadcastObject().select(Collections.emptyList());
 		assertTreeSelectionModels();
 		assertSelectionModels();
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/validator/AbstractLayoutRequestValidatorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/validator/AbstractLayoutRequestValidatorTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.editor.validator;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
@@ -25,6 +23,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+
+import java.util.List;
 
 /**
  * Abstract tests for {@link ILayoutRequestValidator}.
@@ -101,7 +101,7 @@ public abstract class AbstractLayoutRequestValidatorTest extends SwingModelTest 
 			EditPart host,
 			JavaInfo child) throws Exception {
 		JavaInfoMemento memento = JavaInfoMemento.createMemento(child);
-		PasteRequest request = new PasteRequest(ImmutableList.of(memento));
+		PasteRequest request = new PasteRequest(List.of(memento));
 		assertEquals(expected, validator.validatePasteRequest(host, request));
 	}
 
@@ -112,7 +112,7 @@ public abstract class AbstractLayoutRequestValidatorTest extends SwingModelTest 
 		EditPart editPart = createHost(child);
 
 		ChangeBoundsRequest request = new ChangeBoundsRequest();
-		request.setEditParts(ImmutableList.of(editPart));
+		request.setEditParts(List.of(editPart));
 		//
 		assertEquals(expected, validator.validateMoveRequest(host, request));
 		//
@@ -127,7 +127,7 @@ public abstract class AbstractLayoutRequestValidatorTest extends SwingModelTest 
 		EditPart editPart = createHost(child);
 
 		ChangeBoundsRequest request = new ChangeBoundsRequest();
-		request.setEditParts(ImmutableList.of(editPart));
+		request.setEditParts(List.of(editPart));
 		//
 		assertEquals(expected, validator.validateAddRequest(host, request));
 		//

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/forms/FormTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/forms/FormTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.rcp.model.forms;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.internal.core.model.menu.IMenuPopupInfo;
 import org.eclipse.wb.internal.rcp.model.forms.FormInfo;
 import org.eclipse.wb.internal.rcp.model.jface.action.ActionContainerInfo;
@@ -425,7 +423,7 @@ public class FormTest extends AbstractFormsTest {
 
 	private IAction getDecorateAction(FormInfo form) throws Exception {
 		IMenuManager manager = getDesignerMenuManager();
-		form.getBroadcastObject().addContextMenu(ImmutableList.of(form), form, manager);
+		form.getBroadcastObject().addContextMenu(List.of(form), form, manager);
 		IAction decorateAction = findChildAction(manager, "Decorate heading");
 		assertNotNull(decorateAction);
 		return decorateAction;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/forms/table/TableWrapLayoutSelectionActionsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/forms/table/TableWrapLayoutSelectionActionsTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.rcp.model.forms.table;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.rcp.model.forms.layout.table.TableWrapLayoutInfo;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
@@ -24,6 +22,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -73,7 +72,7 @@ public class TableWrapLayoutSelectionActionsTest extends AbstractFormsTest {
 		List<Object> actions;
 		{
 			actions = new ArrayList<>();
-			List<ObjectInfo> selectedObjects = ImmutableList.<ObjectInfo>of();
+			List<ObjectInfo> selectedObjects = Collections.emptyList();
 			shell.getBroadcastObject().addSelectionActions(selectedObjects, actions);
 		}
 		// no actions
@@ -101,7 +100,7 @@ public class TableWrapLayoutSelectionActionsTest extends AbstractFormsTest {
 		List<Object> actions;
 		{
 			actions = new ArrayList<>();
-			List<ObjectInfo> selectedObjects = ImmutableList.<ObjectInfo>of(button, shell);
+			List<ObjectInfo> selectedObjects = List.of(button, shell);
 			shell.getBroadcastObject().addSelectionActions(selectedObjects, actions);
 		}
 		// no actions
@@ -139,7 +138,7 @@ public class TableWrapLayoutSelectionActionsTest extends AbstractFormsTest {
 		// actions for "button"
 		{
 			List<Object> actions = new ArrayList<>();
-			List<ObjectInfo> selectedObjects = ImmutableList.<ObjectInfo>of(button);
+			List<ObjectInfo> selectedObjects = List.of(button);
 			shell.getBroadcastObject().addSelectionActions(selectedObjects, actions);
 			// check actions
 			hasAction(actions, "Left", true);
@@ -156,7 +155,7 @@ public class TableWrapLayoutSelectionActionsTest extends AbstractFormsTest {
 		// actions for "label", "button"
 		{
 			List<Object> actions = new ArrayList<>();
-			List<ObjectInfo> selectedObjects = ImmutableList.<ObjectInfo>of(label, button);
+			List<ObjectInfo> selectedObjects = List.of(label, button);
 			shell.getBroadcastObject().addSelectionActions(selectedObjects, actions);
 			// check actions
 			hasAction(actions, "Left", true);
@@ -194,7 +193,7 @@ public class TableWrapLayoutSelectionActionsTest extends AbstractFormsTest {
 		List<Object> actions;
 		{
 			actions = new ArrayList<>();
-			List<ObjectInfo> selectedObjects = ImmutableList.<ObjectInfo>of(button);
+			List<ObjectInfo> selectedObjects = List.of(button);
 			shell.getBroadcastObject().addSelectionActions(selectedObjects, actions);
 		}
 		// use "vertical grab" action
@@ -283,7 +282,7 @@ public class TableWrapLayoutSelectionActionsTest extends AbstractFormsTest {
 		List<Object> actions;
 		{
 			actions = new ArrayList<>();
-			List<ObjectInfo> selectedObjects = ImmutableList.<ObjectInfo>of(button);
+			List<ObjectInfo> selectedObjects = List.of(button);
 			shell.getBroadcastObject().addSelectionActions(selectedObjects, actions);
 		}
 		// set "right" alignment

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/ActionTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/ActionTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.rcp.model.jface;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.editor.palette.PaletteEventListener;
 import org.eclipse.wb.core.editor.palette.model.CategoryInfo;
 import org.eclipse.wb.core.editor.palette.model.EntryInfo;
@@ -215,7 +213,7 @@ public class ActionTest extends RcpModelTest {
 			ClassInstanceCreation actionCreation =
 					(ClassInstanceCreation) action.getCreationSupport().getNode();
 			Expression imageDescriptionExpression = (Expression) actionCreation.arguments().get(1);
-			m_lastEditor.replaceExpression(imageDescriptionExpression, ImmutableList.of(
+			m_lastEditor.replaceExpression(imageDescriptionExpression, List.of(
 					"org.eclipse.jface.resource.ImageDescriptor.createFromURL(",
 					"org.eclipse.core.runtime.Platform.getBundle(\"org.eclipse.ui\").getResource(\"/icons/full/etool16/delete_edit.png\"))"));
 		}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/layout/form/FormLayoutMoveSingleResizableTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/layout/form/FormLayoutMoveSingleResizableTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.rcp.model.layout.form;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.internal.core.gef.policy.snapping.PlacementInfo;
 import org.eclipse.wb.internal.swt.model.layout.form.FormLayoutInfo;
 import org.eclipse.wb.internal.swt.model.layout.form.FormLayoutInfoImplAutomatic;
@@ -25,6 +23,8 @@ import org.eclipse.draw2d.geometry.Rectangle;
 
 import org.junit.Ignore;
 import org.junit.Test;
+
+import java.util.List;
 
 /**
  * Tests for {@link FormLayoutInfoImplAutomatic}.
@@ -289,7 +289,7 @@ public class FormLayoutMoveSingleResizableTest extends RcpModelTest {
 		Rectangle controlBounds = control.getModelBounds();
 		impl.command_moveFreely(
 				new Rectangle(x, 0, controlBounds.width, controlBounds.height),
-				ImmutableList.of(control),
+				List.of(control),
 				control,
 				direction,
 				true);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/layout/form/FormLayoutMoveSingleWithBothSidesTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/layout/form/FormLayoutMoveSingleWithBothSidesTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.rcp.model.layout.form;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.internal.core.gef.policy.snapping.PlacementInfo;
 import org.eclipse.wb.internal.swt.model.layout.form.FormLayoutInfo;
 import org.eclipse.wb.internal.swt.model.layout.form.FormLayoutInfoImplAutomatic;
@@ -23,6 +21,8 @@ import org.eclipse.draw2d.geometry.Rectangle;
 
 import org.junit.Ignore;
 import org.junit.Test;
+
+import java.util.List;
 
 /**
  * Tests for {@link FormLayoutInfoImplAutomatic}.
@@ -496,7 +496,7 @@ public class FormLayoutMoveSingleWithBothSidesTest extends RcpModelTest {
 		Rectangle controlBounds = control.getModelBounds();
 		impl.command_moveFreely(
 				new Rectangle(x, 0, controlBounds.width, controlBounds.height),
-				ImmutableList.of(control),
+				List.of(control),
 				control,
 				direction,
 				true);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/layout/form/FormLayoutMoveSingleWithSingleSideTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/layout/form/FormLayoutMoveSingleWithSingleSideTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.rcp.model.layout.form;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.internal.core.gef.policy.snapping.PlacementInfo;
 import org.eclipse.wb.internal.swt.model.layout.form.FormLayoutInfo;
 import org.eclipse.wb.internal.swt.model.layout.form.FormLayoutInfoImplAutomatic;
@@ -23,6 +21,8 @@ import org.eclipse.draw2d.geometry.Rectangle;
 
 import org.junit.Ignore;
 import org.junit.Test;
+
+import java.util.List;
 
 /**
  * Tests for {@link FormLayoutInfoImplAutomatic}.
@@ -576,7 +576,7 @@ public class FormLayoutMoveSingleWithSingleSideTest extends RcpModelTest {
 		Rectangle controlBounds = control.getModelBounds();
 		impl.command_moveFreely(
 				new Rectangle(x, 0, controlBounds.width, controlBounds.height),
-				ImmutableList.of(control),
+				List.of(control),
 				control,
 				direction,
 				true);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/layout/form/gef/FormLayoutAlignmentTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/layout/form/gef/FormLayoutAlignmentTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.rcp.model.layout.form.gef;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
@@ -452,7 +450,7 @@ public class FormLayoutAlignmentTest extends RcpGefTest {
 		List<Object> actions;
 		{
 			actions = new ArrayList<>();
-			List<ObjectInfo> selectedObjects = ImmutableList.<ObjectInfo>copyOf(controls);
+			List<ObjectInfo> selectedObjects = List.of(controls);
 			shell.getBroadcastObject().addSelectionActions(selectedObjects, actions);
 		}
 		// run action

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/rcp/PdeUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/rcp/PdeUtilsTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.rcp.model.rcp;
 
-import com.google.common.collect.ImmutableMap;
-
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.utils.jdt.core.ProjectUtils;
 import org.eclipse.wb.internal.rcp.Activator;
@@ -438,7 +436,7 @@ public class PdeUtilsTest extends AbstractPdeTest {
 			m_utils.createExtensionElement(
 					pointId,
 					"view",
-					ImmutableMap.of("id", "id_2", "name", "name 2", "class", "C_2"));
+					Map.of("id", "id_2", "name", "name 2", "class", "C_2"));
 			element = m_utils.getExtensionElementById(pointId, "view", "id_2");
 		}
 		assertEquals("id_2", PdeUtils.getAttribute(element, "id"));
@@ -473,7 +471,7 @@ public class PdeUtilsTest extends AbstractPdeTest {
 			m_utils.createExtensionElement(
 					pointId,
 					"view",
-					ImmutableMap.of("id", "id_2", "name", "name 2", "class", "C_2"));
+					Map.of("id", "id_2", "name", "name 2", "class", "C_2"));
 			element = m_utils.waitExtensionElementById(pointId, "view", "id_2");
 			assertNotNull(element);
 		}
@@ -510,7 +508,7 @@ public class PdeUtilsTest extends AbstractPdeTest {
 			m_utils.createExtensionElement(
 					pointId,
 					"view",
-					ImmutableMap.of("id", "id_2", "name", "name 2", "class", "C_2"));
+					Map.of("id", "id_2", "name", "name 2", "class", "C_2"));
 			element = m_utils.waitExtensionElementById(pointId, "view", "id_2");
 		}
 		assertEquals("id_2", PdeUtils.getAttribute(element, "id"));
@@ -554,7 +552,7 @@ public class PdeUtilsTest extends AbstractPdeTest {
 						m_utils.createExtensionElement(
 								pointId,
 								"view",
-								ImmutableMap.of("id", "id_2", "name", "name 2", "class", "C_2"));
+								Map.of("id", "id_2", "name", "name 2", "class", "C_2"));
 					} catch (Throwable e) {
 						DesignerPlugin.log(e);
 					}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/util/SurroundSupportTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/util/SurroundSupportTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.rcp.model.util;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.gef.policy.layout.grid.IGridInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
@@ -45,6 +43,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -81,7 +80,7 @@ public class SurroundSupportTest extends RcpModelTest {
 						"}");
 		shell.refresh();
 		//
-		assertNoSurroundManager(shell, ImmutableList.<ObjectInfo>of());
+		assertNoSurroundManager(shell, Collections.emptyList());
 	}
 
 	/**
@@ -99,7 +98,7 @@ public class SurroundSupportTest extends RcpModelTest {
 		shell.refresh();
 		LayoutInfo layout = shell.getLayout();
 		//
-		assertNoSurroundManager(shell, ImmutableList.of(layout));
+		assertNoSurroundManager(shell, List.of(layout));
 	}
 
 	/**
@@ -120,7 +119,7 @@ public class SurroundSupportTest extends RcpModelTest {
 		shell.refresh();
 		ControlInfo button = shell.getChildrenControls().get(0);
 		//
-		assertNoSurroundManager(shell, ImmutableList.of(shell, button));
+		assertNoSurroundManager(shell, List.of(shell, button));
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -234,7 +233,7 @@ public class SurroundSupportTest extends RcpModelTest {
 		ControlInfo button_1 = shell.getChildrenControls().get(0);
 		ControlInfo button_3 = shell.getChildrenControls().get(2);
 		// can not surround
-		assertNoSurroundManager(button_3, ImmutableList.of(button_1, button_3));
+		assertNoSurroundManager(button_3, List.of(button_1, button_3));
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -662,7 +661,7 @@ public class SurroundSupportTest extends RcpModelTest {
 		ControlInfo button = getJavaInfoByName("getButton()");
 		assertNotNull(button);
 		// no surround
-		assertNoSurroundManager(button, ImmutableList.of(button));
+		assertNoSurroundManager(button, List.of(button));
 	}
 
 	/**
@@ -692,7 +691,7 @@ public class SurroundSupportTest extends RcpModelTest {
 		ControlInfo button_1 = buttons.get(0);
 		ControlInfo button_2 = buttons.get(2);
 		// no surround
-		assertNoSurroundManager(shell, ImmutableList.of(button_1, button_2));
+		assertNoSurroundManager(shell, List.of(button_1, button_2));
 	}
 
 	/**
@@ -1094,7 +1093,7 @@ public class SurroundSupportTest extends RcpModelTest {
 	 */
 	private static void runSurround(String actionText, ObjectInfo... objects) throws Exception {
 		assertFalse(objects.length == 0);
-		IMenuManager surroundManager = createSurroundManager(objects[0], ImmutableList.copyOf(objects));
+		IMenuManager surroundManager = createSurroundManager(objects[0], List.of(objects));
 		assertNotNull(surroundManager);
 		IAction surroundAction = findChildAction(surroundManager, actionText);
 		assertNotNull(surroundAction);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/widgets/CTabFolderTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/widgets/CTabFolderTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.rcp.model.widgets;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.broadcast.ObjectEventListener;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
@@ -144,7 +142,7 @@ public class CTabFolderTest extends RcpModelTest {
 		// check tree/graphical children
 		Assertions.assertThat(tabFolder.getPresentation().getChildrenTree()).containsOnly(item_1, item_2);
 		Assertions.assertThat(tabFolder.getPresentation().getChildrenGraphical()).isEqualTo(
-				ImmutableList.of(item_1, item_2));
+				List.of(item_1, item_2));
 	}
 
 	/**

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/bean/ActionTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/bean/ActionTest.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.swing.model.bean;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.editor.palette.PaletteEventListener;
@@ -1651,7 +1650,7 @@ public class ActionTest extends SwingModelTest {
 		panel.refresh();
 		// no "Set Action" expected
 		MenuManager designerMenu = getDesignerMenuManager();
-		panel.getBroadcastObject().addContextMenu(ImmutableList.of(panel), panel, designerMenu);
+		panel.getBroadcastObject().addContextMenu(List.of(panel), panel, designerMenu);
 		IMenuManager actionsMenu = findChildMenuManager(designerMenu, "Set Action");
 		assertNull(actionsMenu);
 	}
@@ -1680,7 +1679,7 @@ public class ActionTest extends SwingModelTest {
 		IAction runnable;
 		{
 			MenuManager designerMenu = getDesignerMenuManager();
-			panel.getBroadcastObject().addContextMenu(ImmutableList.of(button), button, designerMenu);
+			panel.getBroadcastObject().addContextMenu(List.of(button), button, designerMenu);
 			IMenuManager actionsMenu = findChildMenuManager(designerMenu, "Set Action");
 			runnable = findChildAction(actionsMenu, "m_action");
 			assertNotNull(runnable);
@@ -1730,7 +1729,7 @@ public class ActionTest extends SwingModelTest {
 		{
 			MenuManager designerMenu = getDesignerMenuManager();
 			panel.getBroadcastObject().addContextMenu(
-					ImmutableList.of(button_1, button_2),
+					List.of(button_1, button_2),
 					button_2,
 					designerMenu);
 			IMenuManager actionsMenu = findChildMenuManager(designerMenu, "Set Action");
@@ -1746,7 +1745,7 @@ public class ActionTest extends SwingModelTest {
 		{
 			MenuManager designerMenu = getDesignerMenuManager();
 			panel.getBroadcastObject().addContextMenu(
-					ImmutableList.of(button_1, button_2),
+					List.of(button_1, button_2),
 					button_1,
 					designerMenu);
 			IMenuManager actionsMenu = findChildMenuManager(designerMenu, "Set Action");
@@ -1798,7 +1797,7 @@ public class ActionTest extends SwingModelTest {
 		// do exclude
 		{
 			MenuManager designerMenu = getDesignerMenuManager();
-			panel.getBroadcastObject().addContextMenu(ImmutableList.of(button), button, designerMenu);
+			panel.getBroadcastObject().addContextMenu(List.of(button), button, designerMenu);
 			IMenuManager actionsMenu = findChildMenuManager(designerMenu, "Set Action");
 			IAction runnable = findChildAction(actionsMenu, "None");
 			runnable.run();
@@ -1838,7 +1837,7 @@ public class ActionTest extends SwingModelTest {
 		IAction runnable;
 		{
 			MenuManager designerMenu = getDesignerMenuManager();
-			panel.getBroadcastObject().addContextMenu(ImmutableList.of(button), button, designerMenu);
+			panel.getBroadcastObject().addContextMenu(List.of(button), button, designerMenu);
 			IMenuManager actionsMenu = findChildMenuManager(designerMenu, "Set Action");
 			runnable = findChildAction(actionsMenu, "New...");
 			assertNotNull(runnable);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/bean/ButtonGroupTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/bean/ButtonGroupTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.swing.model.bean;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.model.ObjectReferenceInfo;
 import org.eclipse.wb.internal.swing.model.bean.ButtonGroupContainerInfo;
@@ -451,7 +449,7 @@ public class ButtonGroupTest extends SwingModelTest {
 		{
 			MenuManager designerMenu = getDesignerMenuManager();
 			panel.getBroadcastObject().addContextMenu(
-					ImmutableList.of(button_1, button_2),
+					List.of(button_1, button_2),
 					button_2,
 					designerMenu);
 			IMenuManager groupsMenu = findChildMenuManager(designerMenu, "Set ButtonGroup");

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/JLayeredPaneTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/JLayeredPaneTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.swing.model.component;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.model.presentation.IObjectPresentation;
 import org.eclipse.wb.internal.core.model.property.Property;
@@ -302,6 +300,6 @@ public class JLayeredPaneTest extends SwingModelTest {
 		//
 		IObjectPresentation presentation = pane.getPresentation();
 		List<ObjectInfo> graphical = presentation.getChildrenGraphical();
-		Assertions.assertThat(graphical).isEqualTo(ImmutableList.of(button_2, button_3, button_1));
+		Assertions.assertThat(graphical).isEqualTo(List.of(button_2, button_3, button_1));
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/JTableTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/JTableTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.swing.model.component;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 import org.eclipse.wb.internal.swing.model.component.JTableInfo;
@@ -584,7 +582,7 @@ public class JTableTest extends SwingModelTest {
 		{
 			List<String> invocations = modelDescription.getColumnModelInvocations();
 			Assertions.assertThat(invocations).isEqualTo(
-					ImmutableList.of(
+					List.of(
 							"getColumnModel().getColumn(0).setResizable(false)",
 							"getColumnModel().getColumn(0).setPreferredWidth(100)",
 							"getColumnModel().getColumn(0).setMinWidth(50)",

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/menu/JMenuBarTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/menu/JMenuBarTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.swing.model.component.menu;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.association.RootAssociation;
 import org.eclipse.wb.internal.core.model.clipboard.JavaInfoMemento;
@@ -426,7 +424,7 @@ public class JMenuBarTest extends SwingModelTest {
 		// paste copy of "existingMenu"
 		{
 			JavaInfoMemento memento = JavaInfoMemento.createMemento(existingMenuInfo);
-			List<JavaInfoMemento> mementos = ImmutableList.of(memento);
+			List<JavaInfoMemento> mementos = List.of(memento);
 			assertTrue(policy.validatePaste(mementos));
 			policy.commandPaste(mementos, null);
 		}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/menu/JMenuTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/menu/JMenuTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.swing.model.component.menu;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.association.InvocationVoidAssociation;
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
@@ -557,7 +555,7 @@ public class JMenuTest extends SwingModelTest {
 		// paste copy of "existingItemInfo"
 		{
 			JavaInfoMemento memento = JavaInfoMemento.createMemento(existingItemInfo);
-			List<JavaInfoMemento> mementos = ImmutableList.of(memento);
+			List<JavaInfoMemento> mementos = List.of(memento);
 			assertTrue(policy.validatePaste(mementos));
 			policy.commandPaste(mementos, null);
 		}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/FormLayout/FormLayoutTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/FormLayout/FormLayoutTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.swing.model.layout.FormLayout;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.gef.policy.layout.grid.IGridInfo;
 import org.eclipse.wb.core.model.association.InvocationChildAssociation;
 import org.eclipse.wb.internal.core.model.clipboard.JavaInfoMemento;
@@ -245,7 +243,7 @@ public class FormLayoutTest extends AbstractFormLayoutTest {
 						"}");
 		// check for actions
 		MenuManager menuManager = getDesignerMenuManager();
-		panel.getBroadcastObject().addContextMenu(ImmutableList.of(panel), panel, menuManager);
+		panel.getBroadcastObject().addContextMenu(List.of(panel), panel, menuManager);
 		assertNotNull(findChildAction(menuManager, "Edit c&olumns..."));
 		assertNotNull(findChildAction(menuManager, "Edit &rows..."));
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/MigLayout/MigLayoutConstraintsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/MigLayout/MigLayoutConstraintsTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.swing.model.layout.MigLayout;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.association.InvocationChildAssociation;
 import org.eclipse.wb.internal.core.utils.ast.DomGenerics;
 import org.eclipse.wb.internal.core.utils.state.GlobalState;
@@ -1128,7 +1126,7 @@ public class MigLayoutConstraintsTest extends AbstractMigLayoutTest {
 		IMenuManager alignmentManager;
 		{
 			MenuManager contextMenu = getDesignerMenuManager();
-			panel.getBroadcastObject().addContextMenu(ImmutableList.of(button), button, contextMenu);
+			panel.getBroadcastObject().addContextMenu(List.of(button), button, contextMenu);
 			alignmentManager = findChildMenuManager(contextMenu, managerText);
 			assertNotNull(alignmentManager);
 		}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/MigLayout/MigLayoutSelectionActionsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/MigLayout/MigLayoutSelectionActionsTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.swing.model.layout.MigLayout;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.swing.FormLayout.model.FormLayoutInfo;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
@@ -23,6 +21,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -59,7 +58,7 @@ public class MigLayoutSelectionActionsTest extends AbstractMigLayoutTest {
 		ComponentInfo button = panel.getChildrenComponents().get(0);
 		// prepare actions
 		List<Object> actions = new ArrayList<>();
-		panel.getBroadcastObject().addSelectionActions(ImmutableList.<ObjectInfo>of(button), actions);
+		panel.getBroadcastObject().addSelectionActions(List.of(button), actions);
 		// check actions: 13 action's, 2 separator's
 		assertEquals(15, actions.size());
 		assertNotNull(findAction(actions, "Default"));
@@ -86,7 +85,7 @@ public class MigLayoutSelectionActionsTest extends AbstractMigLayoutTest {
 		panel.refresh();
 		// prepare actions
 		List<Object> actions = new ArrayList<>();
-		panel.getBroadcastObject().addSelectionActions(ImmutableList.<ObjectInfo>of(), actions);
+		panel.getBroadcastObject().addSelectionActions(Collections.emptyList(), actions);
 		// no selection, so no actions
 		Assertions.assertThat(actions).isEmpty();
 	}
@@ -103,7 +102,7 @@ public class MigLayoutSelectionActionsTest extends AbstractMigLayoutTest {
 		panel.refresh();
 		// prepare actions
 		List<Object> actions = new ArrayList<>();
-		List<ObjectInfo> selectedObjects = ImmutableList.<ObjectInfo>of(panel.getLayout());
+		List<ObjectInfo> selectedObjects = List.of(panel.getLayout());
 		panel.getBroadcastObject().addSelectionActions(selectedObjects, actions);
 		// not Component on MigLayout selected, so no actions
 		Assertions.assertThat(actions).isEmpty();
@@ -123,7 +122,7 @@ public class MigLayoutSelectionActionsTest extends AbstractMigLayoutTest {
 		ComponentInfo button = panel.getChildrenComponents().get(0);
 		// prepare actions
 		List<Object> actions = new ArrayList<>();
-		panel.getBroadcastObject().addSelectionActions(ImmutableList.<ObjectInfo>of(button), actions);
+		panel.getBroadcastObject().addSelectionActions(List.of(button), actions);
 		// "Leading" should be checked
 		{
 			IAction leadingAction = findAction(actions, "Leading");
@@ -158,7 +157,7 @@ public class MigLayoutSelectionActionsTest extends AbstractMigLayoutTest {
 		ComponentInfo button = panel.getChildrenComponents().get(0);
 		// prepare actions
 		List<Object> actions = new ArrayList<>();
-		panel.getBroadcastObject().addSelectionActions(ImmutableList.<ObjectInfo>of(button), actions);
+		panel.getBroadcastObject().addSelectionActions(List.of(button), actions);
 		// "Top" should be checked
 		{
 			IAction topAction = findAction(actions, "Top");

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/MigLayout/MigLayoutSurroundSupportTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/MigLayout/MigLayoutSurroundSupportTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.swing.model.layout.MigLayout;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.utils.ui.MenuIntersector;
 import org.eclipse.wb.internal.swing.MigLayout.model.MigLayoutSurroundProcessor;
@@ -81,7 +79,7 @@ public class MigLayoutSurroundSupportTest extends AbstractMigLayoutTest {
 		ComponentInfo button_00 = getButtons(panel).get(0);
 		ComponentInfo button_11 = getButtons(panel).get(2);
 		// no surround
-		assertNoSurroundManager(panel, ImmutableList.of(button_00, button_11));
+		assertNoSurroundManager(panel, List.of(button_00, button_11));
 	}
 
 	/**
@@ -321,7 +319,7 @@ public class MigLayoutSurroundSupportTest extends AbstractMigLayoutTest {
 	private static IAction getSurroundAction(String actionText, ObjectInfo... objects)
 			throws Exception {
 		assertFalse(objects.length == 0);
-		IMenuManager surroundManager = createSurroundManager(objects[0], ImmutableList.copyOf(objects));
+		IMenuManager surroundManager = createSurroundManager(objects[0], List.of(objects));
 		assertNotNull(surroundManager);
 		return findChildAction(surroundManager, actionText);
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/MigLayout/MigLayoutTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/MigLayout/MigLayoutTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.swing.model.layout.MigLayout;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.gef.policy.layout.grid.IGridInfo;
 import org.eclipse.wb.internal.core.model.creation.ConstructorCreationSupport;
 import org.eclipse.wb.internal.core.model.property.Property;
@@ -103,7 +101,7 @@ public class MigLayoutTest extends AbstractMigLayoutTest {
 		IMenuManager layoutManager;
 		{
 			MenuManager menuManager = getDesignerMenuManager();
-			panel.getBroadcastObject().addContextMenu(ImmutableList.of(panel), panel, menuManager);
+			panel.getBroadcastObject().addContextMenu(List.of(panel), panel, menuManager);
 			layoutManager = findChildMenuManager(menuManager, "Set layout");
 			assertNotNull(layoutManager);
 		}
@@ -1972,11 +1970,11 @@ public class MigLayoutTest extends AbstractMigLayoutTest {
 		ComponentInfo button_4 = panel.getChildrenComponents().get(3);
 		ComponentInfo button_5 = panel.getChildrenComponents().get(4);
 		//
-		Assertions.assertThat(layout.getCellComponents(0, 0)).isEqualTo(ImmutableList.of(button_1, button_2));
-		Assertions.assertThat(layout.getCellComponents(1, 0)).isEqualTo(ImmutableList.of(button_3));
-		Assertions.assertThat(layout.getCellComponents(1, 1)).isEqualTo(ImmutableList.of(button_4));
-		Assertions.assertThat(layout.getCellComponents(0, 2)).isEqualTo(ImmutableList.of(button_5));
-		Assertions.assertThat(layout.getCellComponents(1, 2)).isEqualTo(ImmutableList.of(button_5));
+		Assertions.assertThat(layout.getCellComponents(0, 0)).isEqualTo(List.of(button_1, button_2));
+		Assertions.assertThat(layout.getCellComponents(1, 0)).isEqualTo(List.of(button_3));
+		Assertions.assertThat(layout.getCellComponents(1, 1)).isEqualTo(List.of(button_4));
+		Assertions.assertThat(layout.getCellComponents(0, 2)).isEqualTo(List.of(button_5));
+		Assertions.assertThat(layout.getCellComponents(1, 2)).isEqualTo(List.of(button_5));
 		Assertions.assertThat(layout.getCellComponents(2, 2)).isEmpty();
 	}
 
@@ -3093,7 +3091,7 @@ public class MigLayoutTest extends AbstractMigLayoutTest {
 						"}");
 		// check for actions
 		MenuManager menuManager = getDesignerMenuManager();
-		panel.getBroadcastObject().addContextMenu(ImmutableList.of(panel), panel, menuManager);
+		panel.getBroadcastObject().addContextMenu(List.of(panel), panel, menuManager);
 		assertNotNull(findChildAction(menuManager, "Edit c&olumns..."));
 		assertNotNull(findChildAction(menuManager, "Edit &rows..."));
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/gbl/GridBagConstraintsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/gbl/GridBagConstraintsTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.swing.model.layout.gbl;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.gef.policy.layout.grid.IGridInfo;
 import org.eclipse.wb.core.model.association.Association;
 import org.eclipse.wb.core.model.association.EmptyAssociation;
@@ -52,6 +50,7 @@ import org.junit.Test;
 
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
+import java.util.List;
 
 /**
  * Test for {@link GridBagConstraintsInfo}.
@@ -1212,7 +1211,7 @@ public class GridBagConstraintsTest extends AbstractGridBagLayoutTest {
 		IMenuManager alignmentManager;
 		{
 			MenuManager contextMenu = getDesignerMenuManager();
-			panel.getBroadcastObject().addContextMenu(ImmutableList.of(button), button, contextMenu);
+			panel.getBroadcastObject().addContextMenu(List.of(button), button, contextMenu);
 			alignmentManager = findChildMenuManager(contextMenu, managerText);
 			assertNotNull(alignmentManager);
 		}
@@ -1275,7 +1274,7 @@ public class GridBagConstraintsTest extends AbstractGridBagLayoutTest {
 		IMenuManager alignmentManager;
 		{
 			MenuManager contextMenu = getDesignerMenuManager();
-			panel.getBroadcastObject().addContextMenu(ImmutableList.of(button), button, contextMenu);
+			panel.getBroadcastObject().addContextMenu(List.of(button), button, contextMenu);
 			alignmentManager = findChildMenuManager(contextMenu, "Horizontal alignment");
 			assertNotNull(alignmentManager);
 		}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/gbl/GridBagLayoutSurroundSupportTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/gbl/GridBagLayoutSurroundSupportTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.swing.model.layout.gbl;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 import org.eclipse.wb.internal.swing.model.layout.gbl.GridBagConstraintsInfo;
@@ -19,6 +17,8 @@ import org.eclipse.wb.internal.swing.model.layout.gbl.GridBagLayoutInfo;
 import org.eclipse.wb.tests.designer.swing.model.util.SurroundSupportTest;
 
 import org.junit.Test;
+
+import java.util.List;
 
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
@@ -81,7 +81,7 @@ public class GridBagLayoutSurroundSupportTest extends AbstractGridBagLayoutTest 
 		ComponentInfo button_00 = getJavaInfoByName("button_00");
 		ComponentInfo button_11 = getJavaInfoByName("button_11");
 		// no surround
-		SurroundSupportTest.assertNoSurroundManager(panel, ImmutableList.of(button_00, button_11));
+		SurroundSupportTest.assertNoSurroundManager(panel, List.of(button_00, button_11));
 	}
 
 	/**

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/util/SurroundSupportTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/util/SurroundSupportTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.swing.model.util;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.utils.jdt.core.CodeUtils;
 import org.eclipse.wb.internal.core.utils.ui.MenuIntersector;
@@ -36,6 +34,7 @@ import org.junit.Test;
 import org.osgi.framework.Bundle;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import javax.swing.JButton;
@@ -79,7 +78,7 @@ public class SurroundSupportTest extends SwingModelTest {
 						"}");
 		panel.refresh();
 		//
-		assertNoSurroundManager(panel, ImmutableList.<ObjectInfo>of());
+		assertNoSurroundManager(panel, Collections.emptyList());
 	}
 
 	/**
@@ -97,7 +96,7 @@ public class SurroundSupportTest extends SwingModelTest {
 		panel.refresh();
 		LayoutInfo layout = panel.getLayout();
 		//
-		assertNoSurroundManager(panel, ImmutableList.of(layout));
+		assertNoSurroundManager(panel, List.of(layout));
 	}
 
 	/**
@@ -119,7 +118,7 @@ public class SurroundSupportTest extends SwingModelTest {
 		panel.refresh();
 		ComponentInfo button = panel.getChildrenComponents().get(0);
 		//
-		assertNoSurroundManager(panel, ImmutableList.of(panel, button));
+		assertNoSurroundManager(panel, List.of(panel, button));
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -274,7 +273,7 @@ public class SurroundSupportTest extends SwingModelTest {
 		ComponentInfo button_1 = panel.getChildrenComponents().get(0);
 		ComponentInfo button_3 = panel.getChildrenComponents().get(2);
 		// can not surround
-		assertNoSurroundManager(button_3, ImmutableList.of(button_1, button_3));
+		assertNoSurroundManager(button_3, List.of(button_1, button_3));
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -732,7 +731,7 @@ public class SurroundSupportTest extends SwingModelTest {
 		ComponentInfo button_22 = getButtons(panel).get(0);
 		ComponentInfo button_44 = getButtons(panel).get(2);
 		// no surround
-		assertNoSurroundManager(panel, ImmutableList.of(button_22, button_44));
+		assertNoSurroundManager(panel, List.of(button_22, button_44));
 	}
 
 	/**
@@ -1070,7 +1069,7 @@ public class SurroundSupportTest extends SwingModelTest {
 	private static IAction getSurroundAction(String actionText, ObjectInfo... objects)
 			throws Exception {
 		assertFalse(objects.length == 0);
-		IMenuManager surroundManager = createSurroundManager(objects[0], ImmutableList.copyOf(objects));
+		IMenuManager surroundManager = createSurroundManager(objects[0], List.of(objects));
 		assertNotNull(surroundManager);
 		return findChildAction(surroundManager, actionText);
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuBarPopupTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuBarPopupTest.java
@@ -11,7 +11,6 @@
 package org.eclipse.wb.tests.designer.swt.model.menu;
 
 import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
 
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.tools.PasteTool;
@@ -24,6 +23,8 @@ import org.eclipse.wb.tests.designer.rcp.RcpGefTest;
 
 import org.junit.Ignore;
 import org.junit.Test;
+
+import java.util.List;
 
 /**
  * Tests for "bar" and "popup" menu, create/move them.
@@ -231,7 +232,7 @@ public class MenuBarPopupTest extends RcpGefTest {
 		// load "paste" tool
 		{
 			JavaInfoMemento memento = JavaInfoMemento.createMemento(popupInfo);
-			PasteTool pasteTool = new PasteTool(ImmutableList.of(memento));
+			PasteTool pasteTool = new PasteTool(List.of(memento));
 			m_viewerCanvas.getEditDomain().setActiveTool(pasteTool);
 		}
 		// move on "button_2": target feedback

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuComplexTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuComplexTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.swt.model.menu;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.draw2d.IPositionConstants;
 import org.eclipse.wb.gef.core.EditPart;
@@ -28,6 +26,8 @@ import org.eclipse.wb.tests.designer.rcp.RcpGefTest;
 import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import java.util.List;
 
 /**
  * Tests for "popup" with several item's, sub-menu's, etc.
@@ -794,7 +794,7 @@ public class MenuComplexTest extends RcpGefTest {
 		// load "paste" tool
 		{
 			JavaInfoMemento memento = JavaInfoMemento.createMemento(itemInfo);
-			PasteTool pasteTool = new PasteTool(ImmutableList.of(memento));
+			PasteTool pasteTool = new PasteTool(List.of(memento));
 			m_viewerCanvas.getEditDomain().setActiveTool(pasteTool);
 		}
 		// move before "item": add before feedback
@@ -843,7 +843,7 @@ public class MenuComplexTest extends RcpGefTest {
 		// load "paste" tool
 		{
 			JavaInfoMemento memento = JavaInfoMemento.createMemento(buttonInfo);
-			PasteTool pasteTool = new PasteTool(ImmutableList.of(memento));
+			PasteTool pasteTool = new PasteTool(List.of(memento));
 			m_viewerCanvas.getEditDomain().setActiveTool(pasteTool);
 		}
 		// move on "bar"
@@ -890,7 +890,7 @@ public class MenuComplexTest extends RcpGefTest {
 		// load "paste" tool
 		{
 			JavaInfoMemento memento = JavaInfoMemento.createMemento(buttonInfo);
-			PasteTool pasteTool = new PasteTool(ImmutableList.of(memento));
+			PasteTool pasteTool = new PasteTool(List.of(memento));
 			m_viewerCanvas.getEditDomain().setActiveTool(pasteTool);
 		}
 		// initially "popup" has no drop-down

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuObjectInfoUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuObjectInfoUtilsTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.swt.model.menu;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.internal.core.model.menu.IMenuInfo;
 import org.eclipse.wb.internal.core.model.menu.IMenuItemInfo;
 import org.eclipse.wb.internal.core.model.menu.IMenuObjectInfo;
@@ -444,7 +442,7 @@ public class MenuObjectInfoUtilsTest extends DesignerTestCase {
 		IMenuItemInfo item_1 = mock(IMenuItemInfo.class);
 		IMenuItemInfo item_2 = mock(IMenuItemInfo.class);
 		IMenuItemInfo item_3 = mock(IMenuItemInfo.class);
-		List<IMenuItemInfo> items = ImmutableList.of(item_1, item_2, item_3);
+		List<IMenuItemInfo> items = List.of(item_1, item_2, item_3);
 		// prepare scenario
 		when(menu.getItems()).thenReturn(items);
 		when(item_1.getMenu()).thenReturn(null);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/tests/DesignerTestCase.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/tests/DesignerTestCase.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.tests;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.EnvironmentUtils;
@@ -66,6 +64,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -598,7 +597,7 @@ public abstract class DesignerTestCase extends Assert {
 	 */
 	public static IMenuManager getContextMenu(ObjectInfo... objectsArray) throws Exception {
 		IMenuManager manager = getDesignerMenuManager();
-		List<ObjectInfo> objects = ImmutableList.copyOf(objectsArray);
+		List<ObjectInfo> objects = List.of(objectsArray);
 		ObjectInfo object = objectsArray[0];
 		object.getBroadcastObject().addContextMenu(objects, object, manager);
 		return manager;
@@ -609,7 +608,7 @@ public abstract class DesignerTestCase extends Assert {
 	 */
 	public static List<Object> getSelectionActions_noSelection(ObjectInfo root) throws Exception {
 		List<Object> actions = new ArrayList<>();
-		ImmutableList<ObjectInfo> objects = ImmutableList.<ObjectInfo>of();
+		List<ObjectInfo> objects = Collections.emptyList();
 		root.getBroadcastObject().addSelectionActions(objects, actions);
 		return actions;
 	}
@@ -621,7 +620,7 @@ public abstract class DesignerTestCase extends Assert {
 		List<Object> actions = new ArrayList<>();
 		if (objectsArray.length != 0) {
 			ObjectInfo object = objectsArray[0];
-			List<ObjectInfo> objects = ImmutableList.copyOf(objectsArray);
+			List<ObjectInfo> objects = List.of(objectsArray);
 			object.getBroadcastObject().addSelectionActions(objects, actions);
 		}
 		return actions;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/GraphicalRobot.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/GraphicalRobot.java
@@ -11,7 +11,6 @@
 package org.eclipse.wb.tests.gef;
 
 import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
 
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
@@ -134,7 +133,7 @@ public final class GraphicalRobot {
 	 */
 	public void select(Object... models) {
 		EditPart[] editParts = getEditParts(models);
-		m_viewer.setSelection(ImmutableList.copyOf(editParts));
+		m_viewer.setSelection(List.of(editParts));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/TreeRobot.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/TreeRobot.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.gef;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.tools.Tool;
@@ -224,7 +222,7 @@ public final class TreeRobot {
 	public TreeRobot select(Object... models) {
 		TreeEditPart[] editParts = getEditParts(models);
 		m_justSelectedEditParts = editParts;
-		m_viewer.setSelection(ImmutableList.<EditPart>copyOf(editParts));
+		m_viewer.setSelection(List.of(editParts));
 		DesignerTestCase.waitEventLoop(100, 0);
 		return this;
 	}

--- a/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/gef/EditPartFactory.java
+++ b/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/gef/EditPartFactory.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.xwt.gef;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.gef.MatchingEditPartFactory;
 import org.eclipse.wb.core.gef.part.menu.MenuEditPartFactory;
 import org.eclipse.wb.gef.core.EditPart;
@@ -24,6 +22,8 @@ import org.eclipse.wb.internal.core.model.menu.MenuObjectInfoUtils;
 import org.eclipse.wb.internal.xwt.model.widgets.menu.MenuInfo;
 import org.eclipse.wb.internal.xwt.model.widgets.menu.MenuItemInfo;
 
+import java.util.List;
+
 /**
  * {@link IEditPartFactory} for XWT.
  *
@@ -32,11 +32,11 @@ import org.eclipse.wb.internal.xwt.model.widgets.menu.MenuItemInfo;
  */
 public final class EditPartFactory implements IEditPartFactory {
 	private final static IEditPartFactory MATCHING_FACTORY =
-			new MatchingEditPartFactory(ImmutableList.of(
+			new MatchingEditPartFactory(List.of(
 					"org.eclipse.wb.internal.xwt.model.widgets",
 					"org.eclipse.wb.internal.xwt.model.widgets",
 					"org.eclipse.wb.internal.xwt.model.jface",
-					"org.eclipse.wb.internal.xwt.model.forms"), ImmutableList.of(
+					"org.eclipse.wb.internal.xwt.model.forms"), List.of(
 							"org.eclipse.wb.internal.xwt.gef.part",
 							"org.eclipse.wb.internal.rcp.gef.part.widgets",
 							"org.eclipse.wb.internal.xwt.gef.part",

--- a/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/gefTree/EditPartFactory.java
+++ b/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/gefTree/EditPartFactory.java
@@ -10,11 +10,11 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.xwt.gefTree;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.gef.MatchingEditPartFactory;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartFactory;
+
+import java.util.List;
 
 /**
  * {@link IEditPartFactory} for XWT.
@@ -24,8 +24,8 @@ import org.eclipse.wb.gef.core.IEditPartFactory;
  */
 public final class EditPartFactory implements IEditPartFactory {
 	private final static IEditPartFactory MATCHING_FACTORY =
-			new MatchingEditPartFactory(ImmutableList.of("org.eclipse.wb.internal.xwt.model.widgets"),
-					ImmutableList.of("org.eclipse.wb.internal.xwt.gefTree.part"));
+			new MatchingEditPartFactory(List.of("org.eclipse.wb.internal.xwt.model.widgets"),
+					List.of("org.eclipse.wb.internal.xwt.gefTree.part"));
 
 	////////////////////////////////////////////////////////////////////////////
 	//

--- a/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/property/event/XwtListenerProperty.java
+++ b/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/property/event/XwtListenerProperty.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.xwt.model.property.event;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.editor.IContextMenuConstants;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.model.property.Property;
@@ -41,6 +39,8 @@ import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.texteditor.ITextEditor;
 
 import org.apache.commons.lang.StringUtils;
+
+import java.util.Collections;
 
 /**
  * {@link Property} for single XML event.
@@ -275,7 +275,7 @@ public final class XwtListenerProperty extends AbstractListenerProperty {
 		MethodDeclaration method =
 				m_editor.addMethodDeclaration(
 						"public void " + methodName + "(org.eclipse.swt.widgets.Event event)",
-						ImmutableList.<String>of(),
+						Collections.emptyList(),
 						new BodyDeclarationTarget(m_typeDeclaration, false));
 		saveAST();
 		// set method in XML

--- a/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/widgets/CTabItemInfo.java
+++ b/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/widgets/CTabItemInfo.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.xwt.model.widgets;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.model.presentation.IObjectPresentation;
 import org.eclipse.wb.internal.core.utils.GenericsUtils;
@@ -23,6 +21,7 @@ import org.eclipse.wb.internal.core.xml.model.description.ComponentDescription;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.swt.custom.CTabItem;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -70,7 +69,7 @@ public class CTabItemInfo extends ItemInfo {
 	private final IObjectPresentation m_presentation = new XmlObjectPresentation(this) {
 		@Override
 		public List<ObjectInfo> getChildrenGraphical() throws Exception {
-			return ImmutableList.of();
+			return Collections.emptyList();
 		}
 	};
 

--- a/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/widgets/ExpandItemInfo.java
+++ b/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/widgets/ExpandItemInfo.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.xwt.model.widgets;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.model.presentation.IObjectPresentation;
 import org.eclipse.wb.internal.core.utils.GenericsUtils;
@@ -27,6 +25,7 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.ExpandBar;
 import org.eclipse.swt.widgets.ExpandItem;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -72,7 +71,7 @@ public final class ExpandItemInfo extends ItemInfo {
 		@Override
 		public List<ObjectInfo> getChildrenGraphical() throws Exception {
 			if (!isExpanded()) {
-				return ImmutableList.of();
+				return Collections.emptyList();
 			}
 			return getChildrenTree();
 		}

--- a/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/widgets/TabItemInfo.java
+++ b/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/widgets/TabItemInfo.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.xwt.model.widgets;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.model.presentation.IObjectPresentation;
 import org.eclipse.wb.internal.core.utils.GenericsUtils;
@@ -24,6 +22,7 @@ import org.eclipse.wb.os.OSSupport;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.swt.widgets.TabItem;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -71,7 +70,7 @@ public class TabItemInfo extends ItemInfo {
 	private final IObjectPresentation m_presentation = new XmlObjectPresentation(this) {
 		@Override
 		public List<ObjectInfo> getChildrenGraphical() throws Exception {
-			return ImmutableList.of();
+			return Collections.emptyList();
 		}
 	};
 

--- a/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/widgets/menu/MenuItemInfo.java
+++ b/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/widgets/menu/MenuItemInfo.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.xwt.model.widgets.menu;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.broadcast.ObjectEventListener;
 import org.eclipse.wb.core.model.broadcast.ObjectInfoChildAddBefore;
@@ -49,6 +47,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -386,7 +385,7 @@ public final class MenuItemInfo extends ItemInfo implements IAdaptable {
 
 		@Override
 		public List<?> commandPaste(Object mementoObject, Object nextObject) throws Exception {
-			return ImmutableList.of();
+			return Collections.emptyList();
 		}
 
 		@Override

--- a/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/parser/XwtEditorContext.java
+++ b/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/parser/XwtEditorContext.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.xwt.parser;
 
-import com.google.common.collect.ImmutableMap;
-
 import org.eclipse.wb.internal.core.model.description.resource.IDescriptionVersionsProvider;
 import org.eclipse.wb.internal.core.model.description.resource.IDescriptionVersionsProviderFactory;
 import org.eclipse.wb.internal.core.utils.external.ExternalFactoriesHelper;
@@ -31,6 +29,7 @@ import org.apache.commons.lang.StringUtils;
 import java.security.AccessController;
 import java.security.PrivilegedExceptionAction;
 import java.util.List;
+import java.util.Map;
 
 /**
  * {@link EditorContext} for XWT.
@@ -47,7 +46,7 @@ public final class XwtEditorContext extends EditorContext {
 	public XwtEditorContext(IFile file, IDocument document) throws Exception {
 		super(RcpToolkitDescription.INSTANCE, file, document);
 		configureDescriptionVersionsProviders();
-		addVersions(ImmutableMap.of("isXWT", "true"));
+		addVersions(Map.of("isXWT", "true"));
 	}
 
 	////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Java itself is powerful enough to express immutability. There is no need to keep using Guava for this. This change removes all usages of ImmutableList, ImmutableSet and ImmutableMap and replaces them with List, Set, Map and the Collections utility class.

Example:
ImmutableList.copyOf(...) -> List.copyOf(...)
ImmutableMap.of(...) -> Map.of(...)
ImmutableSet.of() -> Collections.emptySet()

#270 