### PR TITLE
[GEF] Cleanup method signatures in IEditPartFactory to use GEF EditPart

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/CoreEditPartConfigurator.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/CoreEditPartConfigurator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,10 +14,12 @@ import org.eclipse.wb.core.gef.IEditPartConfigurator;
 import org.eclipse.wb.core.gef.policy.DirectTextPropertyEditPolicy;
 import org.eclipse.wb.core.model.AbstractComponentInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.internal.core.gef.policy.DblClickRunScriptEditPolicy;
 import org.eclipse.wb.internal.core.gef.policy.FlipBooleanPropertyEditPolicy;
 import org.eclipse.wb.internal.core.utils.state.GlobalState;
+
+import org.eclipse.gef.EditPart;
+import org.eclipse.gef.EditPolicy;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -29,7 +31,7 @@ import org.apache.commons.lang3.StringUtils;
  */
 public final class CoreEditPartConfigurator implements IEditPartConfigurator {
 	@Override
-	public void configure(EditPart context, EditPart editPart) {
+	public void configure(EditPart context, org.eclipse.wb.gef.core.EditPart editPart) {
 		Object model = editPart.getModel();
 		// double click
 		if (GlobalState.isComponent(model)) {
@@ -58,7 +60,8 @@ public final class CoreEditPartConfigurator implements IEditPartConfigurator {
 						component,
 						"double-click.flipBooleanProperty");
 		if (!StringUtils.isEmpty(propertyPath)) {
-			editPart.installEditPolicy(new FlipBooleanPropertyEditPolicy(component, propertyPath));
+			EditPolicy editPolicy = new FlipBooleanPropertyEditPolicy(component, propertyPath);
+			editPart.installEditPolicy(editPolicy.getClass(), editPolicy);
 		}
 	}
 
@@ -69,7 +72,8 @@ public final class CoreEditPartConfigurator implements IEditPartConfigurator {
 		String propertyPath =
 				GlobalState.getParametersProvider().getParameter(component, "double-click.runScript");
 		if (!StringUtils.isEmpty(propertyPath)) {
-			editPart.installEditPolicy(new DblClickRunScriptEditPolicy(component, propertyPath));
+			EditPolicy editPolicy = new DblClickRunScriptEditPolicy(component, propertyPath);
+			editPart.installEditPolicy(editPolicy.getClass(), editPolicy);
 		}
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/EditPartFactory2.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/EditPartFactory2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,13 +12,14 @@ package org.eclipse.wb.internal.core.gef;
 
 import org.eclipse.wb.core.model.IWrapper;
 import org.eclipse.wb.core.model.IWrapperInfo;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartFactory;
 import org.eclipse.wb.internal.core.gef.part.AbstractWrapperEditPart;
 import org.eclipse.wb.internal.core.gef.part.DesignRootEditPart;
 import org.eclipse.wb.internal.core.gef.part.nonvisual.ArrayObjectEditPart;
 import org.eclipse.wb.internal.core.model.DesignRootObject;
 import org.eclipse.wb.internal.core.model.nonvisual.AbstractArrayObjectInfo;
+
+import org.eclipse.gef.EditPart;
 
 /**
  * Generic implementation of {@link IEditPartFactory} that redirects {@link EditPart}'s creation to
@@ -44,7 +45,7 @@ public final class EditPartFactory2 implements IEditPartFactory {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public EditPart createEditPart(EditPart context, Object model) {
+	public org.eclipse.wb.gef.core.EditPart createEditPart(EditPart context, Object model) {
 		if (model == null) {
 			return null;
 		}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/GenericContainersConfigurator.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/GenericContainersConfigurator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,6 @@ package org.eclipse.wb.internal.core.gef;
 
 import org.eclipse.wb.core.gef.IEditPartConfigurator;
 import org.eclipse.wb.core.model.JavaInfo;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.internal.core.gef.policy.layout.generic.FlowContainerLayoutEditPolicy;
 import org.eclipse.wb.internal.core.gef.policy.layout.generic.SimpleContainerLayoutEditPolicy;
@@ -20,6 +19,8 @@ import org.eclipse.wb.internal.core.model.generic.FlowContainer;
 import org.eclipse.wb.internal.core.model.generic.FlowContainerFactory;
 import org.eclipse.wb.internal.core.model.generic.SimpleContainer;
 import org.eclipse.wb.internal.core.model.generic.SimpleContainerFactory;
+
+import org.eclipse.gef.EditPart;
 
 import java.util.List;
 
@@ -36,7 +37,7 @@ public final class GenericContainersConfigurator implements IEditPartConfigurato
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public void configure(EditPart context, EditPart editPart) {
+	public void configure(EditPart context, org.eclipse.wb.gef.core.EditPart editPart) {
 		if (editPart.getModel() instanceof JavaInfo) {
 			JavaInfo component = (JavaInfo) editPart.getModel();
 			configureComponent(editPart, component);

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gefTree/EditPartFactory2.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gefTree/EditPartFactory2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,13 +12,14 @@ package org.eclipse.wb.internal.core.gefTree;
 
 import org.eclipse.wb.core.gefTree.part.JavaEditPart;
 import org.eclipse.wb.core.model.JavaInfo;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartFactory;
 import org.eclipse.wb.internal.core.gefTree.part.ArrayObjectEditPart;
 import org.eclipse.wb.internal.core.gefTree.part.FlowContainerGroupEditPart;
 import org.eclipse.wb.internal.core.model.nonvisual.AbstractArrayObjectInfo;
 import org.eclipse.wb.internal.core.model.nonvisual.FlowContainerGroupInfo;
 import org.eclipse.wb.internal.gef.tree.TreeViewer;
+
+import org.eclipse.gef.EditPart;
 
 /**
  * Generic implementation of {@link IEditPartFactory} for {@link TreeViewer} that redirects
@@ -44,7 +45,7 @@ public final class EditPartFactory2 implements IEditPartFactory {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public EditPart createEditPart(EditPart context, Object model) {
+	public org.eclipse.wb.gef.core.EditPart createEditPart(EditPart context, Object model) {
 		if (model == null) {
 			return null;
 		}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gefTree/GenericContainersConfigurator.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gefTree/GenericContainersConfigurator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,6 @@ package org.eclipse.wb.internal.core.gefTree;
 import org.eclipse.wb.core.gef.IEditPartConfigurator;
 import org.eclipse.wb.core.model.AbstractComponentInfo;
 import org.eclipse.wb.core.model.JavaInfo;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.gefTree.policy.generic.FlowContainerLayoutEditPolicy;
@@ -24,6 +23,8 @@ import org.eclipse.wb.internal.core.model.generic.FlowContainerFactory;
 import org.eclipse.wb.internal.core.model.generic.SimpleContainer;
 import org.eclipse.wb.internal.core.model.generic.SimpleContainerFactory;
 import org.eclipse.wb.internal.core.model.nonvisual.FlowContainerGroupInfo;
+
+import org.eclipse.gef.EditPart;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -42,7 +43,7 @@ public final class GenericContainersConfigurator implements IEditPartConfigurato
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public void configure(EditPart context, EditPart editPart) {
+	public void configure(EditPart context, org.eclipse.wb.gef.core.EditPart editPart) {
 		if (editPart.getModel() instanceof JavaInfo) {
 			JavaInfo component = (JavaInfo) editPart.getModel();
 			configureComponent(editPart, component);

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/IEditPartFactory.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/IEditPartFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,11 +26,5 @@ public interface IEditPartFactory extends org.eclipse.gef.EditPartFactory {
 	 * Creates a new {@link EditPart} given the specified <i>context</i> and <i>model</i>.
 	 */
 	@Override
-	default org.eclipse.gef.EditPart createEditPart(org.eclipse.gef.EditPart context, Object model) {
-		return createEditPart((EditPart) context, model);
-	}
-	/**
-	 * Creates a new {@link EditPart} given the specified <i>context</i> and <i>model</i>.
-	 */
-	EditPart createEditPart(EditPart context, Object model);
+	EditPart createEditPart(org.eclipse.gef.EditPart context, Object model);
 }

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/core/AbstractEditPartViewer.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/core/AbstractEditPartViewer.java
@@ -93,7 +93,7 @@ public abstract class AbstractEditPartViewer extends org.eclipse.gef.ui.parts.Ab
 	 */
 	public void setInput(Object model) {
 		RootEditPart rootEditPart = getRootEditPart();
-		EditPart contentEditPart = m_factory.createEditPart((EditPart) rootEditPart, model);
+		EditPart contentEditPart = m_factory.createEditPart(rootEditPart, model);
 		rootEditPart.setContents(contentEditPart);
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/IEditPartConfigurator.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/IEditPartConfigurator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,9 +10,10 @@
  *******************************************************************************/
 package org.eclipse.wb.core.gef;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.internal.core.gef.EditPartFactory;
+
+import org.eclipse.gef.EditPart;
 
 /**
  * Implementations of {@link IEditPartConfigurator} are used by {@link EditPartFactory} to configure
@@ -33,5 +34,5 @@ public interface IEditPartConfigurator {
 	/**
 	 * Configures given {@link EditPart}.
 	 */
-	void configure(EditPart context, EditPart editPart);
+	void configure(EditPart context, org.eclipse.wb.gef.core.EditPart editPart);
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/MatchingEditPartFactory.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/MatchingEditPartFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,9 +10,10 @@
  *******************************************************************************/
 package org.eclipse.wb.core.gef;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartFactory;
 import org.eclipse.wb.internal.core.utils.check.Assert;
+
+import org.eclipse.gef.EditPart;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -57,10 +58,10 @@ public final class MatchingEditPartFactory implements IEditPartFactory {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public EditPart createEditPart(EditPart context, Object model) {
+	public org.eclipse.wb.gef.core.EditPart createEditPart(EditPart context, Object model) {
 		Class<?> modelClass = model.getClass();
 		for (; modelClass != null; modelClass = modelClass.getSuperclass()) {
-			EditPart editPart = createEditPart(model, modelClass);
+			org.eclipse.wb.gef.core.EditPart editPart = createEditPart(model, modelClass);
 			if (editPart != null) {
 				return editPart;
 			}
@@ -83,17 +84,17 @@ public final class MatchingEditPartFactory implements IEditPartFactory {
 	 * @return the {@link EditPart} corresponding to <code>modelClass</code>, may be <code>null</code>
 	 *         , if no match found.
 	 */
-	private EditPart createEditPart(Object model, Class<?> modelClass) {
+	private org.eclipse.wb.gef.core.EditPart createEditPart(Object model, Class<?> modelClass) {
 		// "Info" suffix
 		{
-			EditPart editPart = createEditPart(model, modelClass, "Info");
+			org.eclipse.wb.gef.core.EditPart editPart = createEditPart(model, modelClass, "Info");
 			if (editPart != null) {
 				return editPart;
 			}
 		}
 		// no suffix
 		{
-			EditPart editPart = createEditPart(model, modelClass, "");
+			org.eclipse.wb.gef.core.EditPart editPart = createEditPart(model, modelClass, "");
 			if (editPart != null) {
 				return editPart;
 			}
@@ -104,7 +105,7 @@ public final class MatchingEditPartFactory implements IEditPartFactory {
 			if (modelClassName.contains("$")) {
 				modelClassName = StringUtils.remove(modelClassName, "Info");
 				modelClassName = StringUtils.remove(modelClassName, "$");
-				EditPart editPart = createEditPart(model, modelClass, modelClassName, "");
+				org.eclipse.wb.gef.core.EditPart editPart = createEditPart(model, modelClass, modelClassName, "");
 				if (editPart != null) {
 					return editPart;
 				}
@@ -117,7 +118,7 @@ public final class MatchingEditPartFactory implements IEditPartFactory {
 	/**
 	 * Implementation for {@link #createEditPart(Object, Class)}, with single model suffix.
 	 */
-	private EditPart createEditPart(Object model, Class<?> modelClass, String modelSuffix) {
+	private org.eclipse.wb.gef.core.EditPart createEditPart(Object model, Class<?> modelClass, String modelSuffix) {
 		String modelClassName = modelClass.getName();
 		return createEditPart(model, modelClass, modelClassName, modelSuffix);
 	}
@@ -125,7 +126,7 @@ public final class MatchingEditPartFactory implements IEditPartFactory {
 	/**
 	 * Implementation for {@link #createEditPart(Object, Class)}, with single model suffix.
 	 */
-	private EditPart createEditPart(Object model,
+	private org.eclipse.wb.gef.core.EditPart createEditPart(Object model,
 			Class<?> modelClass,
 			String modelClassName,
 			String modelSuffix) {
@@ -141,7 +142,7 @@ public final class MatchingEditPartFactory implements IEditPartFactory {
 				// create corresponding EditPart, use "EditPart" prefix
 				{
 					String partClassName = partPackage + componentName + "EditPart";
-					EditPart editPart = createEditPart0(model, modelClass, partClassName);
+					org.eclipse.wb.gef.core.EditPart editPart = createEditPart0(model, modelClass, partClassName);
 					if (editPart != null) {
 						return editPart;
 					}
@@ -152,14 +153,14 @@ public final class MatchingEditPartFactory implements IEditPartFactory {
 		return null;
 	}
 
-	private static EditPart createEditPart0(Object model, Class<?> modelClass, String partClassName) {
+	private static org.eclipse.wb.gef.core.EditPart createEditPart0(Object model, Class<?> modelClass, String partClassName) {
 		try {
 			ClassLoader classLoader = modelClass.getClassLoader();
 			Class<?> partClass = classLoader.loadClass(partClassName);
 			// try all constructors
 			for (Constructor<?> constructor : partClass.getConstructors()) {
 				try {
-					return (EditPart) constructor.newInstance(model);
+					return (org.eclipse.wb.gef.core.EditPart) constructor.newInstance(model);
 				} catch (Throwable e) {
 					// ignore
 				}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/EditPartFactory.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/EditPartFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,11 +11,12 @@
 package org.eclipse.wb.internal.core.gef;
 
 import org.eclipse.wb.core.gef.IEditPartConfigurator;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartFactory;
 import org.eclipse.wb.internal.core.gef.part.menu.MenuEditPart;
 import org.eclipse.wb.internal.core.gef.part.menu.MenuReference;
 import org.eclipse.wb.internal.core.utils.external.ExternalFactoriesHelper;
+
+import org.eclipse.gef.EditPart;
 
 import java.util.List;
 
@@ -41,7 +42,7 @@ public final class EditPartFactory implements IEditPartFactory {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public EditPart createEditPart(EditPart context, Object model) {
+	public org.eclipse.wb.gef.core.EditPart createEditPart(EditPart context, Object model) {
 		if (model == null) {
 			return null;
 		}
@@ -67,7 +68,7 @@ public final class EditPartFactory implements IEditPartFactory {
 		//    }
 		// check each external factory
 		for (IEditPartFactory factory : getFactories()) {
-			EditPart editPart = factory.createEditPart(context, model);
+			org.eclipse.wb.gef.core.EditPart editPart = factory.createEditPart(context, model);
 			if (editPart != null) {
 				configureEditPart(context, editPart);
 				return editPart;
@@ -101,7 +102,7 @@ public final class EditPartFactory implements IEditPartFactory {
 	/**
 	 * Configures given {@link EditPart} using externally contributed {@link IEditPartConfigurator}'s.
 	 */
-	public static void configureEditPart(EditPart context, EditPart editPart) {
+	public static void configureEditPart(EditPart context, org.eclipse.wb.gef.core.EditPart editPart) {
 		List<IEditPartConfigurator> configurators =
 				ExternalFactoriesHelper.getElementsInstances(
 						IEditPartConfigurator.class,

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/header/HeadersEditPartFactory.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/header/HeadersEditPartFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,8 +10,9 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.gef.header;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartFactory;
+
+import org.eclipse.gef.EditPart;
 
 /**
  * Implementation of {@link IEditPartFactory} for headers.
@@ -21,7 +22,7 @@ import org.eclipse.wb.gef.core.IEditPartFactory;
  */
 public final class HeadersEditPartFactory implements IEditPartFactory {
 	@Override
-	public EditPart createEditPart(EditPart context, Object model) {
-		return (EditPart) model;
+	public org.eclipse.wb.gef.core.EditPart createEditPart(EditPart context, Object model) {
+		return (org.eclipse.wb.gef.core.EditPart) model;
 	}
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gefTree/EditPartFactory.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gefTree/EditPartFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,6 @@ package org.eclipse.wb.internal.core.gefTree;
 import org.eclipse.wb.core.gef.IEditPartConfigurator;
 import org.eclipse.wb.core.gefTree.part.ObjectEditPart;
 import org.eclipse.wb.core.model.ObjectInfo;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartFactory;
 import org.eclipse.wb.internal.core.gefTree.part.menu.MenuEditPart;
 import org.eclipse.wb.internal.core.gefTree.part.menu.MenuItemEditPart;
@@ -22,6 +21,8 @@ import org.eclipse.wb.internal.core.model.menu.IMenuItemInfo;
 import org.eclipse.wb.internal.core.model.menu.MenuObjectInfoUtils;
 import org.eclipse.wb.internal.core.utils.external.ExternalFactoriesHelper;
 import org.eclipse.wb.internal.gef.tree.TreeViewer;
+
+import org.eclipse.gef.EditPart;
 
 import java.util.List;
 
@@ -47,12 +48,12 @@ public final class EditPartFactory implements IEditPartFactory {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public EditPart createEditPart(EditPart context, Object model) {
+	public org.eclipse.wb.gef.core.EditPart createEditPart(EditPart context, Object model) {
 		if (model == null) {
 			return null;
 		}
 		// create EditPart
-		EditPart editPart = createEditPartPure(context, model);
+		org.eclipse.wb.gef.core.EditPart editPart = createEditPartPure(context, model);
 		if (editPart != null) {
 			configureEditPart(context, editPart);
 			return editPart;
@@ -60,7 +61,7 @@ public final class EditPartFactory implements IEditPartFactory {
 		// no EditPart found
 		return null;
 	}
-	private EditPart createEditPartPure(EditPart context, Object model) {
+	private org.eclipse.wb.gef.core.EditPart createEditPartPure(EditPart context, Object model) {
 		// menu
 		if (model instanceof ObjectInfo objectInfo) {
 			{
@@ -78,7 +79,7 @@ public final class EditPartFactory implements IEditPartFactory {
 		}
 		// check each external factory
 		for (IEditPartFactory factory : getFactories()) {
-			EditPart editPart = factory.createEditPart(context, model);
+			org.eclipse.wb.gef.core.EditPart editPart = factory.createEditPart(context, model);
 			if (editPart != null) {
 				return editPart;
 			}
@@ -121,7 +122,7 @@ public final class EditPartFactory implements IEditPartFactory {
 	/**
 	 * Configures given {@link EditPart} using externally contributed {@link IEditPartConfigurator}'s.
 	 */
-	private static void configureEditPart(EditPart context, EditPart editPart) {
+	private static void configureEditPart(EditPart context, org.eclipse.wb.gef.core.EditPart editPart) {
 		List<IEditPartConfigurator> configurators =
 				ExternalFactoriesHelper.getElementsInstances(
 						IEditPartConfigurator.class,

--- a/org.eclipse.wb.rcp.nebula/src/org/eclipse/wb/internal/rcp/nebula/gef/EditPartFactory.java
+++ b/org.eclipse.wb.rcp.nebula/src/org/eclipse/wb/internal/rcp/nebula/gef/EditPartFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,8 +11,9 @@
 package org.eclipse.wb.internal.rcp.nebula.gef;
 
 import org.eclipse.wb.core.gef.MatchingEditPartFactory;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartFactory;
+
+import org.eclipse.gef.EditPart;
 
 import java.util.List;
 
@@ -33,7 +34,7 @@ public final class EditPartFactory implements IEditPartFactory {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public EditPart createEditPart(EditPart context, Object model) {
+	public org.eclipse.wb.gef.core.EditPart createEditPart(EditPart context, Object model) {
 		return MATCHING_FACTORY.createEditPart(context, model);
 	}
 }

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/EditPartFactory.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/EditPartFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,6 @@ package org.eclipse.wb.internal.rcp.gef;
 import org.eclipse.wb.core.gef.MatchingEditPartFactory;
 import org.eclipse.wb.core.gef.part.menu.MenuEditPartFactory;
 import org.eclipse.wb.core.model.AbstractComponentInfo;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartFactory;
 import org.eclipse.wb.internal.core.EnvironmentUtils;
 import org.eclipse.wb.internal.core.model.menu.IMenuInfo;
@@ -25,6 +24,8 @@ import org.eclipse.wb.internal.rcp.model.forms.FormInfo;
 import org.eclipse.wb.internal.rcp.model.jface.DialogInfo;
 import org.eclipse.wb.internal.rcp.model.jface.action.MenuManagerInfo;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
+
+import org.eclipse.gef.EditPart;
 
 import java.util.List;
 
@@ -45,7 +46,7 @@ public final class EditPartFactory implements IEditPartFactory {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public EditPart createEditPart(EditPart context, Object model) {
+	public org.eclipse.wb.gef.core.EditPart createEditPart(EditPart context, Object model) {
 		// special Composite's
 		if (model instanceof CompositeInfo composite) {
 			// Form.getHead()
@@ -89,7 +90,7 @@ public final class EditPartFactory implements IEditPartFactory {
 	// Utils
 	//
 	////////////////////////////////////////////////////////////////////////////
-	private static EditPart createMenuEditPart(Object model, IMenuInfo menuInfo) {
+	private static org.eclipse.wb.gef.core.EditPart createMenuEditPart(Object model, IMenuInfo menuInfo) {
 		return EnvironmentUtils.IS_MAC
 				? MenuEditPartFactory.createMenuMac(model, menuInfo)
 						: MenuEditPartFactory.createMenu(model, menuInfo);

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/RcpPolicyConfigurator.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/RcpPolicyConfigurator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,12 +12,13 @@ package org.eclipse.wb.internal.rcp.gef.policy;
 
 import org.eclipse.wb.core.gef.IEditPartConfigurator;
 import org.eclipse.wb.core.gef.part.menu.IMenuObjectEditPart;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.internal.rcp.gef.policy.jface.ControlDecorationDropLayoutEditPolicy;
 import org.eclipse.wb.internal.rcp.gef.policy.jface.FieldEditorDropRequestProcessor;
 import org.eclipse.wb.internal.rcp.gef.policy.jface.action.ActionDropRequestProcessor;
 import org.eclipse.wb.internal.rcp.model.jface.action.MenuManagerInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
+
+import org.eclipse.gef.EditPart;
 
 /**
  * Configures RCP related {@link EditPart}'s.
@@ -27,7 +28,7 @@ import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
  */
 public final class RcpPolicyConfigurator implements IEditPartConfigurator {
 	@Override
-	public void configure(EditPart context, EditPart editPart) {
+	public void configure(EditPart context, org.eclipse.wb.gef.core.EditPart editPart) {
 		editPart.addRequestProcessor(FieldEditorDropRequestProcessor.INSTANCE);
 		// allow drop Action on MenuManager
 		if (editPart instanceof IMenuObjectEditPart menuEditPart) {

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gefTree/EditPartFactory.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gefTree/EditPartFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,11 +11,12 @@
 package org.eclipse.wb.internal.rcp.gefTree;
 
 import org.eclipse.wb.core.gef.MatchingEditPartFactory;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartFactory;
 import org.eclipse.wb.internal.rcp.gefTree.part.forms.FormHeadEditPart;
 import org.eclipse.wb.internal.rcp.model.forms.FormInfo;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
+
+import org.eclipse.gef.EditPart;
 
 import java.util.List;
 
@@ -36,7 +37,7 @@ public final class EditPartFactory implements IEditPartFactory {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public EditPart createEditPart(EditPart context, Object model) {
+	public org.eclipse.wb.gef.core.EditPart createEditPart(EditPart context, Object model) {
 		// special Composite's
 		if (model instanceof CompositeInfo composite) {
 			// Form.getHead()

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gefTree/policy/RcpPolicyConfigurator.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gefTree/policy/RcpPolicyConfigurator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,11 +11,12 @@
 package org.eclipse.wb.internal.rcp.gefTree.policy;
 
 import org.eclipse.wb.core.gef.IEditPartConfigurator;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.internal.rcp.gef.policy.jface.action.ActionDropRequestProcessor;
 import org.eclipse.wb.internal.rcp.gefTree.policy.jface.ControlDecorationDropLayoutEditPolicy;
 import org.eclipse.wb.internal.rcp.model.jface.action.MenuManagerInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
+
+import org.eclipse.gef.EditPart;
 
 /**
  * Configures RCP related {@link EditPart}'s.
@@ -25,7 +26,7 @@ import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
  */
 public final class RcpPolicyConfigurator implements IEditPartConfigurator {
 	@Override
-	public void configure(EditPart context, EditPart editPart) {
+	public void configure(EditPart context, org.eclipse.wb.gef.core.EditPart editPart) {
 		// allow drop Action on MenuManager
 		if (editPart.getModel() instanceof MenuManagerInfo) {
 			editPart.addRequestProcessor(ActionDropRequestProcessor.INSTANCE);

--- a/org.eclipse.wb.swing.jsr296/src/org/eclipse/wb/internal/swing/jsr296/gef/EditPartFactory.java
+++ b/org.eclipse.wb.swing.jsr296/src/org/eclipse/wb/internal/swing/jsr296/gef/EditPartFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,8 +11,9 @@
 package org.eclipse.wb.internal.swing.jsr296.gef;
 
 import org.eclipse.wb.core.gef.MatchingEditPartFactory;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartFactory;
+
+import org.eclipse.gef.EditPart;
 
 import java.util.List;
 
@@ -33,7 +34,7 @@ public final class EditPartFactory implements IEditPartFactory {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public EditPart createEditPart(EditPart context, Object model) {
+	public org.eclipse.wb.gef.core.EditPart createEditPart(EditPart context, Object model) {
 		return MATCHING_FACTORY.createEditPart(context, model);
 	}
 }

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/EditPartFactory.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/EditPartFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,6 @@ package org.eclipse.wb.internal.swing.gef;
 
 import org.eclipse.wb.core.gef.MatchingEditPartFactory;
 import org.eclipse.wb.core.gef.part.menu.MenuEditPartFactory;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartFactory;
 import org.eclipse.wb.internal.core.model.creation.factory.StaticFactoryCreationSupport;
 import org.eclipse.wb.internal.core.model.description.factory.FactoryMethodDescription;
@@ -43,6 +42,8 @@ import org.eclipse.wb.internal.swing.model.component.menu.JMenuInfo;
 import org.eclipse.wb.internal.swing.model.component.menu.JMenuItemInfo;
 import org.eclipse.wb.internal.swing.model.component.menu.JPopupMenuInfo;
 
+import org.eclipse.gef.EditPart;
+
 import java.util.List;
 
 import javax.swing.Box;
@@ -67,9 +68,9 @@ public final class EditPartFactory implements IEditPartFactory {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public EditPart createEditPart(EditPart context, Object model) {
+	public org.eclipse.wb.gef.core.EditPart createEditPart(EditPart context, Object model) {
 		for (IEditPartFactory factory : FACTORIES) {
-			EditPart editPart = factory.createEditPart(null, model);
+			org.eclipse.wb.gef.core.EditPart editPart = factory.createEditPart(null, model);
 			if (editPart != null) {
 				return editPart;
 			}
@@ -84,7 +85,7 @@ public final class EditPartFactory implements IEditPartFactory {
 	////////////////////////////////////////////////////////////////////////////
 	private static final IEditPartFactory MENU_FACTORY = new IEditPartFactory() {
 		@Override
-		public EditPart createEditPart(EditPart context, Object model) {
+		public org.eclipse.wb.gef.core.EditPart createEditPart(EditPart context, Object model) {
 			if (model instanceof JMenuBarInfo menu) {
 				IMenuInfo menuObject = MenuObjectInfoUtils.getMenuInfo(menu);
 				return MenuEditPartFactory.createMenu(model, menuObject);
@@ -109,7 +110,7 @@ public final class EditPartFactory implements IEditPartFactory {
 	};
 	private static final IEditPartFactory SPECIAL_FACTORY = new IEditPartFactory() {
 		@Override
-		public EditPart createEditPart(EditPart context, Object model) {
+		public org.eclipse.wb.gef.core.EditPart createEditPart(EditPart context, Object model) {
 			if (model instanceof JSplitPaneInfo) {
 				return new JSplitPaneEditPart((JSplitPaneInfo) model);
 			}
@@ -127,7 +128,7 @@ public final class EditPartFactory implements IEditPartFactory {
 	};
 	private static final IEditPartFactory BOX_FACTORY = new IEditPartFactory() {
 		@Override
-		public EditPart createEditPart(EditPart context, Object model) {
+		public org.eclipse.wb.gef.core.EditPart createEditPart(EditPart context, Object model) {
 			if (model instanceof ComponentInfo component) {
 				if (component.getCreationSupport() instanceof StaticFactoryCreationSupport) {
 					StaticFactoryCreationSupport factoryCreationSupport =
@@ -143,7 +144,7 @@ public final class EditPartFactory implements IEditPartFactory {
 			return null;
 		}
 
-		private EditPart createEditPart(ComponentInfo component, String signature) {
+		private org.eclipse.wb.gef.core.EditPart createEditPart(ComponentInfo component, String signature) {
 			// glue
 			if (signature.equals("createGlue()")) {
 				return new BoxGlueEditPart(component);
@@ -173,7 +174,7 @@ public final class EditPartFactory implements IEditPartFactory {
 					List.of("org.eclipse.wb.internal.swing.gef.part"));
 	private static final IEditPartFactory GENERIC_FACTORY = new IEditPartFactory() {
 		@Override
-		public EditPart createEditPart(EditPart context, Object model) {
+		public org.eclipse.wb.gef.core.EditPart createEditPart(EditPart context, Object model) {
 			if (model instanceof ContainerInfo) {
 				return new ContainerEditPart((ContainerInfo) model);
 			}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/action/ActionDropPolicyConfigurator.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/action/ActionDropPolicyConfigurator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,10 +11,11 @@
 package org.eclipse.wb.internal.swing.gef.policy.action;
 
 import org.eclipse.wb.core.gef.IEditPartConfigurator;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.internal.swing.model.bean.ActionInfo;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
+
+import org.eclipse.gef.EditPart;
 
 import javax.swing.AbstractButton;
 
@@ -26,7 +27,7 @@ import javax.swing.AbstractButton;
  */
 public final class ActionDropPolicyConfigurator implements IEditPartConfigurator {
 	@Override
-	public void configure(EditPart context, EditPart editPart) {
+	public void configure(EditPart context, org.eclipse.wb.gef.core.EditPart editPart) {
 		// drop ActionInfo on javax.swing.AbstractButton
 		if (editPart.getModel() instanceof ComponentInfo) {
 			ComponentInfo component = (ComponentInfo) editPart.getModel();

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/menu/MenuDropPolicyConfigurator.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/menu/MenuDropPolicyConfigurator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,10 +11,11 @@
 package org.eclipse.wb.internal.swing.gef.policy.menu;
 
 import org.eclipse.wb.core.gef.IEditPartConfigurator;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
+
+import org.eclipse.gef.EditPart;
 
 import javax.swing.JApplet;
 import javax.swing.JDialog;
@@ -30,7 +31,7 @@ import javax.swing.JInternalFrame;
 @SuppressWarnings("removal")
 public final class MenuDropPolicyConfigurator implements IEditPartConfigurator {
 	@Override
-	public void configure(EditPart context, EditPart editPart) {
+	public void configure(EditPart context, org.eclipse.wb.gef.core.EditPart editPart) {
 		// drop JMenuBar on JFrame, JDialog and JApply
 		if (editPart.getModel() instanceof ContainerInfo) {
 			ContainerInfo container = (ContainerInfo) editPart.getModel();

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gefTree/EditPartFactory.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gefTree/EditPartFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,12 +10,13 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.gefTree;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartFactory;
 import org.eclipse.wb.internal.swing.gefTree.part.ComponentEditPart;
 import org.eclipse.wb.internal.swing.gefTree.part.ContainerEditPart;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
+
+import org.eclipse.gef.EditPart;
 
 /**
  * Implementation of {@link IEditPartFactory} for Swing.
@@ -30,7 +31,7 @@ public final class EditPartFactory implements IEditPartFactory {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public EditPart createEditPart(EditPart context, Object model) {
+	public org.eclipse.wb.gef.core.EditPart createEditPart(EditPart context, Object model) {
 		// components
 		if (model instanceof ContainerInfo) {
 			return new ContainerEditPart((ContainerInfo) model);

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/EditPartFactory.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/EditPartFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,6 @@ package org.eclipse.wb.internal.swt.gef;
 
 import org.eclipse.wb.core.gef.MatchingEditPartFactory;
 import org.eclipse.wb.core.gef.part.menu.MenuEditPartFactory;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartFactory;
 import org.eclipse.wb.internal.core.EnvironmentUtils;
 import org.eclipse.wb.internal.core.model.menu.IMenuInfo;
@@ -21,6 +20,8 @@ import org.eclipse.wb.internal.core.model.menu.IMenuPopupInfo;
 import org.eclipse.wb.internal.core.model.menu.MenuObjectInfoUtils;
 import org.eclipse.wb.internal.swt.model.widgets.menu.MenuInfo;
 import org.eclipse.wb.internal.swt.model.widgets.menu.MenuItemInfo;
+
+import org.eclipse.gef.EditPart;
 
 import java.util.List;
 
@@ -45,7 +46,7 @@ public final class EditPartFactory implements IEditPartFactory {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public EditPart createEditPart(EditPart context, Object model) {
+	public org.eclipse.wb.gef.core.EditPart createEditPart(EditPart context, Object model) {
 		// menu
 		{
 			if (model instanceof MenuInfo menu) {
@@ -71,7 +72,7 @@ public final class EditPartFactory implements IEditPartFactory {
 	// Utils
 	//
 	////////////////////////////////////////////////////////////////////////////
-	private EditPart createMenuEditPart(Object model, IMenuInfo menuInfo) {
+	private org.eclipse.wb.gef.core.EditPart createMenuEditPart(Object model, IMenuInfo menuInfo) {
 		return EnvironmentUtils.IS_MAC
 				? MenuEditPartFactory.createMenuMac(model, menuInfo)
 						: MenuEditPartFactory.createMenu(model, menuInfo);

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gefTree/EditPartFactory.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gefTree/EditPartFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,8 +11,9 @@
 package org.eclipse.wb.internal.swt.gefTree;
 
 import org.eclipse.wb.core.gef.MatchingEditPartFactory;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartFactory;
+
+import org.eclipse.gef.EditPart;
 
 import java.util.List;
 
@@ -33,7 +34,7 @@ public final class EditPartFactory implements IEditPartFactory {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public EditPart createEditPart(EditPart context, Object model) {
+	public org.eclipse.wb.gef.core.EditPart createEditPart(EditPart context, Object model) {
 		// most EditPart's can be created using matching
 		return MATCHING_FACTORY.createEditPart(context, model);
 	}


### PR DESCRIPTION
We no longer define two createEditPart methods, one for the GEF EditPart and one for the WB EditPart, but instead only the former inherited from the parent interface.

This makes this interface eligible for removal at a later point.