### PR TITLE
Typify LayoutDesigner & friends in Netbeans Modules Form component

### DIFF
--- a/org.eclipse.wb.layout.group/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.layout.group/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.layout.group;singleton:=true
-Bundle-Version: 1.9.400.qualifier
+Bundle-Version: 1.9.500.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.wb.layout.group/netbeans-src/org/netbeans/modules/form/layoutdesign/LayoutAligner.java
+++ b/org.eclipse.wb.layout.group/netbeans-src/org/netbeans/modules/form/layoutdesign/LayoutAligner.java
@@ -939,8 +939,8 @@ class LayoutAligner implements LayoutConstants {
 		}
 		// prepare separation to groups
 		List<LayoutInterval> aligned = new LinkedList<>();
-		List<List> restLeading = new LinkedList<>();
-		List<List> restTrailing = new LinkedList<>();
+		List<List<Object>> restLeading = new LinkedList<>();
+		List<List<Object>> restTrailing = new LinkedList<>();
 		int mainEffectiveAlign = -1;
 		int originalCount = commonGroup.getSubIntervalCount();
 		for (int i = 0; i < intervals.length; i++) {

--- a/org.eclipse.wb.layout.group/netbeans-src/org/netbeans/modules/form/layoutdesign/LayoutComponent.java
+++ b/org.eclipse.wb.layout.group/netbeans-src/org/netbeans/modules/form/layoutdesign/LayoutComponent.java
@@ -196,7 +196,7 @@ public final class LayoutComponent implements LayoutConstants {
 	public List<LayoutComponent> getSubcomponents() {
 		return subComponents != null && subComponents.size() > 0
 				? Collections.unmodifiableList(subComponents)
-						: Collections.EMPTY_LIST;
+						: Collections.emptyList();
 	}
 
 	int getSubComponentCount() {
@@ -229,7 +229,7 @@ public final class LayoutComponent implements LayoutConstants {
 
 	int removeComponent(LayoutComponent comp) {
 		if (subComponents != null) {
-			Iterator it = subComponents.iterator();
+			Iterator<LayoutComponent> it = subComponents.iterator();
 			int index = -1;
 			while (it.hasNext()) {
 				index++;

--- a/org.eclipse.wb.layout.group/netbeans-src/org/netbeans/modules/form/layoutdesign/LayoutDesigner.java
+++ b/org.eclipse.wb.layout.group/netbeans-src/org/netbeans/modules/form/layoutdesign/LayoutDesigner.java
@@ -104,9 +104,9 @@ public class LayoutDesigner implements LayoutConstants {
 	void requireStructureOptimization() {
 		optimizeStructure = true;
 		visualStateUpToDate = false;
-		Iterator it = layoutModel.getAllComponents();
+		Iterator<LayoutComponent> it = layoutModel.getAllComponents();
 		while (it.hasNext()) {
-			LayoutComponent comp = (LayoutComponent) it.next();
+			LayoutComponent comp = it.next();
 			if (comp.isLayoutContainer()) {
 				LayoutInterval[] roots = getActiveLayoutRoots(comp);
 				for (int dim = 0; dim < DIM_COUNT; dim++) {
@@ -117,9 +117,9 @@ public class LayoutDesigner implements LayoutConstants {
 	}
 
 	private void updatePositions(Set<LayoutComponent> updatedContainers) {
-		Iterator it = layoutModel.getAllComponents();
+		Iterator<LayoutComponent> it = layoutModel.getAllComponents();
 		while (it.hasNext()) {
-			LayoutComponent comp = (LayoutComponent) it.next();
+			LayoutComponent comp = it.next();
 			if (!comp.isLayoutContainer()) {
 				continue;
 			}
@@ -173,9 +173,9 @@ public class LayoutDesigner implements LayoutConstants {
 		boolean firstResizingSpace = false;
 		int leadingSpace = 0;
 		boolean skipNext = false;
-		Iterator it = interval.getSubIntervals();
+		Iterator<LayoutInterval> it = interval.getSubIntervals();
 		while (it.hasNext()) {
-			LayoutInterval sub = (LayoutInterval) it.next();
+			LayoutInterval sub = it.next();
 			if (sub.isEmptySpace()) {
 				if (!interval.isSequential()) {
 					// filling gap in empty root group
@@ -780,7 +780,7 @@ public class LayoutDesigner implements LayoutConstants {
 		if (interval.isGroup()) {
 			boolean parallel = interval.isParallel();
 			LayoutInterval copy = LayoutInterval.cloneInterval(interval, null);
-			Iterator iter = interval.getSubIntervals();
+			Iterator<? extends Object> iter = interval.getSubIntervals();
 			int compCount = 0; // Number of components already copied to the group
 			boolean includeGap = false; // Helper variables that allow us to insert gaps
 			int firstGapToInclude = 0; // instead of components that has been filtered out.
@@ -1146,12 +1146,12 @@ public class LayoutDesigner implements LayoutConstants {
 			}
 		} else {
 			int dimension = component.isLinkSized(HORIZONTAL) ? HORIZONTAL : VERTICAL;
-			Map map = layoutModel.getLinkSizeGroups(dimension);
+			Map<Integer, List<String>> map = layoutModel.getLinkSizeGroups(dimension);
 			Integer linkId = Integer.valueOf(component.getLinkSizeId(dimension));
-			List l = (List) map.get(linkId);
-			Iterator mergedIt = l.iterator();
+			List<String> l = map.get(linkId);
+			Iterator<String> mergedIt = l.iterator();
 			while (mergedIt.hasNext()) {
-				String id = (String) mergedIt.next();
+				String id = mergedIt.next();
 				LayoutComponent lc = layoutModel.getLayoutComponent(id);
 				LayoutInterval interval = lc.getLayoutInterval(dimension);
 				LayoutRegion region = interval.getCurrentSpace();
@@ -1314,9 +1314,9 @@ public class LayoutDesigner implements LayoutConstants {
 		int min = Short.MAX_VALUE;
 		int max = Short.MIN_VALUE;
 		if (interval.isParallel() && interval.getGroupAlignment() != BASELINE) {
-			Iterator iter = interval.getSubIntervals();
+			Iterator<LayoutInterval> iter = interval.getSubIntervals();
 			while (iter.hasNext()) {
-				LayoutInterval subInterval = (LayoutInterval) iter.next();
+				LayoutInterval subInterval = iter.next();
 				int imin, imax;
 				int oppDim = dimension == HORIZONTAL ? VERTICAL : HORIZONTAL;
 				if (LayoutInterval.isPlacedAtBorder(subInterval, oppDim, alignment)) {
@@ -1747,9 +1747,9 @@ public class LayoutDesigner implements LayoutConstants {
 			LayoutInterval knownSub,
 			LayoutInterval[] dupIntervals) {
 		assert group.isGroup();
-		Iterator it = group.getSubIntervals();
+		Iterator<LayoutInterval> it = group.getSubIntervals();
 		while (it.hasNext()) {
-			LayoutInterval sub = (LayoutInterval) it.next();
+			LayoutInterval sub = it.next();
 			if (sub == knownSub || sub.isEmptySpace()) {
 				continue;
 			}
@@ -2385,9 +2385,9 @@ public class LayoutDesigner implements LayoutConstants {
 				}
 			} else {
 				boolean before = true;
-				Iterator iter = parent.getSubIntervals();
+				Iterator<LayoutInterval> iter = parent.getSubIntervals();
 				while (iter.hasNext()) {
-					LayoutInterval li = (LayoutInterval) iter.next();
+					LayoutInterval li = iter.next();
 					if (li == interval) {
 						before = false;
 					} else if (LayoutInterval.wantResize(li)) {
@@ -2461,12 +2461,12 @@ public class LayoutDesigner implements LayoutConstants {
 			LayoutComponent comp = interval.getComponent();
 			dimension = interval == comp.getLayoutInterval(HORIZONTAL) ? HORIZONTAL : VERTICAL;
 			if (comp.isLinkSized(dimension)) {
-				Collection linked = layoutModel.getLinkSizeGroups(dimension).get(
+				Collection<String> linked = layoutModel.getLinkSizeGroups(dimension).get(
 						Integer.valueOf(comp.getLinkSizeId(dimension)));
-				Iterator iter = linked.iterator();
+				Iterator<String> iter = linked.iterator();
 				int prefSize = 0;
 				while (iter.hasNext()) {
-					String compId = (String) iter.next();
+					String compId = iter.next();
 					LayoutComponent component = layoutModel.getLayoutComponent(compId);
 					LayoutInterval intr = component.getLayoutInterval(dimension);
 					int pref = intr.getPreferredSize();
@@ -2490,15 +2490,15 @@ public class LayoutDesigner implements LayoutConstants {
 			} else {
 				assert interval.isGroup();
 				prefSize = 0;
-				Iterator iter = interval.getSubIntervals();
+				Iterator<LayoutInterval> iter = interval.getSubIntervals();
 				if (interval.isSequential()) {
 					while (iter.hasNext()) {
-						LayoutInterval subInterval = (LayoutInterval) iter.next();
+						LayoutInterval subInterval = iter.next();
 						prefSize += prefSizeOfInterval(subInterval);
 					}
 				} else {
 					while (iter.hasNext()) {
-						LayoutInterval subInterval = (LayoutInterval) iter.next();
+						LayoutInterval subInterval = iter.next();
 						prefSize = Math.max(prefSize, prefSizeOfInterval(subInterval));
 					}
 				}
@@ -2533,17 +2533,17 @@ public class LayoutDesigner implements LayoutConstants {
 		LayoutInterval interval = comp.getLayoutInterval(dimension);
 		// Unset the same-size if we are making the component resizable
 		if (resizing && comp.isLinkSized(dimension)) {
-			Collection linked = layoutModel.getLinkSizeGroups(dimension).get(
+			Collection<String> linked = layoutModel.getLinkSizeGroups(dimension).get(
 					Integer.valueOf(comp.getLinkSizeId(dimension)));
-			Collection toChange;
+			Collection<String> toChange;
 			if (linked.size() == 2) { // The second component will be unlinked, too.
 				toChange = linked;
 			} else {
 				toChange = Collections.singletonList(comp.getId());
 			}
-			Iterator iter = toChange.iterator();
+			Iterator<String> iter = toChange.iterator();
 			while (iter.hasNext()) {
-				String compId = (String) iter.next();
+				String compId = iter.next();
 				LayoutComponent component = layoutModel.getLayoutComponent(compId);
 				LayoutInterval intr = component.getLayoutInterval(dimension);
 				Dimension prefDim = visualMapper.getComponentPreferredSize(compId);
@@ -2616,9 +2616,9 @@ public class LayoutDesigner implements LayoutConstants {
 				LayoutInterval leadingGap = null;
 				LayoutInterval trailingGap = null;
 				boolean afterDefining = false;
-				Iterator iter = par.getSubIntervals();
+				Iterator<LayoutInterval> iter = par.getSubIntervals();
 				while (iter.hasNext()) {
-					LayoutInterval candidate = (LayoutInterval) iter.next();
+					LayoutInterval candidate = iter.next();
 					if (candidate == interval) {
 						afterDefining = true;
 					}
@@ -2678,7 +2678,7 @@ public class LayoutDesigner implements LayoutConstants {
 							- prefSizeOfInterval(par)
 							+ delta) / resizableList.size();
 					while (iter.hasNext()) {
-						LayoutInterval candidate = (LayoutInterval) iter.next();
+						LayoutInterval candidate = iter.next();
 						if (candidate.isGroup()) {
 							// PENDING currSize could change - we can't modify prefSize of group directly
 						} else {
@@ -2763,9 +2763,9 @@ public class LayoutDesigner implements LayoutConstants {
 		}
 		if (interval.isGroup()) {
 			boolean subres = true;
-			Iterator it = interval.getSubIntervals();
+			Iterator<LayoutInterval> it = interval.getSubIntervals();
 			while (it.hasNext()) {
-				LayoutInterval li = (LayoutInterval) it.next();
+				LayoutInterval li = it.next();
 				if (LayoutInterval.wantResize(li) && !fillResizable(li)) {
 					subres = false;
 					break;
@@ -2818,12 +2818,12 @@ public class LayoutDesigner implements LayoutConstants {
 	 * @param alignment
 	 *          requested alignment.
 	 */
-	public void align(Collection componentIds, boolean closed, int dimension, int alignment) {
+	public void align(Collection<String> componentIds, boolean closed, int dimension, int alignment) {
 		LayoutInterval[] intervals = new LayoutInterval[componentIds.size()];
 		int counter = 0;
-		Iterator iter = componentIds.iterator();
+		Iterator<String> iter = componentIds.iterator();
 		while (iter.hasNext()) {
-			String id = (String) iter.next();
+			String id = iter.next();
 			LayoutComponent component = layoutModel.getLayoutComponent(id);
 			intervals[counter++] = component.getLayoutInterval(dimension);
 		}
@@ -2841,9 +2841,9 @@ public class LayoutDesigner implements LayoutConstants {
 	}
 
 	private void destroyRedundantGroups(Set<LayoutComponent> updatedContainers) {
-		Iterator it = layoutModel.getAllComponents();
+		Iterator<LayoutComponent> it = layoutModel.getAllComponents();
 		while (it.hasNext()) {
-			LayoutComponent comp = (LayoutComponent) it.next();
+			LayoutComponent comp = it.next();
 			if (!comp.isLayoutContainer()) {
 				continue;
 			}
@@ -2952,9 +2952,9 @@ public class LayoutDesigner implements LayoutConstants {
 				layoutModel.addInterval(gap, parent, index);
 			}
 		}
-		Iterator iter = toRemove.iterator();
+		Iterator<LayoutInterval> iter = toRemove.iterator();
 		while (iter.hasNext()) {
-			LayoutInterval remove = (LayoutInterval) iter.next();
+			LayoutInterval remove = iter.next();
 			layoutModel.removeInterval(remove);
 		}
 		// Consolidate parent
@@ -2980,7 +2980,7 @@ public class LayoutDesigner implements LayoutConstants {
 	 * @param dimension
 	 *          dimension the remainder group is created in.
 	 */
-	void createRemainderGroup(List list,
+	void createRemainderGroup(List<List<Object>> list,
 			LayoutInterval seq,
 			int index,
 			int position,
@@ -2999,7 +2999,7 @@ public class LayoutDesigner implements LayoutConstants {
 		boolean gapTrails = true;
 		// Remove sequences just with one gap
 		for (int i = list.size() - 1; i >= 0; i--) {
-			List subList = (List) list.get(i);
+			List<Object> subList = list.get(i);
 			if (subList.size() == 2) { // there is just one interval
 				int alignment = ((Integer) subList.get(0)).intValue();
 				LayoutInterval li = (LayoutInterval) subList.get(1);
@@ -3026,8 +3026,8 @@ public class LayoutDesigner implements LayoutConstants {
 			}
 		}
 		if (list.size() == 1) { // just one sequence, need not a group
-			List subList = (List) list.get(0);
-			Iterator itr = subList.iterator();
+			List<Object> subList = list.get(0);
+			Iterator<Object> itr = subList.iterator();
 			itr.next(); // skip alignment
 			do {
 				LayoutInterval li = (LayoutInterval) itr.next();
@@ -3036,12 +3036,12 @@ public class LayoutDesigner implements LayoutConstants {
 			return;
 		}
 		// find common ending gaps, possibility to eliminate some...
-		for (Iterator it = list.iterator(); it.hasNext();) {
-			List subList = (List) it.next();
+		for (Iterator<List<Object>> it = list.iterator(); it.hasNext();) {
+			List<Object> subList = it.next();
 			if (subList.size() != 2) { // there are more intervals (will form a sequential group)
 				onlyGaps = false;
 				boolean first = true;
-				Iterator itr = subList.iterator();
+				Iterator<Object> itr = subList.iterator();
 				itr.next(); // skip seq. alignment
 				do {
 					LayoutInterval li = (LayoutInterval) itr.next();
@@ -3075,8 +3075,8 @@ public class LayoutDesigner implements LayoutConstants {
 		}
 		//        group.setGroupAlignment(alignment);
 		// fill the group
-		for (Iterator it = list.iterator(); it.hasNext();) {
-			List subList = (List) it.next();
+		for (Iterator<List<Object>> it = list.iterator(); it.hasNext();) {
+			List<Object> subList = it.next();
 			if (gapLeads) {
 				subList.remove(1);
 			}
@@ -3092,7 +3092,7 @@ public class LayoutDesigner implements LayoutConstants {
 				}
 			} else { // there are more intervals - group them in a sequence
 				interval = new LayoutInterval(SEQUENTIAL);
-				Iterator itr = subList.iterator();
+				Iterator<Object> itr = subList.iterator();
 				int alignment = ((Integer) itr.next()).intValue();
 				if (alignment == LEADING || alignment == TRAILING) {
 					interval.setAlignment(alignment);
@@ -3278,8 +3278,8 @@ index = -1;
 				interval.setAttribute(LayoutInterval.ATTR_FORCED_DEFAULT);
 			}
 		} else {
-			for (Iterator it = interval.getSubIntervals(); it.hasNext();) {
-				setDefaultSizeInContainer((LayoutInterval) it.next());
+			for (Iterator<LayoutInterval> it = interval.getSubIntervals(); it.hasNext();) {
+				setDefaultSizeInContainer(it.next());
 			}
 		}
 	}
@@ -3357,15 +3357,15 @@ index = -1;
 		LayoutInterval parent = resGap.getParent();
 		do {
 			if (parent.isSequential()) {
-				for (Iterator it = parent.getSubIntervals(); it.hasNext();) {
-					LayoutInterval li = (LayoutInterval) it.next();
+				for (Iterator<LayoutInterval> it = parent.getSubIntervals(); it.hasNext();) {
+					LayoutInterval li = it.next();
 					if (li != sub) {
 						li.setAttribute(LayoutInterval.ATTR_DESIGN_SUPPRESSED_RESIZING);
 					}
 				}
 			} else { // parallel parent
-				for (Iterator it = parent.getSubIntervals(); it.hasNext();) {
-					LayoutInterval interval = (LayoutInterval) it.next();
+				for (Iterator<LayoutInterval> it = parent.getSubIntervals(); it.hasNext();) {
+					LayoutInterval interval = it.next();
 					if (interval != sub) {
 						assert interval.isSequential();
 						if (interval.isSequential()) {
@@ -3395,8 +3395,8 @@ index = -1;
 		assert group.isParallel();
 		LayoutInterval theGap = null;
 		int gapSize = Integer.MAX_VALUE;
-		for (Iterator it = group.getSubIntervals(); it.hasNext();) {
-			LayoutInterval seq = (LayoutInterval) it.next();
+		for (Iterator<LayoutInterval> it = group.getSubIntervals(); it.hasNext();) {
+			LayoutInterval seq = it.next();
 			if (!seq.isSequential()) {
 				return null;
 			}
@@ -3862,9 +3862,9 @@ index = -1;
 		int leadCompPos = Integer.MAX_VALUE;
 		int trailCompPos = Integer.MIN_VALUE;
 		int subSize = Integer.MIN_VALUE;
-		Iterator it = group.getSubIntervals();
+		Iterator<LayoutInterval> it = group.getSubIntervals();
 		while (it.hasNext()) {
-			LayoutInterval li = (LayoutInterval) it.next();
+			LayoutInterval li = it.next();
 			int align = li.getAlignment();
 			int l, t; // leading and trailing position of first and last component
 			if (li != excluded) {

--- a/org.eclipse.wb.layout.group/netbeans-src/org/netbeans/modules/form/layoutdesign/LayoutDragger.java
+++ b/org.eclipse.wb.layout.group/netbeans-src/org/netbeans/modules/form/layoutdesign/LayoutDragger.java
@@ -205,8 +205,8 @@ class LayoutDragger implements LayoutConstants {
 	}
 
 	private LayoutInterval findResizingGap(LayoutInterval group) {
-		for (Iterator it = group.getSubIntervals(); it.hasNext();) {
-			LayoutInterval li = (LayoutInterval) it.next();
+		for (Iterator<LayoutInterval> it = group.getSubIntervals(); it.hasNext();) {
+			LayoutInterval li = it.next();
 			if (li.isEmptySpace() && li.hasAttribute(LayoutInterval.ATTR_DESIGN_CONTAINER_GAP)) {
 				return li;
 			} else if (li.isGroup()) {
@@ -1002,9 +1002,9 @@ class LayoutDragger implements LayoutConstants {
 	 */
 	private void scanLayoutForAligned(LayoutInterval interval, int alignment) {
 		assert alignment == LayoutRegion.ALL_POINTS || alignment == LEADING || alignment == TRAILING;
-		Iterator it = interval.getSubIntervals();
+		Iterator<LayoutInterval> it = interval.getSubIntervals();
 		while (it.hasNext()) {
-			LayoutInterval sub = (LayoutInterval) it.next();
+			LayoutInterval sub = it.next();
 			if (sub.isEmptySpace()) {
 				continue;
 			}
@@ -1077,9 +1077,9 @@ class LayoutDragger implements LayoutConstants {
 		// check if the interval is not the last one to remain in parallel group
 		if (presentAlign != DEFAULT) {
 			boolean lastOne = true;
-			Iterator it = interval.getParent().getSubIntervals();
+			Iterator<LayoutInterval> it = interval.getParent().getSubIntervals();
 			while (it.hasNext()) {
-				LayoutInterval li = (LayoutInterval) it.next();
+				LayoutInterval li = it.next();
 				if (li != interval && isValidInterval(li)) {
 					lastOne = false;
 					break;
@@ -1383,9 +1383,9 @@ class LayoutDragger implements LayoutConstants {
 			// group must contain at least two other intervals - otherwise it
 			// is dissolved before the moving intervals are re-added
 			int count = 0;
-			Iterator it = interval.getSubIntervals();
+			Iterator<LayoutInterval> it = interval.getSubIntervals();
 			while (it.hasNext()) {
-				LayoutInterval li = (LayoutInterval) it.next();
+				LayoutInterval li = it.next();
 				if ((!li.isEmptySpace() || interval.isSequential()) && isValidInterval(li)) { // filling gap (in parallel group) does not count
 					count++;
 					if (count > 1) {
@@ -1583,10 +1583,10 @@ class LayoutDragger implements LayoutConstants {
 			int dimension,
 			int alignment) {
 		int oppAlignment = alignment == LEADING ? TRAILING : LEADING;
-		List movingComps = LayoutUtils.edgeSubComponents(moving, alignment);
-		List fixedComps = LayoutUtils.edgeSubComponents(interval, oppAlignment);
-		List sources = alignment == LEADING ? fixedComps : movingComps;
-		List targets = alignment == LEADING ? movingComps : fixedComps;
+		List<LayoutInterval> movingComps = LayoutUtils.edgeSubComponents(moving, alignment);
+		List<LayoutInterval> fixedComps = LayoutUtils.edgeSubComponents(interval, oppAlignment);
+		List<LayoutInterval> sources = alignment == LEADING ? fixedComps : movingComps;
+		List<LayoutInterval> targets = alignment == LEADING ? movingComps : fixedComps;
 		Map<String, LayoutRegion> map = new HashMap<>();
 		for (int i = 0; i < movingComponents.length; i++) {
 			map.put(movingComponents[i].getId(), movingBounds[i]);

--- a/org.eclipse.wb.layout.group/netbeans-src/org/netbeans/modules/form/layoutdesign/LayoutFeeder.java
+++ b/org.eclipse.wb.layout.group/netbeans-src/org/netbeans/modules/form/layoutdesign/LayoutFeeder.java
@@ -1526,7 +1526,7 @@ resizing = false;
 		//        }
 		// separate content out of the emerging group
 		List<LayoutInterval> alignedList = new ArrayList<>(2);
-		List<List> remainder = new ArrayList<>(2);
+		List<List<Object>> remainder = new ArrayList<>(2);
 		int originalCount = parParent.getSubIntervalCount();
 		int extAlign1 = extract(toAlignWith, alignedList, remainder, alignment);
 		extract(aligning, alignedList, remainder, alignment);
@@ -1659,7 +1659,7 @@ resizing = false;
 
 	private int extract(LayoutInterval interval,
 			List<LayoutInterval> toAlign,
-			List<List> toRemain,
+			List<List<Object>> toRemain,
 			int alignment) {
 		int effAlign = LayoutInterval.getEffectiveAlignment(interval, alignment);
 		LayoutInterval parent = interval.getParent();
@@ -2335,8 +2335,8 @@ return false; */
 		// 3rd analyse inclusions requiring a subgroup (parallel with part of sequence)
 		LayoutInterval subGroup = null;
 		LayoutInterval nextTo = null;
-		List<List> separatedLeading = new LinkedList<>();
-		List<List> separatedTrailing = new LinkedList<>();
+		List<List<Object>> separatedLeading = new LinkedList<>();
+		List<List<Object>> separatedTrailing = new LinkedList<>();
 		for (IncludeDesc iDesc : inclusions) {
 			if (iDesc.parent.isSequential() && iDesc.newSubGroup) {
 				LayoutInterval parSeq =

--- a/org.eclipse.wb.layout.group/netbeans-src/org/netbeans/modules/form/layoutdesign/LayoutInterval.java
+++ b/org.eclipse.wb.layout.group/netbeans-src/org/netbeans/modules/form/layoutdesign/LayoutInterval.java
@@ -285,7 +285,7 @@ public final class LayoutInterval implements LayoutConstants {
 	 * @return iterator of sub-intervals, empty if there are no sub-intervals
 	 */
 	public Iterator<LayoutInterval> getSubIntervals() {
-		return subIntervals != null ? subIntervals.iterator() : Collections.EMPTY_LIST.iterator();
+		return subIntervals != null ? subIntervals.iterator() : Collections.<LayoutInterval>emptyList().iterator();
 	}
 
 	/**
@@ -541,22 +541,22 @@ public final class LayoutInterval implements LayoutConstants {
 	 */
 	static LayoutInterval getCommonParent(LayoutInterval interval1, LayoutInterval interval2) {
 		// Find all parents of given intervals
-		Iterator parents1 = parentsOfInterval(interval1).iterator();
-		Iterator parents2 = parentsOfInterval(interval2).iterator();
-		LayoutInterval parent1 = (LayoutInterval) parents1.next();
-		LayoutInterval parent2 = (LayoutInterval) parents2.next();
+		Iterator<LayoutInterval> parents1 = parentsOfInterval(interval1).iterator();
+		Iterator<LayoutInterval> parents2 = parentsOfInterval(interval2).iterator();
+		LayoutInterval parent1 = parents1.next();
+		LayoutInterval parent2 = parents2.next();
 		assert parent1 == parent2;
 		// Candidate for the common parent
 		LayoutInterval parent = null;
 		while (parent1 == parent2) {
 			parent = parent1;
 			if (parents1.hasNext()) {
-				parent1 = (LayoutInterval) parents1.next();
+				parent1 = parents1.next();
 			} else {
 				break;
 			}
 			if (parents2.hasNext()) {
-				parent2 = (LayoutInterval) parents2.next();
+				parent2 = parents2.next();
 			} else {
 				break;
 			}
@@ -584,9 +584,9 @@ public final class LayoutInterval implements LayoutConstants {
 
 	static int getCount(LayoutInterval group, int alignment, boolean nonEmpty) {
 		int n = 0;
-		Iterator it = group.getSubIntervals();
+		Iterator<LayoutInterval> it = group.getSubIntervals();
 		while (it.hasNext()) {
-			LayoutInterval li = (LayoutInterval) it.next();
+			LayoutInterval li = it.next();
 			if ((group.isSequential()
 					|| alignment == LayoutRegion.ALL_POINTS
 					|| li.getAlignment() == alignment || wantResize(li))
@@ -663,12 +663,12 @@ public final class LayoutInterval implements LayoutConstants {
 				parent = parent.getParent();
 			} while (parent != null && parent.getType() != parentType);
 			if (parent != null) {
-				List subs = parent.subIntervals;
+				List<LayoutInterval> subs = parent.subIntervals;
 				int index = subs.indexOf(interval);
 				if (alignment == LEADING && index > 0) {
-					sibling = (LayoutInterval) subs.get(index - 1);
+					sibling = subs.get(index - 1);
 				} else if (alignment == TRAILING && index + 1 < subs.size()) {
-					sibling = (LayoutInterval) subs.get(index + 1);
+					sibling = subs.get(index + 1);
 				}
 			}
 		} while (parent != null && sibling == null);
@@ -684,8 +684,8 @@ public final class LayoutInterval implements LayoutConstants {
 			int index = alignment == LEADING ? 0 : interval.getSubIntervalCount() - 1;
 			return startsWithEmptySpace(interval.getSubInterval(index), alignment);
 		} else { // parallel group
-			for (Iterator it = interval.getSubIntervals(); it.hasNext();) {
-				LayoutInterval li = (LayoutInterval) it.next();
+			for (Iterator<LayoutInterval> it = interval.getSubIntervals(); it.hasNext();) {
+				LayoutInterval li = it.next();
 				if (startsWithEmptySpace(li, alignment)) {
 					return true;
 				}
@@ -828,9 +828,9 @@ public final class LayoutInterval implements LayoutConstants {
 				|| group.getGroupAlignment() == BASELINE) {
 			return true;
 		}
-		Iterator it = group.getSubIntervals();
+		Iterator<LayoutInterval> it = group.getSubIntervals();
 		while (it.hasNext()) {
-			LayoutInterval li = (LayoutInterval) it.next();
+			LayoutInterval li = it.next();
 			if (li.getAlignment() == alignment || wantResize(li)) {
 				return true;
 			}
@@ -896,9 +896,9 @@ public final class LayoutInterval implements LayoutConstants {
 
 	static boolean contentWantResize(LayoutInterval group) {
 		boolean subres = false;
-		Iterator it = group.getSubIntervals();
+		Iterator<LayoutInterval> it = group.getSubIntervals();
 		while (it.hasNext()) {
-			if (wantResize((LayoutInterval) it.next())) {
+			if (wantResize(it.next())) {
 				subres = true;
 				break;
 			}
@@ -951,9 +951,9 @@ public final class LayoutInterval implements LayoutConstants {
 		boolean before = true;
 		boolean leadingFixed = true;
 		boolean trailingFixed = true;
-		Iterator it = parent.getSubIntervals();
+		Iterator<LayoutInterval> it = parent.getSubIntervals();
 		do {
-			LayoutInterval li = (LayoutInterval) it.next();
+			LayoutInterval li = it.next();
 			if (li == interval) {
 				before = false;
 			} else if (LayoutInterval.wantResize(li)) {

--- a/org.eclipse.wb.layout.group/netbeans-src/org/netbeans/modules/form/layoutdesign/LayoutModel.java
+++ b/org.eclipse.wb.layout.group/netbeans-src/org/netbeans/modules/form/layoutdesign/LayoutModel.java
@@ -226,7 +226,7 @@ public class LayoutModel implements LayoutConstants {
 		registerComponentImpl(substComp);
 	}
 
-	Iterator getAllComponents() {
+	Iterator<LayoutComponent> getAllComponents() {
 		return idToComponents.values().iterator();
 	}
 
@@ -500,13 +500,13 @@ public class LayoutModel implements LayoutConstants {
 
 	private void copySubIntervals(LayoutInterval sourceInterval,
 			LayoutInterval targetInterval,
-			Map/*<String,String>*/ sourceToTargetIds) {
-		Iterator iter = sourceInterval.getSubIntervals();
+			Map<String, String> sourceToTargetIds) {
+		Iterator<LayoutInterval> iter = sourceInterval.getSubIntervals();
 		while (iter.hasNext()) {
-			LayoutInterval sourceSub = (LayoutInterval) iter.next();
+			LayoutInterval sourceSub = iter.next();
 			LayoutInterval clone = null;
 			if (sourceSub.isComponent()) {
-				String compId = (String) sourceToTargetIds.get(sourceSub.getComponent().getId());
+				String compId = sourceToTargetIds.get(sourceSub.getComponent().getId());
 				LayoutComponent comp = getLayoutComponent(compId);
 				int dimension = sourceSub == sourceSub.getComponent().getLayoutInterval(HORIZONTAL)
 						? HORIZONTAL
@@ -716,7 +716,7 @@ public class LayoutModel implements LayoutConstants {
 			return parts;
 		}
 
-		private void mergeSubRegions(List regions, int dimension) {
+		private void mergeSubRegions(List<RegionInfo> regions, int dimension) {
 			if (regions.size() == 0) {
 				horizontal = new LayoutInterval(PARALLEL);
 				vertical = new LayoutInterval(PARALLEL);
@@ -725,9 +725,9 @@ public class LayoutModel implements LayoutConstants {
 			LayoutInterval seqGroup = new LayoutInterval(SEQUENTIAL);
 			LayoutInterval parGroup = new LayoutInterval(PARALLEL);
 			int lastSeqTrailing = dimension == HORIZONTAL ? minx : miny;
-			Iterator iter = regions.iterator();
+			Iterator<RegionInfo> iter = regions.iterator();
 			while (iter.hasNext()) {
-				RegionInfo region = (RegionInfo) iter.next();
+				RegionInfo region = iter.next();
 				LayoutInterval seqInterval;
 				LayoutInterval parInterval;
 				int seqGap;
@@ -804,9 +804,9 @@ public class LayoutModel implements LayoutConstants {
 
 	private void fireEvent(LayoutEvent event) {
 		if (listeners != null && listeners.size() > 0) {
-			Iterator it = ((List) listeners.clone()).iterator();
+			Iterator<Listener> it = new ArrayList<>(listeners).iterator();
 			while (it.hasNext()) {
-				((Listener) it.next()).layoutChanged(event);
+				it.next().layoutChanged(event);
 			}
 		}
 	}
@@ -1021,9 +1021,9 @@ public class LayoutModel implements LayoutConstants {
 		}
 		StringBuilder sb = new StringBuilder();
 		sb.append("<LayoutModel>\n"); // NOI18N
-		Iterator rootIter = roots.iterator();
+		Iterator<LayoutComponent> rootIter = roots.iterator();
 		while (rootIter.hasNext()) {
-			LayoutComponent root = (LayoutComponent) rootIter.next();
+			LayoutComponent root = rootIter.next();
 			String rootId = root.getId();
 			if (idToNameMap != null) {
 				rootId = idToNameMap.get(rootId);
@@ -1208,10 +1208,10 @@ public class LayoutModel implements LayoutConstants {
 			boolean retVal = getLayoutComponent(id).isLinkSized(dimension);
 			return retVal ? TRUE : FALSE;
 		}
-		Iterator i = components.iterator();
+		Iterator<String> i = components.iterator();
 		List<Integer> idsFound = new ArrayList<>();
 		while (i.hasNext()) {
-			String cid = (String) i.next();
+			String cid = i.next();
 			LayoutComponent lc = getLayoutComponent(cid);
 			Integer linkSizeId = Integer.valueOf(lc.getLinkSizeId(dimension));
 			if (!idsFound.contains(linkSizeId)) {
@@ -1244,29 +1244,29 @@ public class LayoutModel implements LayoutConstants {
 		return null; // incorrect dimension passed
 	}
 
-	public void unsetSameSize(List/*<String>*/ components, int dimension) {
-		Iterator i = components.iterator();
+	public void unsetSameSize(List<String> components, int dimension) {
+		Iterator<String> i = components.iterator();
 		while (i.hasNext()) {
-			String cid = (String) i.next();
+			String cid = i.next();
 			LayoutComponent lc = getLayoutComponent(cid);
 			removeComponentFromLinkSizedGroup(lc, dimension);
 		}
 	}
 
-	public void setSameSize(List/*<String>*/ components, int dimension) {
-		Iterator i = components.iterator();
+	public void setSameSize(List<String> components, int dimension) {
+		Iterator<String> i = components.iterator();
 		int groupId = findGroupId(components, dimension);
 		while (i.hasNext()) {
-			String cid = (String) i.next();
+			String cid = i.next();
 			LayoutComponent lc = getLayoutComponent(cid);
 			addComponentToLinkSizedGroup(groupId, lc.getId(), dimension);
 		}
 	}
 
-	private int findGroupId(List/*<String*/ components, int dimension) {
-		Iterator i = components.iterator();
+	private int findGroupId(List<String> components, int dimension) {
+		Iterator<String> i = components.iterator();
 		while (i.hasNext()) {
-			String cid = (String) i.next();
+			String cid = i.next();
 			LayoutComponent lc = getLayoutComponent(cid);
 			if (lc.isLinkSized(dimension)) {
 				return lc.getLinkSizeId(dimension);

--- a/org.eclipse.wb.layout.group/netbeans-src/org/netbeans/modules/form/layoutdesign/LayoutOperations.java
+++ b/org.eclipse.wb.layout.group/netbeans-src/org/netbeans/modules/form/layoutdesign/LayoutOperations.java
@@ -66,8 +66,8 @@ class LayoutOperations implements LayoutConstants {
 	int extract(LayoutInterval interval,
 			int alignment,
 			boolean closed,
-			List<List> restLeading,
-			List<List> restTrailing) {
+			List<List<Object>> restLeading,
+			List<List<Object>> restTrailing) {
 		return extract(interval, interval, alignment, closed, restLeading, restTrailing);
 	}
 
@@ -75,8 +75,8 @@ class LayoutOperations implements LayoutConstants {
 			LayoutInterval trailing,
 			int alignment,
 			boolean closed,
-			List<List> restLeading,
-			List<List> restTrailing) {
+			List<List<Object>> restLeading,
+			List<List<Object>> restTrailing) {
 		LayoutInterval seq = leading.getParent();
 		assert seq.isSequential();
 		int leadingIndex = seq.indexOf(leading);
@@ -95,7 +95,7 @@ class LayoutOperations implements LayoutConstants {
 			List<Object/*Integer or LayoutInterval*/> toRemainT = null;
 			int startIndex = alignment == LEADING ? leadingIndex : leadingIndex - extractCount + 1;
 			int endIndex = alignment == LEADING ? trailingIndex + extractCount - 1 : trailingIndex;
-			Iterator it = seq.getSubIntervals();
+			Iterator<? extends Object> it = seq.getSubIntervals();
 			for (int idx = 0; it.hasNext(); idx++) {
 				LayoutInterval li = (LayoutInterval) it.next();
 				if (idx < startIndex) {
@@ -149,7 +149,7 @@ class LayoutOperations implements LayoutConstants {
 	 *          TRAILING or something else meaning not aligned)
 	 * @return parallel group if it has been created, or null
 	 */
-	LayoutInterval addGroupContent(List<List> list,
+	LayoutInterval addGroupContent(List<List<Object/* Integer or LayoutInterval */>> list,
 			LayoutInterval seq,
 			int index,
 			int dimension,
@@ -160,7 +160,7 @@ class LayoutOperations implements LayoutConstants {
 		boolean onlyGaps = true;
 		// Remove sequences just with one gap
 		for (int i = list.size() - 1; i >= 0; i--) {
-			List subList = list.get(i);
+			List<Object> subList = list.get(i);
 			assert subList.size() >= 2;
 			if (subList.size() == 2) { // there is just one interval
 				LayoutInterval li = (LayoutInterval) subList.get(1);
@@ -191,7 +191,7 @@ class LayoutOperations implements LayoutConstants {
 			return null;
 		}
 		if (list.size() == 1) { // just one sequence
-			List subList = list.get(0);
+			List<Object> subList = list.get(0);
 			for (int n = subList.size(), i = n - 1; i > 0; i--) { // skip alignment at 0
 				LayoutInterval li = (LayoutInterval) subList.get(i);
 				if (resizingFillGap
@@ -221,8 +221,8 @@ class LayoutOperations implements LayoutConstants {
 		//        }
 		////        group.setGroupAlignment(alignment);
 		// fill the group
-		for (Iterator it = list.iterator(); it.hasNext();) {
-			List subList = (List) it.next();
+		for (Iterator<List<Object>> it = list.iterator(); it.hasNext();) {
+			List<Object> subList = it.next();
 			LayoutInterval interval;
 			if (subList.size() == 2) { // there is just one interval - use it directly
 				int alignment = ((Integer) subList.get(0)).intValue();
@@ -1351,9 +1351,9 @@ class LayoutOperations implements LayoutConstants {
 	}
 
 	void mergeAdjacentGaps(Set<LayoutComponent> updatedContainers) {
-		Iterator it = layoutModel.getAllComponents();
+		Iterator<LayoutComponent> it = layoutModel.getAllComponents();
 		while (it.hasNext()) {
-			LayoutComponent comp = (LayoutComponent) it.next();
+			LayoutComponent comp = it.next();
 			if (!comp.isLayoutContainer()) {
 				continue;
 			}

--- a/org.eclipse.wb.layout.group/netbeans-src/org/netbeans/modules/form/layoutdesign/LayoutUtils.java
+++ b/org.eclipse.wb.layout.group/netbeans-src/org/netbeans/modules/form/layoutdesign/LayoutUtils.java
@@ -182,8 +182,8 @@ public class LayoutUtils implements LayoutConstants {
 			}
 		}
 		// Find sources and targets inside srcInt and targetInt
-		List sources = edgeSubComponents(srcInt, TRAILING);
-		List targets = edgeSubComponents(targetInt, LEADING);
+		List<LayoutInterval> sources = edgeSubComponents(srcInt, TRAILING);
+		List<LayoutInterval> targets = edgeSubComponents(targetInt, LEADING);
 		// Calculate size of gap from sources and targets and their positions
 		return getSizesOfDefaultGap(
 				sources,
@@ -191,7 +191,7 @@ public class LayoutUtils implements LayoutConstants {
 				interval.getPaddingType(),
 				visualMapper,
 				null,
-				Collections.EMPTY_MAP)[0];
+				Collections.emptyMap())[0];
 	}
 
 	/**
@@ -204,8 +204,8 @@ public class LayoutUtils implements LayoutConstants {
 	 * @return array of sizes - one element if specific padding type is asked or four elements if null
 	 *         is provided
 	 */
-	static int[] getSizesOfDefaultGap(List sources,
-			List targets,
+	static int[] getSizesOfDefaultGap(List<LayoutInterval> sources,
+			List<LayoutInterval> targets,
 			PaddingType gapType,
 			VisualMapper visualMapper,
 			String contId,
@@ -213,8 +213,8 @@ public class LayoutUtils implements LayoutConstants {
 		if (sources != null && sources.isEmpty() || targets != null && targets.isEmpty()) {
 			return new int[]{0}; // Preferred gap not between components
 		}
-		sources = sources == null ? Collections.EMPTY_LIST : sources;
-		targets = targets == null ? Collections.EMPTY_LIST : targets;
+		sources = sources == null ? Collections.emptyList() : sources;
+		targets = targets == null ? Collections.emptyList() : targets;
 		boolean containerGap = false;
 		int containerGapAlignment = -1;
 		LayoutInterval temp = null;
@@ -225,10 +225,10 @@ public class LayoutUtils implements LayoutConstants {
 				// Leading container gap
 				containerGap = true;
 				containerGapAlignment = LEADING;
-				temp = (LayoutInterval) targets.get(0);
+				temp = targets.get(0);
 			}
 		} else {
-			temp = (LayoutInterval) sources.get(0);
+			temp = sources.get(0);
 			if (targets.isEmpty()) {
 				// Trailing container gap
 				containerGap = true;
@@ -241,9 +241,9 @@ public class LayoutUtils implements LayoutConstants {
 		int max = Short.MIN_VALUE;
 		int min = Short.MAX_VALUE;
 		boolean positionsNotUpdated = false;
-		Iterator iter = sources.iterator();
+		Iterator<LayoutInterval> iter = sources.iterator();
 		while (iter.hasNext()) {
-			LayoutInterval source = (LayoutInterval) iter.next();
+			LayoutInterval source = iter.next();
 			LayoutRegion region = sizeOfEmptySpaceHelper(source, boundsMap);
 			int trailing = region.positions[dimension][TRAILING];
 			if (trailing == LayoutRegion.UNKNOWN) {
@@ -255,7 +255,7 @@ public class LayoutUtils implements LayoutConstants {
 		}
 		iter = targets.iterator();
 		while (iter.hasNext()) {
-			LayoutInterval target = (LayoutInterval) iter.next();
+			LayoutInterval target = iter.next();
 			LayoutRegion region = sizeOfEmptySpaceHelper(target, boundsMap);
 			int leading = region.positions[dimension][LEADING];
 			if (leading == LayoutRegion.UNKNOWN) {
@@ -270,7 +270,7 @@ public class LayoutUtils implements LayoutConstants {
 			sizes = new int[1];
 			iter = sources.isEmpty() ? targets.iterator() : sources.iterator();
 			while (iter.hasNext()) {
-				LayoutInterval interval = (LayoutInterval) iter.next();
+				LayoutInterval interval = iter.next();
 				LayoutComponent component = interval.getComponent();
 				LayoutRegion region = sizeOfEmptySpaceHelper(interval, boundsMap);
 				String parentId = contId == null ? component.getParent().getId() : contId;
@@ -291,15 +291,15 @@ public class LayoutUtils implements LayoutConstants {
 			PaddingType[] paddingTypes = // just one, or all types of gaps
 					gapType != null ? new PaddingType[]{gapType} : PADDINGS;
 			sizes = new int[paddingTypes.length];
-			Iterator srcIter = sources.iterator();
+			Iterator<LayoutInterval> srcIter = sources.iterator();
 			while (srcIter.hasNext()) {
-				LayoutInterval srcCandidate = (LayoutInterval) srcIter.next();
+				LayoutInterval srcCandidate = srcIter.next();
 				String srcId = srcCandidate.getComponent().getId();
 				LayoutRegion srcRegion = sizeOfEmptySpaceHelper(srcCandidate, boundsMap);
 				int srcDelta = max - srcRegion.positions[dimension][TRAILING];
-				Iterator targetIter = targets.iterator();
+				Iterator<LayoutInterval> targetIter = targets.iterator();
 				while (targetIter.hasNext()) {
-					LayoutInterval targetCandidate = (LayoutInterval) targetIter.next();
+					LayoutInterval targetCandidate = targetIter.next();
 					String targetId = targetCandidate.getComponent().getId();
 					LayoutRegion targetRegion = sizeOfEmptySpaceHelper(targetCandidate, boundsMap);
 					int targetDelta = targetRegion.positions[dimension][LEADING] - min;
@@ -456,10 +456,10 @@ public class LayoutUtils implements LayoutConstants {
 		// [more efficient algorithm based on region merging and ordering could be found...]
 		List<LayoutInterval> int2list = null;
 		List<LayoutInterval> addList = null;
-		Iterator it1 = getComponentIterator(interval1);
+		Iterator<LayoutInterval> it1 = getComponentIterator(interval1);
 		while (it1.hasNext()) {
-			LayoutRegion space1 = ((LayoutInterval) it1.next()).getCurrentSpace();
-			Iterator it2 =
+			LayoutRegion space1 = it1.next().getCurrentSpace();
+			Iterator<LayoutInterval> it2 =
 					int2list != null ? int2list.iterator() : getComponentIterator(
 							interval2,
 							fromIndex,
@@ -469,7 +469,7 @@ public class LayoutUtils implements LayoutConstants {
 				addList = int2list;
 			}
 			while (it2.hasNext()) {
-				LayoutInterval li2 = (LayoutInterval) it2.next();
+				LayoutInterval li2 = it2.next();
 				if (LayoutRegion.overlap(space1, li2.getCurrentSpace(), dimension, 0)) {
 					return true;
 				}
@@ -491,13 +491,13 @@ public class LayoutUtils implements LayoutConstants {
 			LayoutInterval interval,
 			int dimension) {
 		int otherDim = dimension ^ 1;
-		compInterval = (LayoutInterval) getComponentIterator(compInterval).next();
+		compInterval = getComponentIterator(compInterval).next();
 		LayoutComponent component = compInterval.getComponent();
 		LayoutInterval otherCompInterval = component.getLayoutInterval(otherDim);
-		Iterator it = getComponentIterator(interval);
+		Iterator<LayoutInterval> it = getComponentIterator(interval);
 		assert it.hasNext();
 		do {
-			LayoutComponent comp = ((LayoutInterval) it.next()).getComponent();
+			LayoutComponent comp = it.next().getComponent();
 			LayoutInterval otherInterval = comp.getLayoutInterval(otherDim);
 			LayoutInterval parent = LayoutInterval.getCommonParent(otherCompInterval, otherInterval);
 			if (parent == null || parent.isParallel()) {
@@ -507,15 +507,15 @@ public class LayoutUtils implements LayoutConstants {
 		return true;
 	}
 
-	static Iterator getComponentIterator(LayoutInterval interval) {
+	static Iterator<LayoutInterval> getComponentIterator(LayoutInterval interval) {
 		return new ComponentIterator(interval, 0, interval.getSubIntervalCount() - 1);
 	}
 
-	static Iterator getComponentIterator(LayoutInterval interval, int startIndex, int endIndex) {
+	static Iterator<LayoutInterval> getComponentIterator(LayoutInterval interval, int startIndex, int endIndex) {
 		return new ComponentIterator(interval, startIndex, endIndex);
 	}
 
-	private static class ComponentIterator implements Iterator {
+	private static class ComponentIterator implements Iterator<LayoutInterval> {
 		private final LayoutInterval root;
 		private final int startIndex, endIndex;
 		private final boolean initialized;
@@ -586,11 +586,11 @@ public class LayoutUtils implements LayoutConstants {
 		}
 
 		@Override
-		public Object next() {
+		public LayoutInterval next() {
 			if (next == null) {
 				throw new NoSuchElementException();
 			}
-			Object ret = next;
+			LayoutInterval ret = next;
 			findNext();
 			return ret;
 		}

--- a/org.eclipse.wb.layout.group/netbeans-src/org/netbeans/modules/form/layoutdesign/support/SwingLayoutCodeGenerator.java
+++ b/org.eclipse.wb.layout.group/netbeans-src/org/netbeans/modules/form/layoutdesign/support/SwingLayoutCodeGenerator.java
@@ -41,7 +41,6 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -189,10 +188,10 @@ public class SwingLayoutCodeGenerator {
 		} else {
 			layout.append(layoutVarName).append(".createSequentialGroup()"); // NOI18N
 		}
-		Iterator subIntervals = group.getSubIntervals();
+		Iterator<LayoutInterval> subIntervals = group.getSubIntervals();
 		while (subIntervals.hasNext()) {
 			layout.append("\n"); // NOI18N
-			LayoutInterval subInterval = (LayoutInterval) subIntervals.next();
+			LayoutInterval subInterval = subIntervals.next();
 			fillGroup(
 					layout,
 					subInterval,
@@ -457,13 +456,10 @@ public class SwingLayoutCodeGenerator {
 		while (linkGroupsIt.hasNext()) {
 			List<String> l = linkGroupsIt.next();
 			// sort so that the generated line is always the same when no changes were made
-			Collections.sort(l, new Comparator<String>() {
-				@Override
-				public int compare(String id1, String id2) {
-					ComponentInfo info1 = componentIDMap.get(id1);
-					ComponentInfo info2 = componentIDMap.get(id2);
-					return info1.variableName.compareTo(info2.variableName);
-				}
+			Collections.sort(l, (id1, id2) -> {
+				ComponentInfo info1 = componentIDMap.get(id1);
+				ComponentInfo info2 = componentIDMap.get(id2);
+				return info1.variableName.compareTo(info2.variableName);
 			});
 			if (l.size() > 1) {
 				layout.append("\n\n" + layoutVarName + ".linkSize("); // NOI18N
@@ -504,7 +500,7 @@ public class SwingLayoutCodeGenerator {
 		/** Variable name of the component. */
 		public String variableName;
 		/** The component's class. */
-		public Class clazz;
+		public Class<?> clazz;
 		/** The component's minimum size. */
 		public Dimension minSize;
 		/**

--- a/org.eclipse.wb.layout.group/netbeans-src/org/netbeans/modules/form/layoutdesign/support/SwingLayoutUtils.java
+++ b/org.eclipse.wb.layout.group/netbeans-src/org/netbeans/modules/form/layoutdesign/support/SwingLayoutUtils.java
@@ -104,7 +104,7 @@ public class SwingLayoutUtils {
 	 * @return <code>STATUS_RESIZABLE</code>, <code>STATUS_NON_RESIZABLE</code> or
 	 *         <code>STATUS_UNKNOWN</code>.
 	 */
-	public static int getResizableStatus(Class componentClass) {
+	public static int getResizableStatus(Class<?> componentClass) {
 		String className = componentClass.getName();
 		if (resizableComponents.contains(className)) {
 			return STATUS_RESIZABLE;

--- a/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/model/assistant/GroupLayoutAlignmentPage.java
+++ b/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/model/assistant/GroupLayoutAlignmentPage.java
@@ -82,7 +82,7 @@ LayoutConstants {
 		List<ObjectInfo> sel = new ArrayList<>();
 		List<Object> actions = new ArrayList<>();
 		CollectionUtils.addAll(sel, m_objects.iterator());
-		new AlignmentsSupport(m_layout).addAlignmentActions(sel, actions);
+		new AlignmentsSupport<>(m_layout).addAlignmentActions(sel, actions);
 		for (Object action : actions) {
 			if (action instanceof IContributionItem) {
 				m_toolBarManager.add((IContributionItem) action);


### PR DESCRIPTION
This fork is the cause of ~200 warnings regarding raw types, which make up about 1/4 of all warnings created by the builder.

Remark:
I thought about migrating to the upstream project: https://github.com/apache/netbeans/tree/master/java/form

However, the latest release already takes up 6MB, while our fork only requires 400kB...
```
<dependency>
    <groupId>org.netbeans.modules</groupId>
    <artifactId>org-netbeans-modules-form</artifactId>
    <version>RELEASE200</version>
</dependency>
```