### PR TITLE
Replace occurrences of Guava Predicates with their Java counterpart

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/creation/VoidInvocationCreationSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/creation/VoidInvocationCreationSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.creation;
-
-import com.google.common.base.Predicate;
 
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
@@ -27,6 +25,7 @@ import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * Abstract {@link CreationSupport} for components created by {@link MethodInvocation} that return

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/MethodsOperationRule.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/MethodsOperationRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description.rules;
-
-import com.google.common.base.Predicate;
 
 import org.eclipse.wb.internal.core.model.description.ComponentDescription;
 import org.eclipse.wb.internal.core.model.description.MethodDescription;
@@ -22,6 +20,7 @@ import org.xml.sax.Attributes;
 
 import java.lang.reflect.Method;
 import java.util.Iterator;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 /**
@@ -67,21 +66,11 @@ public final class MethodsOperationRule extends AbstractDesignerRule {
 
 	private void processRegexp(final String signature) throws Exception {
 		final Pattern pattern = Pattern.compile(StringUtils.substring(signature, 1, -1));
-		process(new Predicate<String>() {
-			@Override
-			public boolean apply(String t) {
-				return pattern.matcher(t).matches();
-			}
-		});
+		process(t -> pattern.matcher(t).matches());
 	}
 
 	private void processSingleSignature(final String signature) throws Exception {
-		process(new Predicate<String>() {
-			@Override
-			public boolean apply(String t) {
-				return signature.equals(t);
-			}
-		});
+		process(t -> signature.equals(t));
 	}
 
 	private void process(Predicate<String> signaturePredicate) throws Exception {
@@ -96,7 +85,7 @@ public final class MethodsOperationRule extends AbstractDesignerRule {
 		Method[] methods = componentDescription.getComponentClass().getMethods();
 		for (Method method : methods) {
 			String methodSignature = ReflectionUtils.getMethodSignature(method);
-			if (signaturePredicate.apply(methodSignature)) {
+			if (signaturePredicate.test(methodSignature)) {
 				componentDescription.addMethod(method);
 			}
 		}
@@ -106,7 +95,7 @@ public final class MethodsOperationRule extends AbstractDesignerRule {
 		for (Iterator<MethodDescription> I = componentDescription.getMethods().iterator(); I.hasNext();) {
 			MethodDescription methodDescription = I.next();
 			String methodSignature = methodDescription.getSignature();
-			if (signaturePredicate.apply(methodSignature)) {
+			if (signaturePredicate.test(methodSignature)) {
 				I.remove();
 			}
 		}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/generic/FlowContainerConfigurable.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/generic/FlowContainerConfigurable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -46,12 +46,12 @@ public final class FlowContainerConfigurable implements FlowContainer {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public boolean isHorizontal() {
-		return m_configuration.getHorizontalPredicate().apply(m_container);
+		return m_configuration.getHorizontalPredicate().test(m_container);
 	}
 
 	@Override
 	public boolean isRtl() {
-		return m_configuration.getRtlPredicate().apply(m_container);
+		return m_configuration.getRtlPredicate().test(m_container);
 	}
 
 	public String getGroupName() {

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/generic/FlowContainerConfiguration.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/generic/FlowContainerConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.generic;
 
-import com.google.common.base.Predicate;
-
 import org.eclipse.wb.core.model.association.AssociationObjectFactory;
+
+import java.util.function.Predicate;
 
 /**
  * Configuration for {@link FlowContainerConfigurable}.

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/generic/FlowContainerFactory.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/generic/FlowContainerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,13 +10,11 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.generic;
 
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.association.AssociationObjectFactories;
 import org.eclipse.wb.core.model.association.AssociationObjectFactory;
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
+import org.eclipse.wb.internal.core.model.util.predicate.AlwaysPredicate;
 import org.eclipse.wb.internal.core.model.util.predicate.ExpressionPredicate;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
@@ -26,6 +24,7 @@ import org.apache.commons.lang.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * Factory for accessing {@link FlowContainer} for {@link JavaInfo}.
@@ -174,7 +173,7 @@ public final class FlowContainerFactory {
 	private Predicate<Object> getHorizontalPredicate(String prefix, boolean def) {
 		String horizontalString = getParameter(prefix + ".horizontal");
 		if (horizontalString == null) {
-			return Predicates.alwaysTrue();
+			return new AlwaysPredicate<>(true);
 		}
 		return new ExpressionPredicate<>(horizontalString);
 	}
@@ -182,7 +181,7 @@ public final class FlowContainerFactory {
 	private Predicate<Object> getRtlPredicate(String prefix, boolean def) {
 		String rtlString = getParameter(prefix + ".rtl");
 		if (rtlString == null) {
-			return Predicates.alwaysFalse();
+			return new AlwaysPredicate<>(false);
 		}
 		return new ExpressionPredicate<>(rtlString);
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/ObjectPropertyEditor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/ObjectPropertyEditor.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.property.editor;
 
-import com.google.common.base.Predicate;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.DesignerPlugin;
@@ -41,6 +39,7 @@ import org.eclipse.ui.dialogs.ISelectionStatusValidator;
 
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * {@link PropertyEditor} for selecting model of {@link Object}, for example in
@@ -142,7 +141,7 @@ IComplexPropertyEditor {
 		final ITreeContentProvider[] contentProvider = new ITreeContentProvider[1];
 		contentProvider[0] = new ObjectsTreeContentProvider(new Predicate<ObjectInfo>() {
 			@Override
-			public boolean apply(ObjectInfo t) {
+			public boolean test(ObjectInfo t) {
 				return isValidComponent(propertyType, t) || hasValidComponents(t);
 			}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/ExposePropertySupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/ExposePropertySupport.java
@@ -1,7 +1,5 @@
 package org.eclipse.wb.internal.core.model.util;
 
-import com.google.common.base.Predicate;
-
 import org.eclipse.wb.core.model.AbstractComponentInfo;
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.DesignerPlugin;
@@ -155,16 +153,13 @@ public final class ExposePropertySupport implements IPropertiesMenuContributor {
 				final List<VariableDeclaration> variables =
 						AstNodeUtils.getVariableDeclarationsAll(m_editor.getAstUnit());
 				m_exposedSetterParameter =
-						CodeUtils.generateUniqueName(m_property.getTitle(), new Predicate<String>() {
-							@Override
-							public boolean apply(String name) {
-								for (VariableDeclaration variable : variables) {
-									if (variable.getName().getIdentifier().equals(name)) {
-										return false;
-									}
+						CodeUtils.generateUniqueName(m_property.getTitle(), name -> {
+							for (VariableDeclaration variable : variables) {
+								if (variable.getName().getIdentifier().equals(name)) {
+									return false;
 								}
-								return true;
 							}
+							return true;
 						});
 			}
 		}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/factory/FactoryCreateAction.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/factory/FactoryCreateAction.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.util.factory;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 
 import org.eclipse.wb.core.editor.IDesignPageSite;
@@ -564,12 +563,7 @@ public final class FactoryCreateAction extends Action {
 	 * @return the new generated identifier.
 	 */
 	private static String generateUniqueIdentifier(final Set<String> usedIdentifiers, String baseName) {
-		String newIdentifier = CodeUtils.generateUniqueName(baseName, new Predicate<String>() {
-			@Override
-			public boolean apply(String t) {
-				return !usedIdentifiers.contains(t);
-			}
-		});
+		String newIdentifier = CodeUtils.generateUniqueName(baseName, t -> !usedIdentifiers.contains(t));
 		usedIdentifiers.add(newIdentifier);
 		return newIdentifier;
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/generic/CopyPropertyTopAbstractSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/generic/CopyPropertyTopAbstractSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.util.generic;
-
-import com.google.common.base.Predicate;
 
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.broadcast.JavaInfoAddProperties;
@@ -24,6 +22,7 @@ import org.eclipse.wb.internal.core.utils.state.EditorWarning;
 import org.apache.commons.lang.StringUtils;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * This helper allows to create top-level {@link Property} as copy of other {@link Property}
@@ -110,7 +109,7 @@ public abstract class CopyPropertyTopAbstractSupport {
 			someJavaInfo.addBroadcastListener(new JavaInfoAddProperties() {
 				@Override
 				public void invoke(JavaInfo javaInfo, List<Property> properties) throws Exception {
-					if (m_targetPredicate.apply(javaInfo)) {
+					if (m_targetPredicate.test(javaInfo)) {
 						Property source = PropertyUtils.getByPath(properties, m_sourcePath);
 						Property copy = getCopy(source);
 						if (copy != null) {

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/generic/CopyPropertyTopChildSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/generic/CopyPropertyTopChildSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,11 +10,11 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.util.generic;
 
-import com.google.common.base.Predicate;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.association.InvocationChildAssociation;
 import org.eclipse.wb.internal.core.model.property.Property;
+
+import java.util.function.Predicate;
 
 /**
  * This helper allows to create top-level {@link Property} as copy of other {@link Property}
@@ -53,11 +53,6 @@ public final class CopyPropertyTopChildSupport extends CopyPropertyTopAbstractSu
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	protected Predicate<JavaInfo> createTargetPredicate(final JavaInfo javaInfo) {
-		return new Predicate<>() {
-			@Override
-			public boolean apply(JavaInfo t) {
-				return t.getParent() == javaInfo;
-			}
-		};
+		return t -> t.getParent() == javaInfo;
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/generic/CopyPropertyTopSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/generic/CopyPropertyTopSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,10 +10,10 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.util.generic;
 
-import com.google.common.base.Predicate;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.model.property.Property;
+
+import java.util.function.Predicate;
 
 /**
  * This helper allows to create top-level {@link Property} as copy of other {@link Property}
@@ -50,11 +50,6 @@ public final class CopyPropertyTopSupport extends CopyPropertyTopAbstractSupport
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	protected Predicate<JavaInfo> createTargetPredicate(final JavaInfo javaInfo) {
-		return new Predicate<>() {
-			@Override
-			public boolean apply(JavaInfo t) {
-				return t == javaInfo;
-			}
-		};
+		return t -> t == javaInfo;
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/predicate/ComponentSubclassPredicate.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/predicate/ComponentSubclassPredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,10 +10,10 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.util.predicate;
 
-import com.google.common.base.Predicate;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
+
+import java.util.function.Predicate;
 
 /**
  * {@link Predicate} that checks that given {@link Object} is {@link JavaInfo} with compatible
@@ -50,7 +50,7 @@ public final class ComponentSubclassPredicate implements Predicate<Object> {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public boolean apply(Object t) {
+	public boolean test(Object t) {
 		if (t instanceof JavaInfo javaInfo) {
 			Class<?> componentClass = javaInfo.getDescription().getComponentClass();
 			return ReflectionUtils.isSuccessorOf(componentClass, m_superClass);

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/AstEditor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/AstEditor.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.utils.ast;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 
 import org.eclipse.wb.internal.core.utils.GenericsUtils;
@@ -1226,12 +1225,7 @@ public final class AstEditor {
 			existingIdentifiers.add(declaration.getName().getIdentifier());
 		}
 		// generate unique name
-		return CodeUtils.generateUniqueName(baseName, new Predicate<String>() {
-			@Override
-			public boolean apply(String name) {
-				return !existingIdentifiers.contains(name);
-			}
-		});
+		return CodeUtils.generateUniqueName(baseName, name -> !existingIdentifiers.contains(name));
 	}
 
 	/**
@@ -1252,12 +1246,7 @@ public final class AstEditor {
 			}
 		});
 		// generate unique name
-		return CodeUtils.generateUniqueName(baseName, new Predicate<String>() {
-			@Override
-			public boolean apply(String name) {
-				return !existingMethods.contains(name);
-			}
-		});
+		return CodeUtils.generateUniqueName(baseName, name -> !existingMethods.contains(name));
 	}
 
 	/**
@@ -1273,12 +1262,7 @@ public final class AstEditor {
 			}
 		});
 		// generate unique name
-		return CodeUtils.generateUniqueName(baseName, new Predicate<String>() {
-			@Override
-			public boolean apply(String name) {
-				return !existingTypes.contains(name);
-			}
-		});
+		return CodeUtils.generateUniqueName(baseName, name -> !existingTypes.contains(name));
 	}
 
 	/**

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/core/CodeUtils.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/core/CodeUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.utils.jdt.core;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 
 import org.eclipse.wb.internal.core.DesignerPlugin;
@@ -65,6 +64,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.function.Predicate;
 
 /**
  * This class contains different utilities for working with Java model elements.
@@ -416,7 +416,7 @@ public class CodeUtils {
 				name += "_" + index;
 			}
 			// if name is unique, return it
-			if (validator.apply(name)) {
+			if (validator.test(name)) {
 				return name;
 			}
 		}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/core/ProjectUtils.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/core/ProjectUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.core.utils.jdt.core;
-
-import com.google.common.base.Predicate;
 
 import org.eclipse.wb.internal.core.BundleResourceProvider;
 import org.eclipse.wb.internal.core.EnvironmentUtils;
@@ -58,6 +56,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * The class implements utility methods that operate on {@link IProject} and {@link IJavaProject}.
@@ -453,7 +452,7 @@ public final class ProjectUtils {
 		List<IClasspathEntry> newEntries = new ArrayList<>();
 		IClasspathEntry[] existingEntries = javaProject.getRawClasspath();
 		for (IClasspathEntry entry : existingEntries) {
-			if (!predicate.apply(entry)) {
+			if (!predicate.test(entry)) {
 				newEntries.add(entry);
 			}
 		}

--- a/org.eclipse.wb.core.ui/src/org/eclipse/wb/internal/core/wizards/actions/NewDesignerTypeDropDownAction.java
+++ b/org.eclipse.wb.core.ui/src/org/eclipse/wb/internal/core/wizards/actions/NewDesignerTypeDropDownAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.wizards.actions;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 
 import org.eclipse.wb.internal.core.utils.external.ExternalFactoriesHelper;
@@ -198,12 +197,7 @@ IActionDelegate2 {
 			final String parentCategoryId) {
 		List<IConfigurationElement> allCategories =
 				ExternalFactoriesHelper.getElements("org.eclipse.ui.newWizards", elementName);
-		return Iterables.filter(allCategories, new Predicate<IConfigurationElement>() {
-			@Override
-			public boolean apply(IConfigurationElement t) {
-				return parentCategoryId.equals(t.getAttribute(attributeName));
-			}
-		});
+		return Iterables.filter(allCategories, t -> parentCategoryId.equals(t.getAttribute(attributeName)));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/generic/FlowContainerConfigurable.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/generic/FlowContainerConfigurable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -47,12 +47,12 @@ public final class FlowContainerConfigurable implements FlowContainer {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public boolean isHorizontal() {
-		return m_configuration.getHorizontalPredicate().apply(m_container);
+		return m_configuration.getHorizontalPredicate().test(m_container);
 	}
 
 	@Override
 	public boolean isRtl() {
-		return m_configuration.getRtlPredicate().apply(m_container);
+		return m_configuration.getRtlPredicate().test(m_container);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/generic/FlowContainerConfiguration.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/generic/FlowContainerConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,10 +10,10 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.xml.model.generic;
 
-import com.google.common.base.Predicate;
-
 import org.eclipse.wb.internal.core.model.generic.ContainerObjectValidator;
 import org.eclipse.wb.internal.core.xml.model.association.Association;
+
+import java.util.function.Predicate;
 
 /**
  * Configuration for {@link FlowContainerConfigurable}.

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/generic/FlowContainerFactory.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/generic/FlowContainerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,12 +10,10 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.xml.model.generic;
 
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
-
 import org.eclipse.wb.internal.core.model.generic.ContainerObjectValidator;
 import org.eclipse.wb.internal.core.model.generic.ContainerObjectValidators;
 import org.eclipse.wb.internal.core.model.generic.FlowContainer;
+import org.eclipse.wb.internal.core.model.util.predicate.AlwaysPredicate;
 import org.eclipse.wb.internal.core.model.util.predicate.ExpressionPredicate;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
@@ -31,6 +29,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 /**
  * Factory for accessing {@link FlowContainer} for {@link XmlObjectInfo}.
@@ -72,12 +71,7 @@ public final class FlowContainerFactory {
 	}
 
 	public List<FlowContainerConfiguration> getConfigurations() {
-		return ExecutionUtils.runObject(new RunnableObjectEx<List<FlowContainerConfiguration>>() {
-			@Override
-			public List<FlowContainerConfiguration> runObject() throws Exception {
-				return getConfigurationsEx();
-			}
-		}, "Exception during reading flow container configurations for %s", m_object);
+		return ExecutionUtils.runObject((RunnableObjectEx<List<FlowContainerConfiguration>>) () -> getConfigurationsEx(), "Exception during reading flow container configurations for %s", m_object);
 	}
 
 	private List<FlowContainerConfiguration> getConfigurationsEx() {
@@ -176,7 +170,7 @@ public final class FlowContainerFactory {
 	private Predicate<Object> getHorizontalPredicate(String prefix, boolean def) {
 		String horizontalString = getParameter(prefix + ".horizontal");
 		if (horizontalString == null) {
-			return Predicates.alwaysTrue();
+			return new AlwaysPredicate<>(true);
 		}
 		return new ExpressionPredicate<>(horizontalString);
 	}
@@ -184,7 +178,7 @@ public final class FlowContainerFactory {
 	private Predicate<Object> getRtlPredicate(String prefix, boolean def) {
 		String rtlString = getParameter(prefix + ".rtl");
 		if (rtlString == null) {
-			return Predicates.alwaysFalse();
+			return new AlwaysPredicate<>(false);
 		}
 		return new ExpressionPredicate<>(rtlString);
 	}

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/utils/CopyPropertyTopAbstractSupport.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/utils/CopyPropertyTopAbstractSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.xml.model.utils;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.MapMaker;
 
 import org.eclipse.wb.core.model.ObjectInfo;
@@ -26,6 +25,7 @@ import org.apache.commons.lang.StringUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 /**
  * This helper allows to create top-level {@link Property} as copy of other {@link Property}
@@ -140,7 +140,7 @@ public abstract class CopyPropertyTopAbstractSupport {
 		private Property m_oldCopy;
 
 		public void addCopy(XmlObjectInfo object, List<Property> properties) throws Exception {
-			if (m_targetPredicate.apply(object)) {
+			if (m_targetPredicate.test(object)) {
 				Property copy = getCopy(properties);
 				if (copy != null) {
 					properties.add(copy);

--- a/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/utils/CopyPropertyTopSupport.java
+++ b/org.eclipse.wb.core.xml/src/org/eclipse/wb/internal/core/xml/model/utils/CopyPropertyTopSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,11 +10,11 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.xml.model.utils;
 
-import com.google.common.base.Predicate;
-
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.xml.model.XmlObjectInfo;
+
+import java.util.function.Predicate;
 
 /**
  * This helper allows to create top-level {@link Property} as copy of other {@link Property}
@@ -51,11 +51,6 @@ public final class CopyPropertyTopSupport extends CopyPropertyTopAbstractSupport
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	protected Predicate<XmlObjectInfo> createTargetPredicate(final XmlObjectInfo object) {
-		return new Predicate<>() {
-			@Override
-			public boolean apply(XmlObjectInfo t) {
-				return t == object;
-			}
-		};
+		return t -> t == object;
 	}
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/generic/ContainerObjectValidators.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/generic/ContainerObjectValidators.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.generic;
-
-import com.google.common.base.Predicate;
 
 import org.eclipse.wb.internal.core.model.description.IComponentDescription;
 import org.eclipse.wb.internal.core.model.util.ScriptUtils;
@@ -23,6 +21,7 @@ import org.apache.commons.lang.StringUtils;
 
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.Predicate;
 
 /**
  * Factory for {@link ContainerObjectValidator} objects.
@@ -164,7 +163,7 @@ public final class ContainerObjectValidators {
 	public static Predicate<Object> forContainerExpression(final String expression) {
 		return new Predicate<>() {
 			@Override
-			public boolean apply(Object container) {
+			public boolean test(Object container) {
 				ILayoutRequestValidatorHelper validatorHelper = GlobalState.getValidatorHelper();
 				if (validatorHelper.isComponent(container)) {
 					return validateContainer(expression, container);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/ObjectsTreeContentProvider.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/ObjectsTreeContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,15 +10,12 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.util;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
-
 import org.eclipse.wb.core.model.ObjectInfo;
 
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.Viewer;
 
-import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * Implementation of {@link ITreeContentProvider} for {@link ObjectInfo}.
@@ -59,9 +56,10 @@ public final class ObjectsTreeContentProvider implements ITreeContentProvider {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public Object[] getChildren(Object parentElement) {
-		List<ObjectInfo> children = ((ObjectInfo) parentElement).getChildren();
-		Iterable<ObjectInfo> filtered = Iterables.filter(children, m_predicate);
-		return Iterables.toArray(filtered, ObjectInfo.class);
+		return ((ObjectInfo) parentElement).getChildren() //
+				.stream() //
+				.filter(m_predicate) //
+				.toArray();
 	}
 
 	@Override

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/PropertyUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/PropertyUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,9 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.util;
-
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
 
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.model.property.Property;
@@ -27,6 +24,7 @@ import org.apache.commons.lang.StringUtils;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * Utils for {@link Property}.
@@ -164,7 +162,7 @@ public final class PropertyUtils {
 		Property[] properties = objectInfo.getProperties();
 		List<Property> filteredProperties = new ArrayList<>();
 		for (Property property : properties) {
-			if (predicate.apply(property)) {
+			if (predicate.test(property)) {
 				filteredProperties.add(property);
 			}
 		}
@@ -186,7 +184,7 @@ public final class PropertyUtils {
 			throws Exception {
 		for (Iterator<Property> I = properties.iterator(); I.hasNext();) {
 			Property property = I.next();
-			if (!predicate.apply(property)) {
+			if (!predicate.test(property)) {
 				I.remove();
 			}
 		}
@@ -197,7 +195,7 @@ public final class PropertyUtils {
 	 */
 	public static Predicate<Property> getExcludeByTitlePredicate(ObjectInfo objectInfo,
 			String parameterName) {
-		Predicate<Property> predicate = Predicates.alwaysTrue();
+		Predicate<Property> predicate = o -> true;
 		String propertiesExcludeString =
 				GlobalState.getParametersProvider().getParameter(objectInfo, parameterName);
 		if (propertiesExcludeString != null) {
@@ -211,22 +209,12 @@ public final class PropertyUtils {
 	 *         titles.
 	 */
 	public static Predicate<Property> getExcludeByTitlePredicate(final String... excludeTitles) {
-		return new Predicate<>() {
-			@Override
-			public boolean apply(Property t) {
-				return !ArrayUtils.contains(excludeTitles, t.getTitle());
-			}
-		};
+		return t -> !ArrayUtils.contains(excludeTitles, t.getTitle());
 	}
 	/**
 	 * @return the {@link Predicate} for {@link Property} that does accept properties given titles.
 	 */
 	public static Predicate<Property> getIncludeByTitlePredicate(final String... includeTitles) {
-		return new Predicate<>() {
-			@Override
-			public boolean apply(Property t) {
-				return ArrayUtils.contains(includeTitles, t.getTitle());
-			}
-		};
+		return t -> ArrayUtils.contains(includeTitles, t.getTitle());
 	}
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/predicate/AlwaysPredicate.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/predicate/AlwaysPredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.util.predicate;
 
-import com.google.common.base.Predicate;
+import java.util.function.Predicate;
 
 /**
  * {@link Predicate} always returns same value.
@@ -18,7 +18,7 @@ import com.google.common.base.Predicate;
  * @author scheglov_ke
  * @coverage core.model.util
  */
-public final class AlwaysPredicate implements Predicate<Object> {
+public final class AlwaysPredicate<T> implements Predicate<T> {
 	private final boolean m_value;
 
 	////////////////////////////////////////////////////////////////////////////
@@ -36,7 +36,7 @@ public final class AlwaysPredicate implements Predicate<Object> {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public boolean apply(Object t) {
+	public boolean test(T t) {
 		return m_value;
 	}
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/predicate/ExpressionPredicate.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/predicate/ExpressionPredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.util.predicate;
 
-import com.google.common.base.Predicate;
-
 import org.mvel2.MVEL;
+
+import java.util.function.Predicate;
 
 /**
  * {@link Predicate} that evaluates its value using some script expressions, currently using MVEL.
@@ -48,7 +48,7 @@ public final class ExpressionPredicate<T> implements Predicate<T> {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public boolean apply(T t) {
+	public boolean test(T t) {
 		return MVEL.evalToBoolean(m_expression, t);
 	}
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/predicate/SubclassPredicate.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/predicate/SubclassPredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.util.predicate;
 
-import com.google.common.base.Predicate;
-
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
+
+import java.util.function.Predicate;
 
 /**
  * {@link Predicate} that checks that given {@link Object} has compatible class.
@@ -38,7 +38,7 @@ public final class SubclassPredicate implements Predicate<Object> {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public boolean apply(Object t) {
+	public boolean test(Object t) {
 		return ReflectionUtils.isAssignableFrom(m_superClass, t);
 	}
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/GenericsUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/GenericsUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.core.utils;
-
-import com.google.common.base.Predicate;
 
 import org.eclipse.wb.internal.core.utils.check.Assert;
 
@@ -25,6 +23,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * Helper with various generics related utilities.
@@ -378,7 +377,7 @@ public final class GenericsUtils {
 	public static <T extends Enum<?>> T[] getEnumValues(Class<T> enumClass, Predicate<T> predicate) {
 		List<T> selectedElements = new ArrayList<>();
 		for (T element : enumClass.getEnumConstants()) {
-			if (predicate.apply(element)) {
+			if (predicate.test(element)) {
 				selectedElements.add(element);
 			}
 		}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/PdeUtils.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/PdeUtils.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.rcp;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 
 import org.eclipse.wb.internal.core.DesignerPlugin;
@@ -62,6 +61,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.function.Predicate;
 
 /**
  * Helper for working with PDE model.
@@ -250,12 +250,7 @@ public final class PdeUtils {
 	 */
 	public String generateUniqueID(String baseId) {
 		final Set<String> idSet = getIDSet();
-		return CodeUtils.generateUniqueName(baseId, new Predicate<String>() {
-			@Override
-			public boolean apply(String t) {
-				return !idSet.contains(t);
-			}
-		});
+		return CodeUtils.generateUniqueName(baseId, t -> !idSet.contains(t));
 	}
 
 	/**

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/PageLayoutInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/PageLayoutInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.rcp.perspective;
-
-import com.google.common.base.Predicate;
 
 import org.eclipse.wb.core.editor.palette.PaletteEventListener;
 import org.eclipse.wb.core.editor.palette.model.CategoryInfo;
@@ -785,12 +783,7 @@ public final class PageLayoutInfo extends AbstractComponentInfo {
 				usedIDs.add(part.getId());
 			}
 			// do generate unique
-			folderId = CodeUtils.generateUniqueName("folder", new Predicate<String>() {
-				@Override
-				public boolean apply(String t) {
-					return !usedIDs.contains(t);
-				}
-			});
+			folderId = CodeUtils.generateUniqueName("folder", t -> !usedIDs.contains(t));
 		}
 		// prepare CreationSupport
 		CreationSupport creationSupport;

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/bean/AbstractActionInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/bean/AbstractActionInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.model.bean;
 
-import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
 
 import org.eclipse.wb.core.model.JavaInfo;
@@ -44,6 +43,7 @@ import org.apache.commons.lang.SystemUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -128,7 +128,7 @@ public class AbstractActionInfo extends ActionInfo {
 			properties.add(createIconProperty("large icon", "LARGE_ICON_KEY"));
 		}
 		// remove null-s
-		Iterables.removeIf(properties, Predicates.isNull());
+		properties.removeIf(Objects::isNull);
 		return properties;
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/model/generic/ContainerObjectValidatorsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/model/generic/ContainerObjectValidatorsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.XML.model.generic;
 
-import com.google.common.base.Predicate;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.model.generic.ContainerObjectValidator;
 import org.eclipse.wb.internal.core.model.generic.ContainerObjectValidators;
@@ -20,6 +18,8 @@ import org.eclipse.wb.tests.designer.XML.model.description.AbstractCoreTest;
 
 import org.apache.commons.lang.StringUtils;
 import org.junit.Test;
+
+import java.util.function.Predicate;
 
 /**
  * Test for {@link ContainerObjectValidators}.
@@ -120,7 +120,7 @@ public class ContainerObjectValidatorsTest extends AbstractCoreTest {
 	private static void assertContainerValidator(boolean expected, String expression, Object container) {
 		Predicate<Object> validator = ContainerObjectValidators.forContainerExpression(expression);
 		assertEquals(expression, validator.toString());
-		assertEquals(expected, validator.apply(container));
+		assertEquals(expected, validator.test(container));
 		if (container instanceof JavaInfo) {
 			assertEquals(expected, ContainerObjectValidators.validateContainer(container, expression));
 		}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/model/generic/FlowContainerModelTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/model/generic/FlowContainerModelTest.java
@@ -10,12 +10,10 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.XML.model.generic;
 
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.model.generic.ContainerObjectValidators;
 import org.eclipse.wb.internal.core.model.generic.FlowContainer;
+import org.eclipse.wb.internal.core.model.util.predicate.AlwaysPredicate;
 import org.eclipse.wb.internal.core.utils.check.AssertionFailedException;
 import org.eclipse.wb.internal.core.utils.exception.DesignerExceptionUtils;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
@@ -41,6 +39,7 @@ import org.mockito.InOrder;
 
 import java.text.MessageFormat;
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * Test for {@link FlowContainer} and {@link FlowContainerConfigurable} models.
@@ -497,7 +496,7 @@ public class FlowContainerModelTest extends AbstractCoreTest {
 
 	private static String getHorizontalPredicateString(FlowContainerConfiguration configuration) {
 		Predicate<Object> predicate = configuration.getHorizontalPredicate();
-		if (predicate == Predicates.alwaysTrue()) {
+		if (predicate instanceof AlwaysPredicate && ReflectionUtils.getFieldBoolean(predicate, "m_value")) {
 			return "alwaysTrue";
 		}
 		return predicate.toString();
@@ -606,8 +605,8 @@ public class FlowContainerModelTest extends AbstractCoreTest {
 		final InOrder inOrder = inOrder(component, nextComponent, container);
 		final FlowContainer flowContainer =
 				new FlowContainerConfigurable(container,
-						new FlowContainerConfiguration(Predicates.alwaysTrue(),
-								Predicates.alwaysFalse(),
+						new FlowContainerConfiguration(o -> true,
+								o -> false,
 								Associations.direct(),
 								ContainerObjectValidators.alwaysTrue(),
 								ContainerObjectValidators.alwaysTrue()));
@@ -640,8 +639,7 @@ public class FlowContainerModelTest extends AbstractCoreTest {
 		final InOrder inOrder = inOrder(component, oldContainer, nextComponent, container);
 		final FlowContainer flowContainer =
 				new FlowContainerConfigurable(container,
-						new FlowContainerConfiguration(Predicates.alwaysTrue(),
-								Predicates.alwaysFalse(),
+						new FlowContainerConfiguration(o -> true, o -> false,
 								Associations.direct(),
 								ContainerObjectValidators.alwaysTrue(),
 								ContainerObjectValidators.alwaysTrue()));
@@ -671,8 +669,7 @@ public class FlowContainerModelTest extends AbstractCoreTest {
 		final InOrder inOrder = inOrder(component, nextComponent, container);
 		final FlowContainer flowContainer =
 				new FlowContainerConfigurable(container,
-						new FlowContainerConfiguration(Predicates.alwaysTrue(),
-								Predicates.alwaysFalse(),
+						new FlowContainerConfiguration(o -> true, o -> false,
 								Associations.direct(),
 								ContainerObjectValidators.alwaysTrue(),
 								ContainerObjectValidators.alwaysTrue()));
@@ -697,7 +694,7 @@ public class FlowContainerModelTest extends AbstractCoreTest {
 		final InOrder inOrder = inOrder(container, component, reference, configuration);
 		final FlowContainer flowContainer = new FlowContainerConfigurable(container, configuration);
 		// isHorizontal()
-		when(configuration.getHorizontalPredicate()).thenReturn(Predicates.alwaysTrue());
+		when(configuration.getHorizontalPredicate()).thenReturn(o -> true);
 		//
 		assertTrue(flowContainer.isHorizontal());
 		//
@@ -812,8 +809,8 @@ public class FlowContainerModelTest extends AbstractCoreTest {
 		// prepare FlowContainer
 		FlowContainer flowContainer =
 				new FlowContainerConfigurable(panel,
-						new FlowContainerConfiguration(Predicates.alwaysTrue(),
-								Predicates.alwaysFalse(),
+						new FlowContainerConfiguration(o -> true,
+								o -> false,
 								Associations.direct(),
 								ContainerObjectValidators.alwaysTrue(),
 								ContainerObjectValidators.alwaysTrue()));

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/generic/ContainerObjectValidatorsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/generic/ContainerObjectValidatorsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.model.generic;
 
-import com.google.common.base.Predicate;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.model.generic.ContainerObjectValidator;
 import org.eclipse.wb.internal.core.model.generic.ContainerObjectValidators;
@@ -21,6 +19,8 @@ import org.eclipse.wb.tests.designer.swing.SwingModelTest;
 
 import org.apache.commons.lang.StringUtils;
 import org.junit.Test;
+
+import java.util.function.Predicate;
 
 /**
  * Test for {@link ContainerObjectValidators}.
@@ -119,7 +119,7 @@ public class ContainerObjectValidatorsTest extends SwingModelTest {
 	private static void assertContainerValidator(boolean expected, String expression, Object container) {
 		Predicate<Object> validator = ContainerObjectValidators.forContainerExpression(expression);
 		assertEquals(expression, validator.toString());
-		assertEquals(expected, validator.apply(container));
+		assertEquals(expected, validator.test(container));
 		if (container instanceof JavaInfo) {
 			assertEquals(expected, ContainerObjectValidators.validateContainer(container, expression));
 		}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/generic/FlowContainerModelTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/generic/FlowContainerModelTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,9 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.model.generic;
-
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
 
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.association.Association;
@@ -23,7 +20,9 @@ import org.eclipse.wb.internal.core.model.generic.FlowContainer;
 import org.eclipse.wb.internal.core.model.generic.FlowContainerConfigurable;
 import org.eclipse.wb.internal.core.model.generic.FlowContainerConfiguration;
 import org.eclipse.wb.internal.core.model.generic.FlowContainerFactory;
+import org.eclipse.wb.internal.core.model.util.predicate.AlwaysPredicate;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
+import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 import org.eclipse.wb.tests.designer.core.AbstractJavaProjectTest;
@@ -41,6 +40,7 @@ import org.mockito.InOrder;
 
 import java.text.MessageFormat;
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * Test for {@link FlowContainer} and {@link FlowContainerConfigurable} models.
@@ -507,7 +507,7 @@ public class FlowContainerModelTest extends SwingModelTest {
 
 	private static String getHorizontalPredicateString(FlowContainerConfiguration configuration) {
 		Predicate<Object> predicate = configuration.getHorizontalPredicate();
-		if (predicate == Predicates.alwaysTrue()) {
+		if (predicate instanceof AlwaysPredicate && ReflectionUtils.getFieldBoolean(predicate, "m_value")) {
 			return "alwaysTrue";
 		}
 		return predicate.toString();
@@ -617,8 +617,8 @@ public class FlowContainerModelTest extends SwingModelTest {
 		final InOrder inOrder = inOrder(component, nextComponent, container);
 		final FlowContainer flowContainer =
 				new FlowContainerConfigurable(container,
-						new FlowContainerConfiguration(Predicates.alwaysTrue(),
-								Predicates.alwaysFalse(),
+						new FlowContainerConfiguration(o -> true,
+								o -> false,
 								null,
 								ContainerObjectValidators.alwaysTrue(),
 								ContainerObjectValidators.alwaysTrue(),
@@ -650,8 +650,8 @@ public class FlowContainerModelTest extends SwingModelTest {
 		final InOrder inOrder = inOrder(component, nextComponent, container);
 		final FlowContainer flowContainer =
 				new FlowContainerConfigurable(container,
-						new FlowContainerConfiguration(Predicates.alwaysTrue(),
-								Predicates.alwaysFalse(),
+						new FlowContainerConfiguration(o -> true,
+								o -> false,
 								null,
 								ContainerObjectValidators.alwaysTrue(),
 								ContainerObjectValidators.alwaysTrue(),
@@ -677,7 +677,7 @@ public class FlowContainerModelTest extends SwingModelTest {
 		final InOrder inOrder = inOrder(container, component, reference, configuration);
 		final FlowContainer flowContainer = new FlowContainerConfigurable(container, configuration);
 		// isHorizontal()
-		when(configuration.getHorizontalPredicate()).thenReturn(Predicates.alwaysTrue());
+		when(configuration.getHorizontalPredicate()).thenReturn(o -> true);
 		//
 		assertTrue(flowContainer.isHorizontal());
 		//
@@ -816,8 +816,8 @@ public class FlowContainerModelTest extends SwingModelTest {
 		// prepare FlowContainer
 		FlowContainer flowContainer =
 				new FlowContainerConfigurable(panel,
-						new FlowContainerConfiguration(Predicates.alwaysTrue(),
-								Predicates.alwaysFalse(),
+						new FlowContainerConfiguration(o -> true,
+								o -> false,
 								AssociationObjectFactories.invocationChild("%parent%.add(%child%)", false),
 								ContainerObjectValidators.alwaysTrue(),
 								ContainerObjectValidators.alwaysTrue(),

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/ObjectsTreeContentProviderTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/ObjectsTreeContentProviderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.model.util;
 
-import com.google.common.base.Predicate;
-
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.model.util.ObjectsTreeContentProvider;
 import org.eclipse.wb.tests.designer.core.model.TestObjectInfo;
@@ -21,6 +19,8 @@ import org.eclipse.jface.viewers.ITreeContentProvider;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
+
+import java.util.function.Predicate;
 
 /**
  * Test for {@link ObjectsTreeContentProvider}.
@@ -36,12 +36,7 @@ public class ObjectsTreeContentProviderTest extends DesignerTestCase {
 		parent.addChild(child_1);
 		parent.addChild(child_2);
 		// prepare ITreeContentProvider
-		Predicate<ObjectInfo> predicate = new Predicate<>() {
-			@Override
-			public boolean apply(ObjectInfo t) {
-				return t != child_2;
-			}
-		};
+		Predicate<ObjectInfo> predicate = t -> t != child_2;
 		ITreeContentProvider contentProvider = new ObjectsTreeContentProvider(predicate);
 		// check ITreeContentProvider
 		Assertions.assertThat(contentProvider.getElements(new Object[]{parent})).containsOnly(parent);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/PredicatesTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/PredicatesTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.model.util;
 
-import com.google.common.base.Predicate;
-
 import org.eclipse.wb.internal.core.model.util.predicate.AlwaysPredicate;
 import org.eclipse.wb.internal.core.model.util.predicate.ComponentSubclassPredicate;
 import org.eclipse.wb.internal.core.model.util.predicate.ExpressionPredicate;
@@ -20,6 +18,8 @@ import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 import org.eclipse.wb.tests.designer.swing.SwingModelTest;
 
 import org.junit.Test;
+
+import java.util.function.Predicate;
 
 /**
  * Test for {@link Predicate} implementations.
@@ -37,10 +37,10 @@ public class PredicatesTest extends SwingModelTest {
 	 */
 	@Test
 	public void test_AlwaysPredicate_true() throws Exception {
-		Predicate<Object> predicate = new AlwaysPredicate(true);
-		assertTrue(predicate.apply("yes"));
-		assertTrue(predicate.apply(this));
-		assertTrue(predicate.apply(null));
+		Predicate<Object> predicate = new AlwaysPredicate<>(true);
+		assertTrue(predicate.test("yes"));
+		assertTrue(predicate.test(this));
+		assertTrue(predicate.test(null));
 	}
 
 	/**
@@ -48,10 +48,10 @@ public class PredicatesTest extends SwingModelTest {
 	 */
 	@Test
 	public void test_AlwaysPredicate_false() throws Exception {
-		Predicate<Object> predicate = new AlwaysPredicate(false);
-		assertFalse(predicate.apply("yes"));
-		assertFalse(predicate.apply(this));
-		assertFalse(predicate.apply(null));
+		Predicate<Object> predicate = new AlwaysPredicate<>(false);
+		assertFalse(predicate.test("yes"));
+		assertFalse(predicate.test(this));
+		assertFalse(predicate.test(null));
 	}
 
 	/**
@@ -60,9 +60,9 @@ public class PredicatesTest extends SwingModelTest {
 	@Test
 	public void test_SubclassPredicate() throws Exception {
 		Predicate<Object> predicate = new SubclassPredicate(String.class);
-		assertTrue(predicate.apply("yes"));
-		assertFalse(predicate.apply(this));
-		assertTrue(predicate.apply(null));
+		assertTrue(predicate.test("yes"));
+		assertFalse(predicate.test(this));
+		assertTrue(predicate.test(null));
 	}
 
 	/**
@@ -79,9 +79,9 @@ public class PredicatesTest extends SwingModelTest {
 						"}");
 		ComponentSubclassPredicate predicate = new ComponentSubclassPredicate("java.awt.Component");
 		assertEquals("java.awt.Component", predicate.toString());
-		assertTrue(predicate.apply(panel));
-		assertFalse(predicate.apply(panel.getLayout()));
-		assertFalse(predicate.apply("not JavaInfo"));
+		assertTrue(predicate.test(panel));
+		assertFalse(predicate.test(panel.getLayout()));
+		assertFalse(predicate.test("not JavaInfo"));
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -96,7 +96,7 @@ public class PredicatesTest extends SwingModelTest {
 	public void test_ExpressionPredicate_alwaysTrue() throws Exception {
 		Predicate<Object> predicate = new ExpressionPredicate<>("true");
 		assertEquals("true", predicate.toString());
-		assertTrue(predicate.apply(null));
+		assertTrue(predicate.test(null));
 	}
 
 	/**
@@ -105,7 +105,7 @@ public class PredicatesTest extends SwingModelTest {
 	@Test
 	public void test_ExpressionPredicate_alwaysFalse() throws Exception {
 		Predicate<Object> predicate = new ExpressionPredicate<>("false");
-		assertFalse(predicate.apply(null));
+		assertFalse(predicate.test(null));
 	}
 
 	/**
@@ -114,7 +114,7 @@ public class PredicatesTest extends SwingModelTest {
 	@Test
 	public void test_ExpressionPredicate_checkLength() throws Exception {
 		Predicate<Object> predicate = new ExpressionPredicate<>("length() > 5");
-		assertFalse(predicate.apply("123"));
-		assertTrue(predicate.apply("123456"));
+		assertFalse(predicate.test("123"));
+		assertTrue(predicate.test("123456"));
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/PropertyUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/PropertyUtilsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.model.util;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.model.JavaInfo;
@@ -25,6 +24,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * Tests for {@link PropertyUtils}.
@@ -252,15 +252,15 @@ public class PropertyUtilsTest extends SwingModelTest {
 		Predicate<Property> predicate = PropertyUtils.getExcludeByTitlePredicate("a", "c");
 		{
 			Property property = new PropertyWithTitle("a");
-			assertFalse(predicate.apply(property));
+			assertFalse(predicate.test(property));
 		}
 		{
 			Property property = new PropertyWithTitle("b");
-			assertTrue(predicate.apply(property));
+			assertTrue(predicate.test(property));
 		}
 		{
 			Property property = new PropertyWithTitle("c");
-			assertFalse(predicate.apply(property));
+			assertFalse(predicate.test(property));
 		}
 	}
 
@@ -272,15 +272,15 @@ public class PropertyUtilsTest extends SwingModelTest {
 		Predicate<Property> predicate = PropertyUtils.getIncludeByTitlePredicate("a", "c");
 		{
 			Property property = new PropertyWithTitle("a");
-			assertTrue(predicate.apply(property));
+			assertTrue(predicate.test(property));
 		}
 		{
 			Property property = new PropertyWithTitle("b");
-			assertFalse(predicate.apply(property));
+			assertFalse(predicate.test(property));
 		}
 		{
 			Property property = new PropertyWithTitle("c");
-			assertTrue(predicate.apply(property));
+			assertTrue(predicate.test(property));
 		}
 	}
 
@@ -345,15 +345,15 @@ public class PropertyUtilsTest extends SwingModelTest {
 				PropertyUtils.getExcludeByTitlePredicate(panel, "exclude-parameter");
 		{
 			Property property = new PropertyWithTitle("a");
-			assertFalse(predicate.apply(property));
+			assertFalse(predicate.test(property));
 		}
 		{
 			Property property = new PropertyWithTitle("b");
-			assertTrue(predicate.apply(property));
+			assertTrue(predicate.test(property));
 		}
 		{
 			Property property = new PropertyWithTitle("c");
-			assertFalse(predicate.apply(property));
+			assertFalse(predicate.test(property));
 		}
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/GenericsUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/GenericsUtilsTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.util;
 
-import com.google.common.base.Predicate;
-
 import org.eclipse.wb.internal.core.utils.GenericTypeError;
 import org.eclipse.wb.internal.core.utils.GenericTypeResolver;
 import org.eclipse.wb.internal.core.utils.GenericsUtils;
@@ -33,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * Tests for {@link GenericsUtils}.
@@ -472,12 +471,7 @@ public class GenericsUtilsTest extends DesignerTestCase {
 	@Test
 	public void test_getEnumValues_filter() throws Exception {
 		MyEnum[] expectedValues = new MyEnum[]{MyEnum.B, MyEnum.C};
-		MyEnum[] actualValues = GenericsUtils.getEnumValues(MyEnum.class, new Predicate<MyEnum>() {
-			@Override
-			public boolean apply(MyEnum t) {
-				return t == MyEnum.B || t == MyEnum.C;
-			}
-		});
+		MyEnum[] actualValues = GenericsUtils.getEnumValues(MyEnum.class, t -> t == MyEnum.B || t == MyEnum.C);
 		Assertions.assertThat(actualValues).isEqualTo(expectedValues);
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/jdt/core/CodeUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/jdt/core/CodeUtilsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,9 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.util.jdt.core;
-
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
 
 import org.eclipse.wb.internal.core.utils.ast.AstNodeUtils;
 import org.eclipse.wb.internal.core.utils.ast.DomGenerics;
@@ -164,13 +161,8 @@ public class CodeUtilsTest extends AbstractJavaTest {
 	 */
 	@Test
 	public void test_generateUniqueName() throws Exception {
-		assertSame("base", CodeUtils.generateUniqueName("base", Predicates.<String>alwaysTrue()));
-		assertEquals("base_3", CodeUtils.generateUniqueName("base", new Predicate<String>() {
-			@Override
-			public boolean apply(String name) {
-				return !name.equals("base") && !name.equals("base_1") && !name.equals("base_2");
-			}
-		}));
+		assertSame("base", CodeUtils.generateUniqueName("base", o -> true));
+		assertEquals("base_3", CodeUtils.generateUniqueName("base", name -> !name.equals("base") && !name.equals("base_1") && !name.equals("base_2")));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/jdt/core/ProjectUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/jdt/core/ProjectUtilsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.core.util.jdt.core;
-
-import com.google.common.base.Predicate;
 
 import org.eclipse.wb.internal.core.utils.jdt.core.ProjectUtils;
 import org.eclipse.wb.internal.core.utils.reflect.ProjectClassLoader;
@@ -51,6 +49,7 @@ import java.io.FileOutputStream;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 /**
  * Tests for {@link ProjectUtils}.
@@ -796,12 +795,9 @@ public class ProjectUtilsTest extends AbstractJavaTest {
 			assertEquals("/TestProject/src", rawClasspath[1].getPath().toPortableString());
 		}
 		// remove "src"
-		ProjectUtils.removeClasspathEntries(m_javaProject, new Predicate<IClasspathEntry>() {
-			@Override
-			public boolean apply(IClasspathEntry entry) {
-				String location = entry.getPath().toPortableString();
-				return location.endsWith("/src");
-			}
+		ProjectUtils.removeClasspathEntries(m_javaProject, entry -> {
+			String location = entry.getPath().toPortableString();
+			return location.endsWith("/src");
 		});
 		// has only JRE_CONTAINER
 		{

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/ApplicationWindowGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/ApplicationWindowGefTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,10 +10,7 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.rcp.model.jface;
 
-import com.google.common.base.Predicate;
-
 import org.eclipse.wb.core.model.ObjectInfo;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.internal.rcp.RcpToolkitDescription;
 import org.eclipse.wb.internal.rcp.model.jface.ApplicationWindowInfo;
 import org.eclipse.wb.internal.rcp.model.jface.action.ActionInfo;
@@ -69,12 +66,7 @@ public class ApplicationWindowGefTest extends RcpGefTest {
 		canvas.assertNoFeedbacks();
 		// move on "shell": target feedback appears
 		canvas.moveTo(shell);
-		canvas.assertFeedbacks(new Predicate<Figure>() {
-			@Override
-			public boolean apply(Figure t) {
-				return t.getSize().width > 200;
-			}
-		});
+		canvas.assertFeedbacks(t -> t.getSize().width > 200);
 		// click, so drop "newMenu"
 		canvas.click();
 		canvas.assertNoFeedbacks();

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuBarPopupTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuBarPopupTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,9 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.swt.model.menu;
 
-import com.google.common.base.Predicate;
-
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.tools.PasteTool;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.core.model.clipboard.JavaInfoMemento;
@@ -302,12 +299,7 @@ public class MenuBarPopupTest extends RcpGefTest {
 		canvas.assertNoFeedbacks();
 		// move on "shell": target feedback appears
 		canvas.moveTo(shellInfo, 0, 0);
-		canvas.assertFeedbacks(new Predicate<Figure>() {
-			@Override
-			public boolean apply(Figure t) {
-				return t.getSize().width > 200;
-			}
-		});
+		canvas.assertFeedbacks(t -> t.getSize().width > 200);
 		// click, so drop "bar"
 		canvas.click();
 		canvas.assertNoFeedbacks();

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuFeedbackTester.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuFeedbackTester.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.swt.model.menu;
 
-import com.google.common.base.Predicate;
-
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.gef.core.IEditPartViewer;
@@ -20,6 +18,8 @@ import org.eclipse.wb.internal.core.gef.policy.menu.MenuSelectionEditPolicy;
 import org.eclipse.wb.tests.gef.GraphicalRobot;
 
 import org.eclipse.draw2d.geometry.Rectangle;
+
+import java.util.function.Predicate;
 
 /**
  * Tester for feedbacks on {@link IEditPartViewer#MENU_FEEDBACK_LAYER}.
@@ -54,12 +54,7 @@ public final class MenuFeedbackTester {
 			FigureUtils.translateFigureToAbsolute(part.getFigure(), partBounds);
 		}
 		// return predicate
-		return new Predicate<>() {
-			@Override
-			public boolean apply(Figure feedback) {
-				return partBounds.equals(feedback.getBounds());
-			}
-		};
+		return feedback -> partBounds.equals(feedback.getBounds());
 	}
 
 	private Predicate<Figure> getSelectionPredicate(Object object) {

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/UiContext.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/UiContext.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.gef;
 
-import com.google.common.base.Predicate;
-
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
@@ -44,6 +42,7 @@ import org.apache.commons.lang.exception.NestableException;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * Helper for testing SWT UI.
@@ -184,24 +183,14 @@ public class UiContext {
 	 * @return the {@link Button} with given text.
 	 */
 	public Button getButtonByTextPrefix(final String prefix) {
-		return getButton(getShell(), new Predicate<String>() {
-			@Override
-			public boolean apply(String input) {
-				return input != null && input.startsWith(prefix);
-			}
-		});
+		return getButton(getShell(), input -> input != null && input.startsWith(prefix));
 	}
 
 	/**
 	 * @return the {@link Button} with given text.
 	 */
 	public Button getButtonByText(Widget start, final String text) {
-		return getButton(start, new Predicate<String>() {
-			@Override
-			public boolean apply(String input) {
-				return isSameText(input, text);
-			}
-		});
+		return getButton(start, input -> isSameText(input, text));
 	}
 
 	/**
@@ -213,7 +202,7 @@ public class UiContext {
 			@Override
 			public void endVisit(Widget widget) {
 				if (widget instanceof Button button) {
-					if (predicate.apply(button.getText()) || predicate.apply(button.getToolTipText())) {
+					if (predicate.test(button.getText()) || predicate.test(button.getToolTipText())) {
 						result[0] = button;
 					}
 				}

--- a/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/property/editor/ObjectPropertyEditor.java
+++ b/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/property/editor/ObjectPropertyEditor.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.xwt.model.property.editor;
 
-import com.google.common.base.Predicate;
-
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.model.property.Property;
@@ -31,6 +29,8 @@ import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.window.Window;
 import org.eclipse.ui.dialogs.ElementTreeSelectionDialog;
 import org.eclipse.ui.dialogs.ISelectionStatusValidator;
+
+import java.util.function.Predicate;
 
 /**
  * {@link PropertyEditor} for selecting model of {@link Object} in XWT.
@@ -129,7 +129,7 @@ public final class ObjectPropertyEditor extends TextDialogPropertyEditor {
 		final ITreeContentProvider[] contentProvider = new ITreeContentProvider[1];
 		contentProvider[0] = new ObjectsTreeContentProvider(new Predicate<ObjectInfo>() {
 			@Override
-			public boolean apply(ObjectInfo t) {
+			public boolean test(ObjectInfo t) {
 				return isValidComponent(propertyType, t) || hasValidComponents(t);
 			}
 

--- a/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/util/NameSupport.java
+++ b/org.eclipse.wb.xwt/src/org/eclipse/wb/internal/xwt/model/util/NameSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.xwt.model.util;
-
-import com.google.common.base.Predicate;
 
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.broadcast.ObjectInfoPresentationDecorateText;
@@ -112,12 +110,7 @@ public final class NameSupport {
 	private static String generateName(XmlObjectInfo object) {
 		String baseName = getBaseName(object);
 		final Set<String> existingNames = getExistingNames(object);
-		String uniqueName = CodeUtils.generateUniqueName(baseName, new Predicate<String>() {
-			@Override
-			public boolean apply(String name) {
-				return !existingNames.contains(name);
-			}
-		});
+		String uniqueName = CodeUtils.generateUniqueName(baseName, name -> !existingNames.contains(name));
 		return uniqueName;
 	}
 


### PR DESCRIPTION
Both interfaces are functionally the same, so we should use the built-in interface (introduced with Java 8) when possible.
Note that the API is slightly different. The Java interface requires a test() method, while Guava expects an apply() method. Furthermore, Guava also has utility methods such as Functions.alwaysTrue() and Functions.alwaysFalse(). But here we can either use functional interfaces (e.g. o -> true) or simply reuse the already existing AlwaysPredicate.

#270 