### PR TITLE
Add required modules to module-info.java file when creating new template

### DIFF
--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/wizards/autobindings/AutomaticDatabindingWizard.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/wizards/autobindings/AutomaticDatabindingWizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,6 +23,9 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 
+import java.util.Collections;
+import java.util.Set;
+
 /**
  * Automatic bindings wizard.
  *
@@ -41,6 +44,11 @@ public abstract class AutomaticDatabindingWizard extends AbstractDesignWizard {
 	@Override
 	protected final AbstractDesignWizardPage createMainPage() {
 		return null;
+	}
+
+	@Override
+	protected final Set<String> getRequiredModuleNames() {
+		return Collections.emptySet();
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/wizards/AbstractDesignWizard.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/wizards/AbstractDesignWizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,12 +10,24 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.wizards;
 
+import org.eclipse.wb.internal.core.utils.jdt.core.ProjectUtils;
+
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IModuleDescription;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.wizard.WizardPage;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Base class for wizard responsible to create Java elements.
@@ -72,12 +84,62 @@ public abstract class AbstractDesignWizard extends DesignerNewElementWizard {
 
 	@Override
 	protected void finishPage(IProgressMonitor monitor) throws Exception {
+		if (getJavaProject() != null && getJavaProject().getModuleDescription() != null) {
+			updateModuleInfo(getJavaProject().getModuleDescription());
+		}
 		m_mainPage.createType(monitor);
 	}
 
 	public final IJavaElement getCreatedElement() {
 		return m_mainPage.getCreatedType();
 	}
+
+	private void updateModuleInfo(IModuleDescription moduleDescription) throws Exception {
+		Set<String> moduleNames = Set.of(moduleDescription.getRequiredModuleNames());
+		if (moduleNames.containsAll(getRequiredModuleNames())) {
+			return;
+		}
+
+		IFile moduleInfo = (IFile) moduleDescription.getResource();
+		List<String> lines = new ArrayList<>(Files.readAllLines(moduleInfo.getLocation().toPath()));
+		// Calculate the content of the new module-info.java file
+		boolean moduleHeaderFound = false;
+		boolean moduleBodyFound = false;
+		for (int i = 0; i < lines.size(); ++i) {
+			if (lines.get(i).contains("module")) {
+				moduleHeaderFound = true;
+			}
+			if (lines.get(i).contains("{")) {
+				moduleBodyFound = true;
+			}
+			if (moduleHeaderFound && moduleBodyFound) {
+				for (String moduleName : getRequiredModuleNames()) {
+					if (!moduleNames.contains(moduleName)) {
+						lines.add(i + 1, String.format("\trequires %s;", moduleName));
+					}
+				}
+				break;
+			}
+		}
+		// Store the updated module-info.java to the file system
+		String sourceCode = lines.stream().reduce((u, v) -> u + System.lineSeparator() + v).orElse(null);
+		if (sourceCode != null) {
+			try (InputStream is = new ByteArrayInputStream(sourceCode.getBytes(StandardCharsets.UTF_8))) {
+				moduleInfo.setContents(is, IResource.FORCE, null);
+			}
+		}
+		//
+		ProjectUtils.requireModuleAttribute(getJavaProject());
+	}
+
+	/**
+	 * This method is called just before a new type is created, to ensure that all
+	 * dependencies are available, before the type is compiled.
+	 *
+	 * @return A set of all modules names that need to be added to
+	 *         {@code module-info.java}.
+	 */
+	protected abstract Set<String> getRequiredModuleNames();
 
 	/**
 	 * Opens creates UI in editor.

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/wizards/RcpWizard.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/wizards/RcpWizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,9 +10,12 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.wizards;
 
+import org.eclipse.wb.internal.core.utils.jdt.core.ProjectUtils;
 import org.eclipse.wb.internal.core.wizards.AbstractDesignWizard;
 
 import org.eclipse.jface.wizard.Wizard;
+
+import java.util.Set;
 
 /**
  * Abstract {@link Wizard} for RCP toolkit.
@@ -21,4 +24,8 @@ import org.eclipse.jface.wizard.Wizard;
  * @coverage rcp.wizards.ui
  */
 public abstract class RcpWizard extends AbstractDesignWizard {
+	@Override
+	protected final Set<String> getRequiredModuleNames() {
+		return Set.copyOf(ProjectUtils.getAllPluginLibraries());
+	}
 }

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/wizards/project/NewProjectWizard.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/wizards/project/NewProjectWizard.java
@@ -54,20 +54,8 @@ public class NewProjectWizard extends DesignerJavaProjectWizard {
 	}
 
 	private static void addRequiredLibraries(IJavaProject javaProject) throws Exception {
-		ProjectUtils.addPluginLibraries(javaProject, "org.eclipse.osgi");
-		ProjectUtils.addPluginLibraries(javaProject, "org.eclipse.core.commands");
-		ProjectUtils.addPluginLibraries(javaProject, "org.eclipse.equinox.common");
-		ProjectUtils.addPluginLibraries(javaProject, "org.eclipse.equinox.registry");
-		ProjectUtils.addPluginLibraries(javaProject, "org.eclipse.core.runtime");
-		ProjectUtils.addPluginLibraries(javaProject, "org.eclipse.text");
-		ProjectUtils.addSWTLibrary(javaProject);
-		ProjectUtils.addPluginLibraries(javaProject, "org.eclipse.jface");
-		ProjectUtils.addPluginLibraries(javaProject, "org.eclipse.jface.text");
-		ProjectUtils.addPluginLibraries(javaProject, "org.eclipse.ui.workbench");
-		ProjectUtils.addPluginLibraries(javaProject, "com.ibm.icu");
-		ProjectUtils.addPluginLibraries(javaProject, "org.eclipse.ui.forms");
-		// E4 support
-		ProjectUtils.addPluginLibraries(javaProject, "javax.annotation");
-		ProjectUtils.addPluginLibraries(javaProject, "org.eclipse.e4.ui.di");
+		for (String symbolicName : ProjectUtils.getAllPluginLibraries()) {
+			ProjectUtils.addPluginLibraries(javaProject, symbolicName);
+		}
 	}
 }

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/wizards/SwingWizard.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/wizards/SwingWizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,8 @@ import org.eclipse.wb.internal.core.wizards.AbstractDesignWizard;
 
 import org.eclipse.jface.wizard.Wizard;
 
+import java.util.Set;
+
 /**
  * Abstract {@link Wizard} for Swing toolkit.
  *
@@ -21,4 +23,8 @@ import org.eclipse.jface.wizard.Wizard;
  * @coverage swing.wizards.ui
  */
 public abstract class SwingWizard extends AbstractDesignWizard {
+	@Override
+	protected final Set<String> getRequiredModuleNames() {
+		return Set.of("java.desktop");
+	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/jdt/core/ProjectUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/jdt/core/ProjectUtilsTest.java
@@ -766,20 +766,6 @@ public class ProjectUtilsTest extends AbstractJavaTest {
 	}
 
 	/**
-	 * Test for {@link ProjectUtils#addSWTLibrary(IJavaProject)}.
-	 */
-	@DisposeProjectAfter
-	@Test
-	public void test_addSWTLibrary() throws Exception {
-		// no org.eclipse.swt.SWT
-		assertFalse(ProjectUtils.hasType(m_javaProject, "org.eclipse.swt.SWT"));
-		// add SWP plugin library
-		ProjectUtils.addSWTLibrary(m_javaProject);
-		// OK, org.eclipse.swt.SWT now exists in project
-		assertTrue(ProjectUtils.hasType(m_javaProject, "org.eclipse.swt.SWT"));
-	}
-
-	/**
 	 * Test for {@link ProjectUtils#removeClasspathEntries(IJavaProject, Predicate)}.
 	 */
 	@DisposeProjectAfter

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/SwingNewWizardTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/SwingNewWizardTest.java
@@ -65,4 +65,18 @@ public class SwingNewWizardTest extends DesignerEditorTestCase {
 	public void testCreateNewApplicationWindow() throws Exception {
 		openDesign(new NewSwingApplicationWizard(), m_packageFragment, "MyApplicationWindow");
 	}
+
+	@Test
+	public void testCreateWithJavaModules() throws Exception {
+		setFileContentSrc("module-info.java", """
+				module test {
+				}""");
+		//
+		openDesign(new NewJFrameWizard(), m_packageFragment, "MyJFrame");
+		//
+		assertEquals(getFileContentSrc("module-info.java"), """
+				module test {
+					requires java.desktop;
+				}""");
+	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/SwingNewWizardTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/SwingNewWizardTest.java
@@ -16,6 +16,7 @@ import org.eclipse.wb.internal.swing.wizards.dialog.NewJDialogWizard;
 import org.eclipse.wb.internal.swing.wizards.frame.NewJFrameWizard;
 import org.eclipse.wb.internal.swing.wizards.frame.NewJInternalFrameWizard;
 import org.eclipse.wb.internal.swing.wizards.panel.NewJPanelWizard;
+import org.eclipse.wb.tests.designer.core.annotations.DisposeProjectAfter;
 import org.eclipse.wb.tests.designer.editor.DesignerEditorTestCase;
 
 import org.eclipse.jdt.core.IPackageFragment;
@@ -37,46 +38,55 @@ public class SwingNewWizardTest extends DesignerEditorTestCase {
 	}
 
 	@Test
+	@DisposeProjectAfter
 	public void testCreateNewJFrame() throws Exception {
 		openDesign(new NewJFrameWizard(), m_packageFragment, "MyJFrame");
 	}
 
 	@Test
+	@DisposeProjectAfter
 	public void testCreateNewJPanel() throws Exception {
 		openDesign(new NewJPanelWizard(), m_packageFragment, "MyJPanel");
 	}
 
 	@Test
+	@DisposeProjectAfter
 	public void testCreateNewJDialog() throws Exception {
 		openDesign(new NewJDialogWizard(), m_packageFragment, "MyJDialog");
 	}
 
 	@Test
+	@DisposeProjectAfter
 	public void testCreateNewJApplet() throws Exception {
 		openDesign(new NewJAppletWizard(), m_packageFragment, "MyJApplet");
 	}
 
 	@Test
+	@DisposeProjectAfter
 	public void testCreateNewJInternalFrame() throws Exception {
 		openDesign(new NewJInternalFrameWizard(), m_packageFragment, "MyJInternalFrame");
 	}
 
 	@Test
+	@DisposeProjectAfter
 	public void testCreateNewApplicationWindow() throws Exception {
 		openDesign(new NewSwingApplicationWizard(), m_packageFragment, "MyApplicationWindow");
 	}
 
 	@Test
+	@DisposeProjectAfter
 	public void testCreateWithJavaModules() throws Exception {
 		setFileContentSrc("module-info.java", """
 				module test {
 				}""");
 		//
 		openDesign(new NewJFrameWizard(), m_packageFragment, "MyJFrame");
-		//
-		assertEquals(getFileContentSrc("module-info.java"), """
-				module test {
-					requires java.desktop;
-				}""");
+		// We can't use code blocks as they don't consider carriage-returns
+		assertArrayEquals(getFileContentSrc("module-info.java").split(System.lineSeparator()),
+				new String[] {
+						"module test {",
+						"	requires java.desktop;",
+						"}"
+				});
 	}
 }


### PR DESCRIPTION
In case a project contains the module-info.java, the user has to manually add e.g. the "java.desktop" module, if they want to use Swing. If not, WindowBuilder will be unable to parse the source code and thus also unable to open the design page.

Given that in the project wizard, the checkmark to create this file is set by default, so it's very common to create and just forget about this file, when setting up a workspace.

Figuring out which modules to add is quite tedious and not immediately obvious for those not experienced with this feature, meaning we should attempt to automate this when possible.

Resolves #472, #473, #574, #592, #613