### PR TITLE
Restore delayed event execution for EditEventManager

### DIFF
--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/EventManager.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/EventManager.java
@@ -181,8 +181,10 @@ public class EventManager extends EventDispatcher {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public void dispatchMouseDoubleClicked(org.eclipse.swt.events.MouseEvent event) {
-		updateFigureUnderCursor(event);
-		sendEvent(() -> m_targetFigure.handleMouseDoubleClicked(m_currentEvent), event);
+		delayEvent(() -> {
+			updateFigureUnderCursor(event);
+			sendEvent(() -> m_targetFigure.handleMouseDoubleClicked(m_currentEvent), event);
+		}, event);
 	}
 
 	@Override
@@ -190,23 +192,29 @@ public class EventManager extends EventDispatcher {
 		if (m_canvas.getToolTipText() != null) {
 			m_canvas.setToolTipText(null);
 		}
-		updateFigureUnderCursor(event);
-		sendEvent(() -> m_targetFigure.handleMousePressed(m_currentEvent), event);
+		delayEvent(() -> {
+			updateFigureUnderCursor(event);
+			sendEvent(() -> m_targetFigure.handleMousePressed(m_currentEvent), event);
+		}, event);
 	}
 
 	@Override
 	public void dispatchMouseReleased(org.eclipse.swt.events.MouseEvent event) {
-		updateFigureUnderCursor(event);
-		sendEvent(() -> m_targetFigure.handleMouseReleased(m_currentEvent), event);
+		delayEvent(() -> {
+			updateFigureUnderCursor(event);
+			sendEvent(() -> m_targetFigure.handleMouseReleased(m_currentEvent), event);
+		}, event);
 	}
 
 	@Override
 	public void dispatchMouseMoved(org.eclipse.swt.events.MouseEvent event) {
-		updateFigureUnderCursor(event);
-		sendEvent(() -> m_targetFigure.handleMouseMoved(m_currentEvent), event);
+		delayEvent(() -> {
+			updateFigureUnderCursor(event);
+			sendEvent(() -> m_targetFigure.handleMouseMoved(m_currentEvent), event);
+		}, event);
 	}
 
-	private <T extends Object> void sendEvent(Runnable delayEvent,
+	private <T extends Object> void sendEvent(Runnable event,
 			org.eclipse.swt.events.MouseEvent e) {
 		m_currentEvent = null;
 		m_targetFigure = m_captureFigure == null ? m_cursorFigure : m_captureFigure;
@@ -223,7 +231,7 @@ public class EventManager extends EventDispatcher {
 			m_currentEvent.x = location.x;
 			m_currentEvent.y = location.y;
 			//
-			delayEvent(e.widget, delayEvent);
+			event.run();
 		}
 	}
 
@@ -271,20 +279,26 @@ public class EventManager extends EventDispatcher {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public void dispatchMouseEntered(org.eclipse.swt.events.MouseEvent event) {
-		updateFigureUnderCursor(event);
-		sendEvent(() -> m_targetFigure.handleMouseEntered(m_currentEvent), event);
+		delayEvent(() -> {
+			updateFigureUnderCursor(event);
+			sendEvent(() -> m_targetFigure.handleMouseEntered(m_currentEvent), event);
+		}, event);
 	}
 
 	@Override
 	public void dispatchMouseExited(org.eclipse.swt.events.MouseEvent event) {
-		updateFigureUnderCursor(event);
-		sendEvent(() -> m_targetFigure.handleMouseExited(m_currentEvent), event);
+		delayEvent(() -> {
+			updateFigureUnderCursor(event);
+			sendEvent(() -> m_targetFigure.handleMouseExited(m_currentEvent), event);
+		}, event);
 	}
 
 	@Override
 	public void dispatchMouseHover(org.eclipse.swt.events.MouseEvent event) {
-		updateFigureUnderCursor(event);
-		sendEvent(() -> m_targetFigure.handleMouseHover(m_currentEvent), event);
+		delayEvent(() -> {
+			updateFigureUnderCursor(event);
+			sendEvent(() -> m_targetFigure.handleMouseHover(m_currentEvent), event);
+		}, event);
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -331,10 +345,11 @@ public class EventManager extends EventDispatcher {
 	 * If arguments contain {@link TypedEvent} and target {@link Control} is disabled, then puts this
 	 * event into {@link List} with key {@link #KEY_DELAYED_EVENTS}.
 	 */
-	private static void delayEvent(Widget widget, Runnable delayEvent) {
+	protected void delayEvent(Runnable event, org.eclipse.swt.events.MouseEvent e) {
+		Widget widget = e.widget;
 		if (widget.isDisposed() || widget.getData(FLAG_DELAY_EVENTS) == null) {
 			// execute immediately
-			delayEvent.run();
+			event.run();
 		} else {
 			// prepare delay queue
 			@SuppressWarnings("unchecked")
@@ -344,7 +359,7 @@ public class EventManager extends EventDispatcher {
 				widget.setData(KEY_DELAYED_EVENTS, eventQueue);
 			}
 			// put event into queue
-			eventQueue.add(delayEvent);
+			eventQueue.add(event);
 		}
 	}
 

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/graphical/EditEventManager.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/graphical/EditEventManager.java
@@ -104,70 +104,78 @@ public class EditEventManager extends EventManager {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public void dispatchMouseDoubleClicked(MouseEvent event) {
-		m_currentMouseEvent = event;
-		//
-		if (!m_eventCapture) {
-			super.dispatchMouseDoubleClicked(event);
-			if (isEventConsumed()) {
-				return;
+		delayEvent(() -> {
+			m_currentMouseEvent = event;
+			//
+			if (!m_eventCapture) {
+				super.dispatchMouseDoubleClicked(event);
+				if (isEventConsumed()) {
+					return;
+				}
 			}
-		}
-		//
-		m_domain.mouseDoubleClick(event, m_viewer);
+			//
+			m_domain.mouseDoubleClick(event, m_viewer);
+		}, event);
 	}
 
 	@Override
 	public void dispatchMousePressed(MouseEvent event) {
-		m_viewer.getControl().forceFocus();
-		m_currentMouseEvent = event;
-		//
-		if (!m_eventCapture) {
-			super.dispatchMousePressed(event);
-			if (isEventConsumed()) {
-				return;
+		delayEvent(() -> {
+			m_viewer.getControl().forceFocus();
+			m_currentMouseEvent = event;
+			//
+			if (!m_eventCapture) {
+				super.dispatchMousePressed(event);
+				if (isEventConsumed()) {
+					return;
+				}
 			}
-		}
-		//
-		m_eventCapture = true;
-		m_domain.mouseDown(event, m_viewer);
+			//
+			m_eventCapture = true;
+			m_domain.mouseDown(event, m_viewer);
+		}, event);
 	}
 
 	@Override
 	public void dispatchMouseReleased(MouseEvent event) {
-		m_currentMouseEvent = event;
-		//
-		if (!m_eventCapture) {
-			super.dispatchMouseReleased(event);
-			if (isEventConsumed()) {
-				return;
+		delayEvent(() -> {
+			m_currentMouseEvent = event;
+			//
+			if (!m_eventCapture) {
+				super.dispatchMouseReleased(event);
+				if (isEventConsumed()) {
+					return;
+				}
 			}
-		}
-		//
-		boolean eventCapture = m_eventCapture;
-		m_eventCapture = false;
-		m_domain.mouseUp(event, m_viewer);
-		// after release capture update mouse figure
-		if (eventCapture) {
-			updateFigureUnderCursor(event);
-		}
+			//
+			boolean eventCapture = m_eventCapture;
+			m_eventCapture = false;
+			m_domain.mouseUp(event, m_viewer);
+			// after release capture update mouse figure
+			if (eventCapture) {
+				updateFigureUnderCursor(event);
+			}
+		}, event);
 	}
 
 	@Override
 	public void dispatchMouseMoved(MouseEvent event) {
-		m_currentMouseEvent = event;
-		//
-		if (!m_eventCapture) {
-			super.dispatchMouseMoved(event);
-			if (isEventConsumed()) {
-				return;
+		delayEvent(() -> {
+			m_currentMouseEvent = event;
+			//
+			if (!m_eventCapture) {
+				super.dispatchMouseMoved(event);
+				if (isEventConsumed()) {
+					return;
+				}
 			}
-		}
-		//
-		if ((event.stateMask & SWT.BUTTON_MASK) != 0) {
-			m_domain.mouseDrag(event, m_viewer);
-		} else {
-			m_domain.mouseMove(event, m_viewer);
-		}
+			//
+			if ((event.stateMask & SWT.BUTTON_MASK) != 0) {
+				m_domain.mouseDrag(event, m_viewer);
+			} else {
+				m_domain.mouseMove(event, m_viewer);
+			}
+		}, event);
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -177,17 +185,21 @@ public class EditEventManager extends EventManager {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public void dispatchMouseEntered(MouseEvent event) {
-		m_currentMouseEvent = event;
-		m_domain.viewerEntered(event, m_viewer);
-		updateFigureUnderCursor(event);
+		delayEvent(() -> {
+			m_currentMouseEvent = event;
+			m_domain.viewerEntered(event, m_viewer);
+			updateFigureUnderCursor(event);
+		}, event);
 	}
 
 	@Override
 	public void dispatchMouseExited(MouseEvent event) {
-		m_eventCapture = false;
-		m_currentMouseEvent = event;
-		m_domain.viewerExited(event, m_viewer);
-		updateFigureUnderCursor(event);
+		delayEvent(() -> {
+			m_eventCapture = false;
+			m_currentMouseEvent = event;
+			m_domain.viewerExited(event, m_viewer);
+			updateFigureUnderCursor(event);
+		}, event);
 	}
 
 	@Override


### PR DESCRIPTION
In an earlier commit, the delayed execution of events was moved to the dispatch methods, instead of being implemented in the listeners directly. Because those methods are overwritten by the EditEventManager, this mechanism was no longer applied here.

Amends 9f074b858f5b5425864ecf669b6a100c417033c3