### PR TITLE
[SimRel] Build and test WindowBuilder against 2023-12 M3

### DIFF
--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/tools/SelectionTool.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/tools/SelectionTool.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.gef.graphical.tools;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.core.IEditPartViewer.IConditional;
 import org.eclipse.wb.gef.core.requests.KeyRequest;
@@ -21,6 +20,7 @@ import org.eclipse.wb.internal.gef.core.EditDomain;
 
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.gef.DragTracker;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.RequestConstants;
@@ -138,7 +138,7 @@ public class SelectionTool extends TargetingTool {
 			((SelectionRequest) getTargetRequest()).setLastButtonPressed(button);
 			updateTargetUnderMouse();
 			//
-			EditPart editPart = getTargetEditPart();
+			org.eclipse.wb.gef.core.EditPart editPart = getTargetEditPart();
 			if (editPart == null) {
 				setDragTrackerTool(null);
 				getCurrentViewer().deselectAll();
@@ -302,7 +302,7 @@ public class SelectionTool extends TargetingTool {
 		if (m_dragTracker != null) {
 			m_dragTracker.keyDown(event, viewer);
 		} else {
-			List<EditPart> selection = viewer.getSelectedEditParts();
+			List<? extends EditPart> selection = viewer.getSelectedEditParts();
 			//
 			if (event.keyCode == SWT.ESC) {
 				if (!selection.isEmpty()) {
@@ -328,7 +328,7 @@ public class SelectionTool extends TargetingTool {
 		}
 	}
 
-	private static void handleKeyEvent(boolean pressed, KeyEvent event, List<EditPart> selection) {
+	private static void handleKeyEvent(boolean pressed, KeyEvent event, List<? extends EditPart> selection) {
 		KeyRequest request = new KeyRequest(pressed, event);
 		for (EditPart part : selection) {
 			part.performRequest(request);

--- a/target-platform/wb.target
+++ b/target-platform/wb.target
@@ -3,7 +3,7 @@
 <target name="wb">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/releases/2023-09"/>
+			<repository location="https://download.eclipse.org/releases/2023-12/202311171000/"/>
 			<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.gef.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>


### PR DESCRIPTION
Due to significant changes in GEF (primarily removal of raw types), we should check whether WindowBuilder still compiles with the latest milestone, in order to avoid any unpleasant surprises after the release.