### PR TITLE
Wait for shell to update as attempt to stabilize image property tests

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ImagePropertyEditorTestWithManager.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ImagePropertyEditorTestWithManager.java
@@ -188,6 +188,7 @@ public class ImagePropertyEditorTestWithManager extends ImagePropertyEditorTest 
 		// set "image" property
 		shell.addMethodInvocation("setImage(org.eclipse.swt.graphics.Image)", imageSource);
 		shell.refresh();
+		waitEventLoop(10);
 		//
 		Property property = shell.getPropertyByTitle("image");
 		assertEquals(expectedText, PropertyEditorTestUtils.getText(property));


### PR DESCRIPTION
It seems the shell hasn't been updated by the time we try to fetch the image that is assigned to it. Pump the event queue for 5ms to give WindowBuilder enough time to update the model.