### PR TITLE
Increase wait time for layout tests to 20ms to reduce instability.

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/layouts/grid/GridLayoutGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/layouts/grid/GridLayoutGefTest.java
@@ -100,7 +100,7 @@ public class GridLayoutGefTest extends RcpGefTest {
 		ControlInfo button = getJavaInfoByName("button");
 		// select "button"
 		canvas.select(button);
-		waitEventLoop(10);
+		waitEventLoop(20);
 		// delete
 		{
 			IAction deleteAction = getDeleteAction();
@@ -146,14 +146,14 @@ public class GridLayoutGefTest extends RcpGefTest {
 				"}");
 		// select "shell", so show headers
 		canvas.select(composite);
-		waitEventLoop(0);
+		waitEventLoop(20);
 		// drop "absolute"
 		{
 			AbsoluteLayoutEntryInfo absoluteEntry = new AbsoluteLayoutEntryInfo();
 			absoluteEntry.initialize(m_viewerCanvas, composite);
 			absoluteEntry.activate(false);
 			canvas.target(composite).in(250, 50).move().click();
-			waitEventLoop(0);
+			waitEventLoop(20);
 		}
 		// validate
 		assertEditor(


### PR DESCRIPTION
The delete action is fired before the selection event has been fully processed, leading to occasional failures. By increasing the wait time, this should be avoided.