### PR TITLE
Add check-dash-licenses to GitHub workflow

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -8,6 +8,10 @@ on:
     branches:
       - master
 jobs:
+  check-dash-licenses:
+    uses: eclipse/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
+    with:
+      projectId: tools.windowbuilder
   build:
     strategy:
       fail-fast: false


### PR DESCRIPTION
The Eclipse Dash License Tool identifies the licenses of content. It is intended primarily for use by Eclipse committers to vet third party content used by their Eclipse open source project.

Note that this tool doesn't automatically create IP Team Review Requests, given that those have to be reviewed manually.