### PR TITLE
Switch back to latest Tycho release (4.0.4) due to unstable builds

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho</groupId>
     <artifactId>tycho-build</artifactId>
-    <version>4.0.0</version>
+    <version>${tycho.version}</version>
   </extension>
 </extensions> 

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Dtycho.version=4.0.4

--- a/pom.xml
+++ b/pom.xml
@@ -19,18 +19,10 @@
 
 
   <properties>
-    <tycho.version>5.0.0-SNAPSHOT</tycho.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <eclipse-jarsigner-version>1.3.2</eclipse-jarsigner-version>
     <baseline.repo>https://download.eclipse.org/windowbuilder/updates/release/latest</baseline.repo>
   </properties>
-  
-  <pluginRepositories>
-    <pluginRepository>
-        <id>tycho-snapshots</id>
-        <url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</url>
-    </pluginRepository>
-  </pluginRepositories>
 
   <profiles>
     <profile>


### PR DESCRIPTION
Using the latest build may cause problems when new Tycho versions are built parallel to the WindowBuilder jobs. Avoid this by using a fixed version.