### PR TITLE
Remove usage of Guava Collections in WindowBuilder Core #270

### DIFF
--- a/org.eclipse.wb.core.databinding/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core.databinding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.core.databinding;singleton:=true
-Bundle-Version: 1.9.400.qualifier
+Bundle-Version: 1.9.500.qualifier
 Bundle-Activator: org.eclipse.wb.internal.core.databinding.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/JavaInfoDeleteManager.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/JavaInfoDeleteManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.core.databinding.model;
-
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
@@ -57,7 +55,7 @@ public abstract class JavaInfoDeleteManager {
 			String reference = getReference(javaInfo);
 			//
 			if (reference != null) {
-				for (IBindingInfo binding : Lists.newArrayList(bindings)) {
+				for (IBindingInfo binding : new ArrayList<>(bindings)) {
 					if (equals(javaInfo, reference, binding.getTarget())
 							|| equals(javaInfo, reference, binding.getModel())) {
 						deleteList.add(binding);

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/ObserveType.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/ObserveType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.core.databinding.ui;
-
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.internal.core.databinding.Activator;
 
@@ -37,7 +35,7 @@ public final class ObserveType {
 			Activator.getImage("Widgets_ObserveType.gif"),
 			ExpandedStrategy.ExpandedAll);
 	//
-	public static final List<ObserveType> TYPES = Lists.newArrayList(
+	public static final List<ObserveType> TYPES = List.of(
 			ObserveType.WIDGETS,
 			ObserveType.BEANS);
 	//

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/core/eval/ExecutionFlowDescription.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/core/eval/ExecutionFlowDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.core.eval;
-
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.internal.core.utils.ast.AstNodeUtils;
 import org.eclipse.wb.internal.core.utils.check.Assert;
@@ -23,6 +21,7 @@ import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -48,7 +47,7 @@ public final class ExecutionFlowDescription {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	public ExecutionFlowDescription(MethodDeclaration... startMethods) {
-		this(Lists.newArrayList(startMethods));
+		this(new ArrayList<>(Arrays.asList(startMethods)));
 	}
 
 	public ExecutionFlowDescription(List<MethodDeclaration> startMethods) {

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/errors/NoEntryPointComposite.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/errors/NoEntryPointComposite.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.editor.errors;
 
-import com.google.common.collect.Lists;
-
 import org.eclipse.wb.core.controls.BrowserComposite;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.EnvironmentUtils;
@@ -48,6 +46,8 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Table;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -180,7 +180,7 @@ public final class NoEntryPointComposite extends Composite {
 	private List<IMethod> getPossibleEntryPoints() throws Exception {
 		String typeName = AstNodeUtils.getFullyQualifiedName(m_typeDeclaration, false);
 		IType type = m_editor.getJavaProject().findType(typeName);
-		List<IMethod> methods = Lists.newArrayList(type.getMethods());
+		List<IMethod> methods = new ArrayList<>(Arrays.asList(type.getMethods()));
 		sortMethods(methods);
 		return methods;
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPalette.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPalette.java
@@ -11,8 +11,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.editor.palette;
 
-import com.google.common.collect.Lists;
-
 import org.eclipse.wb.core.controls.palette.ICategory;
 import org.eclipse.wb.core.controls.palette.IEntry;
 import org.eclipse.wb.core.controls.palette.IPalette;
@@ -328,7 +326,7 @@ public class DesignerPalette {
 
 				@Override
 				public List<IEntry> getEntries() {
-					final List<EntryInfo> entryInfoList = Lists.newArrayList(categoryInfo.getEntries());
+					final List<EntryInfo> entryInfoList = new ArrayList<>(categoryInfo.getEntries());
 					// add new EntryInfo's using broadcast
 					ExecutionUtils.runIgnore(new RunnableEx() {
 						@Override
@@ -411,7 +409,7 @@ public class DesignerPalette {
 				final List<CategoryInfo> categoryInfoList;
 				{
 					List<CategoryInfo> pristineCategories = m_manager.getPalette().getCategories();
-					categoryInfoList = Lists.newArrayList(pristineCategories);
+					categoryInfoList = new ArrayList<>(pristineCategories);
 				}
 				// add new CategoryInfo's using broadcast
 				ExecutionUtils.runLog(new RunnableEx() {

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/JavaInfoUtils.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/JavaInfoUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model;
-
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.editor.IDesignPageSite;
 import org.eclipse.wb.core.eval.ExecutionFlowDescription;
@@ -97,6 +95,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -1826,7 +1825,7 @@ public class JavaInfoUtils {
 		{
 			Statement statement = target.getStatement();
 			if (statement != null) {
-				List<ASTNode> nodes = Lists.newArrayList(statement, javaInfoNode);
+				List<ASTNode> nodes = new ArrayList<>(Arrays.asList(statement, javaInfoNode));
 				sortNodesByFlow(flowDescription, target.isBefore(), nodes);
 				return nodes.get(0) == javaInfoNode;
 			}
@@ -1834,7 +1833,7 @@ public class JavaInfoUtils {
 		// Block
 		{
 			Block block = target.getBlock();
-			List<ASTNode> nodes = Lists.newArrayList(block, javaInfoNode);
+			List<ASTNode> nodes = new ArrayList<>(Arrays.asList(block, javaInfoNode));
 			sortNodesByFlow(flowDescription, target.isBefore(), nodes);
 			return nodes.get(0) == javaInfoNode;
 		}
@@ -1851,7 +1850,7 @@ public class JavaInfoUtils {
 		{
 			BodyDeclaration bodyDeclaration = target.getDeclaration();
 			if (bodyDeclaration != null) {
-				List<ASTNode> nodes = Lists.newArrayList(bodyDeclaration, javaInfoNode);
+				List<ASTNode> nodes = new ArrayList<>(Arrays.asList(bodyDeclaration, javaInfoNode));
 				sortNodesByFlow(flowDescription, target.isBefore(), nodes);
 				return nodes.get(0) == javaInfoNode;
 			}
@@ -1859,7 +1858,7 @@ public class JavaInfoUtils {
 		// TypeDeclaration
 		{
 			TypeDeclaration typeDeclaration = target.getType();
-			List<ASTNode> nodes = Lists.newArrayList(typeDeclaration, javaInfoNode);
+			List<ASTNode> nodes = new ArrayList<>(Arrays.asList(typeDeclaration, javaInfoNode));
 			sortNodesByFlow(flowDescription, target.isBefore(), nodes);
 			return nodes.get(0) == javaInfoNode;
 		}
@@ -1875,7 +1874,7 @@ public class JavaInfoUtils {
 		// prepare target after last component
 		NodeTarget nodeTarget_afterLastComponent;
 		{
-			List<JavaInfo> componentsCopy = Lists.newArrayList(components);
+			List<JavaInfo> componentsCopy = new ArrayList<>(components);
 			sortComponentsByFlow(componentsCopy);
 			JavaInfo lastComponent = componentsCopy.get(componentsCopy.size() - 1);
 			nodeTarget_afterLastComponent = getNodeTarget_afterCreation(lastComponent);

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/ComponentDescription.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/ComponentDescription.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description;
 
-import com.google.common.collect.Lists;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.EnvironmentUtils;
 import org.eclipse.wb.internal.core.model.order.ComponentOrder;
@@ -548,7 +546,7 @@ public class ComponentDescription extends AbstractDescription implements ICompon
 	 * @return all {@link CreationDescription}'s.
 	 */
 	public List<CreationDescription> getCreations() {
-		List<CreationDescription> creations = Lists.newArrayList(m_creations.values());
+		List<CreationDescription> creations = new ArrayList<>(m_creations.values());
 		creations.add(m_creationDefault);
 		return creations;
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/ComponentDescriptionHelper.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/ComponentDescriptionHelper.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description.helpers;
 
-import com.google.common.collect.Lists;
-
 import org.eclipse.wb.internal.core.model.description.AbstractInvocationDescription;
 import org.eclipse.wb.internal.core.model.description.ComponentDescription;
 import org.eclipse.wb.internal.core.model.description.ComponentDescriptionKey;
@@ -209,7 +207,7 @@ public final class ComponentDescriptionHelper {
 		{
 			Class<?> hostComponentClass = hostDescription.getComponentClass();
 			List<Class<?>> types = ReflectionUtils.getSuperHierarchy(hostComponentClass);
-			types = Lists.reverse(types);
+			Collections.reverse(types);
 			for (Class<?> type : types) {
 				ComponentDescriptionKey hostKey = new ComponentDescriptionKey(type);
 				// prepare specific ResourceInfo

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/ComponentPresentationHelper.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/ComponentPresentationHelper.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description.helpers;
 
-import com.google.common.io.Files;
-
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.model.description.ComponentDescription;
 import org.eclipse.wb.internal.core.model.description.ComponentPresentation;
@@ -472,7 +470,7 @@ public final class ComponentPresentationHelper {
 			File stateDirectory = DesignerPlugin.getDefault().getStateLocation().toFile();
 			File descriptionsDirectory = new File(stateDirectory, "descriptions");
 			File cacheFile = new File(descriptionsDirectory, m_toolkitId + ".cached-presentations.dat");
-			Files.createParentDirs(cacheFile);
+			descriptionsDirectory.mkdir();
 			return cacheFile;
 		}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/MethodInvocationArgumentAccessor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/MethodInvocationArgumentAccessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.property.accessor;
-
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.model.description.MethodDescription;
@@ -32,6 +30,7 @@ import org.apache.commons.lang.StringUtils;
 
 import java.lang.reflect.Method;
 import java.text.MessageFormat;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -97,7 +96,7 @@ public final class MethodInvocationArgumentAccessor extends ExpressionAccessor {
 				}
 
 				private String getNewInvocationArguments() {
-					List<String> arguments = Lists.newArrayList(defaultArguments);
+					List<String> arguments = new ArrayList<>(defaultArguments);
 					arguments.set(m_index, source);
 					return StringUtils.join(arguments.iterator(), ", ");
 				}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/event/ListenerInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/event/ListenerInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,18 +10,18 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.property.event;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
-
 import org.eclipse.wb.internal.core.utils.GenericTypeResolver;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
+import org.apache.commons.collections.map.MultiValueMap;
 import org.apache.commons.lang.StringUtils;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 
 /**
@@ -270,7 +270,7 @@ final class ListenerInfo {
 	////////////////////////////////////////////////////////////////////////////
 	static void useSimpleNamesWherePossible(List<ListenerInfo> listeners) {
 		// prepare map: simple name -> qualified names
-		Multimap<String, String> simplePropertyNames = HashMultimap.create();
+		MultiValueMap simplePropertyNames = MultiValueMap.decorate(new HashMap<>(), HashSet::new);
 		for (ListenerInfo listener : listeners) {
 			String qualifiedName = listener.getName();
 			String simpleName = getSimpleName(qualifiedName);
@@ -280,7 +280,7 @@ final class ListenerInfo {
 		for (ListenerInfo listener : listeners) {
 			String qualifiedName = listener.getName();
 			String simpleName = getSimpleName(qualifiedName);
-			if (simplePropertyNames.get(simpleName).size() == 1) {
+			if (simplePropertyNames.size(simpleName) == 1) {
 				listener.m_name = simpleName;
 			}
 		}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/RenameConvertSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/RenameConvertSupport.java
@@ -93,8 +93,7 @@ public final class RenameConvertSupport {
 	 * @param objects
 	 *          The components that should be renamed/converted.
 	 */
-	public static void rename(List<? extends ObjectInfo> objects) {
-		Iterable<JavaInfo> components = Iterables.filter(objects, JavaInfo.class);
+	public static void rename(List<JavaInfo> components) {
 		RenameConvertSupport support = new RenameConvertSupport(components);
 		support.doRename();
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/factory/FactoryCreateAction.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/factory/FactoryCreateAction.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.util.factory;
 
-import com.google.common.collect.Iterables;
-
 import org.eclipse.wb.core.editor.IDesignPageSite;
 import org.eclipse.wb.core.editor.palette.model.CategoryInfo;
 import org.eclipse.wb.core.editor.palette.model.IPaletteSite;
@@ -446,7 +444,7 @@ public final class FactoryCreateAction extends Action {
 					factoryEditor.addMethodDeclaration(m_generate_methodHeader, m_generate_methodBody, target);
 			factoryEditor.setJavadoc(
 					methodDeclaration,
-					Iterables.toArray(m_generate_methodComments, String.class));
+					m_generate_methodComments.toArray(String[]::new));
 		}
 		// commit changes to factory unit
 		factoryEditor.commitChanges();

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/variable/AbstractSimpleVariableSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/variable/AbstractSimpleVariableSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.variable;
-
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.eval.ExecutionFlowDescription;
 import org.eclipse.wb.core.eval.ExecutionFlowUtils;
@@ -448,7 +446,7 @@ public abstract class AbstractSimpleVariableSupport extends AbstractNamedVariabl
 			}
 		}
 		// add children
-		List<JavaInfo> children = Lists.newArrayList(javaInfo.getChildrenJava());
+		List<JavaInfo> children = new ArrayList<>(javaInfo.getChildrenJava());
 		javaInfo.getBroadcastJava().variable_addStatementsToMove(javaInfo, children);
 		for (JavaInfo child : children) {
 			addStatementsToMove(statements, target, child);

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/variable/LazyVariableSupportUtils.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/variable/LazyVariableSupportUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.variable;
-
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
@@ -171,7 +169,7 @@ public final class LazyVariableSupportUtils {
 		{
 			Statement[] statements = moveStatements.toArray(new Statement[moveStatements.size()]);
 			Arrays.sort(statements, AstNodeUtils.SORT_BY_POSITION);
-			moveStatements = Lists.newArrayList(statements);
+			moveStatements = Arrays.asList(statements);
 		}
 		// move statements
 		for (Statement moveStatement : moveStatements) {
@@ -214,7 +212,7 @@ public final class LazyVariableSupportUtils {
 			}
 		}
 		// add children
-		List<JavaInfo> children = Lists.newArrayList(javaInfo.getChildrenJava());
+		List<JavaInfo> children = new ArrayList<>(javaInfo.getChildrenJava());
 		javaInfo.getBroadcastJava().variable_addStatementsToMove(javaInfo, children);
 		for (JavaInfo child : children) {
 			collectNodesToEdit(child, moveStatements, replaceNodes, target);

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/variable/LocalUniqueVariableSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/variable/LocalUniqueVariableSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,9 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.variable;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.ast.AstNodeUtils;
@@ -20,6 +17,7 @@ import org.eclipse.wb.internal.core.utils.ast.NodeTarget;
 import org.eclipse.wb.internal.core.utils.ast.OperatorPrecedence;
 import org.eclipse.wb.internal.core.utils.ast.StatementTarget;
 
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.ParenthesizedExpression;
 import org.eclipse.jdt.core.dom.SimpleName;
@@ -29,6 +27,7 @@ import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
 
 import org.apache.commons.lang.StringUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -188,7 +187,7 @@ public final class LocalUniqueVariableSupport extends LocalVariableSupport {
 	 *         can be inlined.
 	 */
 	public boolean canInline() {
-		List<Expression> references = Lists.newArrayList(getReferences());
+		List<Expression> references = new ArrayList<>(getReferences());
 		references.remove(m_variable);
 		return references.size() == 1;
 	}
@@ -204,9 +203,9 @@ public final class LocalUniqueVariableSupport extends LocalVariableSupport {
 		// prepare single reference on component, that should be replaced with creation Expression
 		Expression reference;
 		{
-			List<Expression> references = Lists.newArrayList(getReferences());
+			List<Expression> references = new ArrayList<>(getReferences());
 			references.remove(m_variable);
-			Preconditions.checkState(references.size() == 1, references);
+			Assert.isLegal(references.size() == 1, references.toString());
 			reference = references.get(0);
 		}
 		// prepare "initializer"

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/nls/edit/EditableSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/nls/edit/EditableSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.core.nls.edit;
-
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
@@ -33,6 +31,7 @@ import org.apache.commons.collections.MapIterator;
 import org.apache.commons.collections.map.MultiKeyMap;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -123,7 +122,7 @@ public final class EditableSupport implements IEditableSupport, ICommandQueue {
 			List<StringPropertyInfo> componentProperties = new ArrayList<>();
 			m_componentToPropertyList.put(component, componentProperties);
 			// prepare list of properties
-			List<Property> properties = Lists.newArrayList(component.getProperties());
+			List<Property> properties = new ArrayList<>(Arrays.asList(component.getProperties()));
 			for (Property property : List.copyOf(properties)) {
 				PropertyEditor editor = property.getEditor();
 				if (editor instanceof INlsPropertyContributor) {

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/AstEditor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/AstEditor.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.utils.ast;
 
-import com.google.common.collect.Lists;
-
 import org.eclipse.wb.internal.core.utils.GenericsUtils;
 import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.core.utils.ast.binding.BindingContext;
@@ -1490,7 +1488,7 @@ public final class AstEditor {
 	public void inlineBlock(Block block) throws Exception {
 		StatementTarget target = new StatementTarget((Statement) block, true);
 		// move Statement's
-		List<Statement> statements = Lists.newArrayList(DomGenerics.statements(block));
+		List<Statement> statements = new ArrayList<>(DomGenerics.statements(block));
 		for (Statement statement : statements) {
 			moveStatement(statement, target);
 		}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/core/CodeUtils.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/core/CodeUtils.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.utils.jdt.core;
 
-import com.google.common.collect.Lists;
-
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.preferences.IPreferenceConstants;
 import org.eclipse.wb.internal.core.utils.ast.AstNodeUtils;
@@ -59,6 +57,7 @@ import org.apache.commons.lang.StringUtils;
 
 import java.lang.reflect.TypeVariable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -557,7 +556,7 @@ public class CodeUtils {
 	public static List<IMethod> findMethods(IType type, List<String> signatures)
 			throws JavaModelException {
 		IMethod[] methods = findMethods(type, signatures.toArray(new String[signatures.size()]));
-		return Lists.newArrayList(methods);
+		return Arrays.asList(methods);
 	}
 
 	/**

--- a/org.eclipse.wb.core.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.core.ui;singleton:=true
-Bundle-Version: 1.10.300.qualifier
+Bundle-Version: 1.10.400.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wb.core.ui/src/org/eclipse/wb/internal/core/wizards/actions/NewDesignerTypeDropDownAction.java
+++ b/org.eclipse.wb.core.ui/src/org/eclipse/wb/internal/core/wizards/actions/NewDesignerTypeDropDownAction.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.wizards.actions;
 
-import com.google.common.collect.Iterables;
-
 import org.eclipse.wb.internal.core.utils.external.ExternalFactoriesHelper;
 
 import org.eclipse.core.runtime.IConfigurationElement;
@@ -32,6 +30,7 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.IWorkbenchWindowPulldownDelegate;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * {@link Action} for displaying all WindowBuilder wizards in single drop-down menu.
@@ -89,15 +88,15 @@ IActionDelegate2 {
 	////////////////////////////////////////////////////////////////////////////
 	private static void createCategoryItems(Menu parent, String parentCategoryId) {
 		// process wizards
-		for (IConfigurationElement wizard : getWizardWizards(parentCategoryId)) {
+		getWizardWizards(parentCategoryId).forEach(wizard -> {
 			if (isWizardVisibleInMenu(wizard)) {
 				IAction action = new OpenTypeWizardAction(wizard);
 				ActionContributionItem item = new ActionContributionItem(action);
 				item.fill(parent, -1);
 			}
-		}
+		});
 		// process sub-categories
-		for (IConfigurationElement category : getWizardCategories(parentCategoryId)) {
+		getWizardCategories(parentCategoryId).forEach(category -> {
 			boolean isInline = "true".equals(category.getAttribute("wbp-menu-inline"));
 			// prepare Menu for category items
 			Menu categoryMenu;
@@ -116,7 +115,7 @@ IActionDelegate2 {
 			if (isInline) {
 				addSeparator(parent);
 			}
-		}
+		});
 	}
 
 	private static void addSeparator(Menu parent) {
@@ -184,20 +183,20 @@ IActionDelegate2 {
 		return visible != null ? "true".equals(visible) : true;
 	}
 
-	private static Iterable<IConfigurationElement> getWizardWizards(String parentCategoryId) {
+	private static Stream<IConfigurationElement> getWizardWizards(String parentCategoryId) {
 		return getWizardElements("wizard", "category", parentCategoryId);
 	}
 
-	private static Iterable<IConfigurationElement> getWizardCategories(String parentCategoryId) {
+	private static Stream<IConfigurationElement> getWizardCategories(String parentCategoryId) {
 		return getWizardElements("category", "parentCategory", parentCategoryId);
 	}
 
-	private static Iterable<IConfigurationElement> getWizardElements(String elementName,
+	private static Stream<IConfigurationElement> getWizardElements(String elementName,
 			final String attributeName,
 			final String parentCategoryId) {
 		List<IConfigurationElement> allCategories =
 				ExternalFactoriesHelper.getElements("org.eclipse.ui.newWizards", elementName);
-		return Iterables.filter(allCategories, t -> parentCategoryId.equals(t.getAttribute(attributeName)));
+		return allCategories.stream().filter(t -> parentCategoryId.equals(t.getAttribute(attributeName)));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.core;singleton:=true
-Bundle-Version: 1.13.100.qualifier
+Bundle-Version: 1.15.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.core.DesignerPlugin

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/EditPart.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/EditPart.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.gef.core;
 
-import com.google.common.collect.Iterators;
-
 import org.eclipse.wb.internal.gef.core.EditPartVisitor;
 
 import org.eclipse.gef.EditPartViewer;
@@ -265,7 +263,7 @@ public abstract class EditPart extends org.eclipse.gef.editparts.AbstractEditPar
 		if (newPartCount - index > 1) {
 			// deselect old child EditPart's
 			List<EditPart> deselectList = new ArrayList<>();
-			Iterators.addAll(deselectList, children.listIterator(index));
+			children.listIterator(index).forEachRemaining(deselectList::add);
 			getViewer().deselect(deselectList);
 		}
 		// remove old child EditPart's

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gefTree/part/ObjectEditPart.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gefTree/part/ObjectEditPart.java
@@ -11,8 +11,6 @@
  *******************************************************************************/
 package org.eclipse.wb.core.gefTree.part;
 
-import com.google.common.collect.Lists;
-
 import org.eclipse.wb.core.editor.constants.IEditorPreferenceConstants;
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.broadcast.ObjectEventListener;
@@ -108,7 +106,7 @@ public class ObjectEditPart extends TreeEditPart {
 					m_delayedSelectionObjects = null;
 					// set selection now, or delay
 					if (!setSelectionIfAllEditParts(objects)) {
-						m_delayedSelectionObjects = Lists.newArrayList(objects);
+						m_delayedSelectionObjects = new ArrayList<>(objects);
 					}
 				}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/model/ObjectInfoUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/model/ObjectInfoUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.wb.core.model;
 
-import com.google.common.collect.MapMaker;
-
 import org.eclipse.wb.internal.core.utils.check.Assert;
+
+import org.apache.commons.collections.map.ReferenceMap;
 
 import java.util.Map;
 
@@ -38,8 +38,10 @@ public final class ObjectInfoUtils {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	private static long m_lastObjectInfoID = 0;
-	private static Map<String, ObjectInfo> m_idToObjectInfo = new MapMaker().weakValues().makeMap();
-	private static Map<ObjectInfo, String> m_objectInfoToId = new MapMaker().weakKeys().makeMap();
+	@SuppressWarnings("unchecked")
+	private static Map<String, ObjectInfo> m_idToObjectInfo = new ReferenceMap(ReferenceMap.HARD, ReferenceMap.WEAK);
+	@SuppressWarnings("unchecked")
+	private static Map<ObjectInfo, String> m_objectInfoToId = new ReferenceMap(ReferenceMap.WEAK, ReferenceMap.HARD);
 
 	/**
 	 * @return the {@link ObjectInfo} with corresponding ID.

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/DesignToolbarHelper.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/DesignToolbarHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.core.editor;
-
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.broadcast.ObjectEventListener;
@@ -198,7 +196,7 @@ public class DesignToolbarHelper {
 	 * Refreshes the actions based on components hierarchy.
 	 */
 	private void refreshHierarchyActions() {
-		final List<IContributionItem> toRemove = Lists.newArrayList(m_hierarchyItems);
+		final List<IContributionItem> toRemove = new ArrayList<>(m_hierarchyItems);
 		// add items for hierarchy
 		ExecutionUtils.runLog(new RunnableEx() {
 			@Override
@@ -257,7 +255,7 @@ public class DesignToolbarHelper {
 	 * Refreshes the actions based on selection.
 	 */
 	private void refreshSelectionActions() {
-		final List<IContributionItem> toRemove = Lists.newArrayList(m_selectionItems);
+		final List<IContributionItem> toRemove = new ArrayList<>(m_selectionItems);
 		// prepare selected ObjectInfo's
 		final List<ObjectInfo> selectedObjects = new ArrayList<>();
 		for (EditPart editPart : m_viewer.getSelectedEditParts()) {

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/errors/report2/logs/EclipseErrorLogsReportEntry.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/errors/report2/logs/EclipseErrorLogsReportEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.editor.errors.report2.logs;
 
-import com.google.common.collect.Lists;
-
 import org.eclipse.wb.internal.core.editor.errors.report2.FileListReportEntry;
 
 import org.eclipse.core.runtime.IPath;
@@ -19,6 +17,7 @@ import org.eclipse.core.runtime.Platform;
 
 import java.io.File;
 import java.io.FilenameFilter;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -40,7 +39,7 @@ public final class EclipseErrorLogsReportEntry extends FileListReportEntry {
 				return name.endsWith(".log");
 			}
 		});
-		return Lists.newArrayList(logFiles);
+		return Arrays.asList(logFiles);
 	}
 
 	@Override

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/snapping/PlacementsSupport.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/snapping/PlacementsSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.core.gef.policy.snapping;
-
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.model.IAbstractComponentInfo;
 import org.eclipse.wb.draw2d.IPositionConstants;
@@ -75,7 +73,7 @@ public final class PlacementsSupport {
 		m_feedbackProxy = feedbackProxy;
 		m_layoutCommands = layout;
 		m_snapPoints = new SnapPoints(visualDataProvider, feedbackProxy, allWidgets);
-		m_allWidgets = Lists.newArrayList(allWidgets);
+		m_allWidgets = new ArrayList<>(allWidgets);
 	}
 
 	/**
@@ -690,7 +688,7 @@ public final class PlacementsSupport {
 		if (!CollectionUtils.isEmpty(m_operatingWidgets) && m_operatingWidgets.get(0).isDeleting()) {
 			return getRemainingWidgets();
 		}
-		return Lists.newArrayList(m_allWidgets);
+		return new ArrayList<>(m_allWidgets);
 	}
 
 	private PlacementInfo getPlacementInfoX() {

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/snapping/SnapPoints.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/snapping/SnapPoints.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.core.gef.policy.snapping;
-
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.model.IAbstractComponentInfo;
 import org.eclipse.wb.draw2d.Figure;
@@ -65,7 +63,7 @@ public class SnapPoints {
 		m_feedbackProxy = feedbackProxy;
 		m_snapPoints = snapPoints;
 		m_listener = listener;
-		m_allWidgets = Lists.newArrayList(allWidgets);
+		m_allWidgets = new ArrayList<>(allWidgets);
 	}
 
 	/**

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/ObjectReferenceInfo.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/ObjectReferenceInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,11 +10,11 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model;
 
-import com.google.common.base.Preconditions;
-
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.broadcast.BroadcastSupport;
 import org.eclipse.wb.internal.core.model.presentation.IObjectPresentation;
+
+import java.util.Objects;
 
 import javax.swing.AbstractButton;
 
@@ -41,7 +41,7 @@ public final class ObjectReferenceInfo extends ObjectInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	public ObjectReferenceInfo(ObjectInfo object) {
-		Preconditions.checkNotNull(object);
+		Objects.requireNonNull(object);
 		m_object = object;
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/table/PropertyTable.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/table/PropertyTable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.property.table;
-
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.draw2d.IColorConstants;
 import org.eclipse.wb.draw2d.ICursorConstants;
@@ -743,7 +741,7 @@ public class PropertyTable extends Canvas implements ISelectionProvider {
 				// expand properties using history
 				while (true) {
 					boolean expanded = false;
-					List<PropertyInfo> currentProperties = Lists.newArrayList(m_properties);
+					List<PropertyInfo> currentProperties = new ArrayList<>(m_properties);
 					for (PropertyInfo propertyInfo : currentProperties) {
 						expanded |= propertyInfo.expandFromHistory();
 					}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/ScriptUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/ScriptUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,14 +10,12 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.util;
 
-import com.google.common.collect.MapMaker;
-import com.google.common.collect.Maps;
-
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 import org.eclipse.wb.internal.core.utils.reflect.ClassLoaderLocalMap;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
+import org.apache.commons.collections.map.ReferenceMap;
 import org.mvel2.MVEL;
 import org.mvel2.ParserConfiguration;
 import org.mvel2.ParserContext;
@@ -143,7 +141,7 @@ public final class ScriptUtils {
 	}
 
 	private static Object evaluate(Object expression, Map<String, Object> _variables) {
-		Map<String, Object> variables = Maps.newHashMap(_variables);
+		Map<String, Object> variables = new HashMap<>(_variables);
 		return MVEL.executeExpression(expression, variables);
 	}
 
@@ -193,8 +191,9 @@ public final class ScriptUtils {
 	// Compilation
 	//
 	////////////////////////////////////////////////////////////////////////////
+	@SuppressWarnings("unchecked")
 	private static final Map<String, Object> m_compiledExpressions =
-			new MapMaker().weakValues().makeMap();
+			new ReferenceMap(ReferenceMap.HARD, ReferenceMap.WEAK);
 
 	/**
 	 * @return the weak cache for given {@link ClassLoader}.

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/exception/DesignerExceptionUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/exception/DesignerExceptionUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.core.utils.exception;
-
-import com.google.common.collect.MapMaker;
 
 import org.eclipse.wb.core.branding.BrandingUtils;
 import org.eclipse.wb.core.controls.BrowserComposite;
@@ -43,6 +41,7 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.browser.IWebBrowser;
 import org.eclipse.ui.browser.IWorkbenchBrowserSupport;
 
+import org.apache.commons.collections.map.ReferenceMap;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
@@ -199,7 +198,8 @@ public final class DesignerExceptionUtils {
 	// Utils
 	//
 	////////////////////////////////////////////////////////////////////////////
-	private static Map<Throwable, Integer> m_exceptionPositions = new MapMaker().weakKeys().makeMap();
+	@SuppressWarnings("unchecked")
+	private static Map<Throwable, Integer> m_exceptionPositions = new ReferenceMap(ReferenceMap.WEAK, ReferenceMap.HARD);
 
 	/**
 	 * See {@link ExceptionUtils#getRootCause(Throwable)}, but returns {@link Throwable} itself if no

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/reflect/CompositeClassLoader.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/reflect/CompositeClassLoader.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.utils.reflect;
 
-import com.google.common.collect.Iterators;
-
 import org.apache.commons.collections.CollectionUtils;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.wiring.BundleCapability;
@@ -21,6 +19,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
@@ -156,7 +155,7 @@ public class CompositeClassLoader extends ClassLoader {
 			Enumeration<URL> resources = classLoader.getResources(name);
 			CollectionUtils.addAll(allResources, resources);
 		}
-		return Iterators.asEnumeration(allResources.iterator());
+		return Collections.enumeration(allResources);
 	}
 
 	@Override

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/reflect/ReflectionUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/reflect/ReflectionUtils.java
@@ -10,13 +10,11 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.utils.reflect;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
-
 import org.eclipse.wb.internal.core.EnvironmentUtils;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 
+import org.apache.commons.collections.map.MultiValueMap;
 import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.StringUtils;
 
@@ -1474,7 +1472,7 @@ public class ReflectionUtils {
 
 	private static void useSimplePropertyNamesWherePossible(List<PropertyDescriptor> descriptors) {
 		// prepare map: simple name -> qualified names
-		Multimap<String, String> simplePropertyNames = HashMultimap.create();
+		MultiValueMap simplePropertyNames = MultiValueMap.decorate(new HashMap<>(), HashSet::new);
 		for (PropertyDescriptor propertyDescriptor : descriptors) {
 			String qualifiedPropertyName = propertyDescriptor.getName();
 			String simplePropertyName = getSimplePropertyName(qualifiedPropertyName);
@@ -1484,7 +1482,7 @@ public class ReflectionUtils {
 		for (PropertyDescriptor propertyDescriptor : descriptors) {
 			String qualifiedPropertyName = propertyDescriptor.getName();
 			String simplePropertyName = getSimplePropertyName(qualifiedPropertyName);
-			if (simplePropertyNames.get(simplePropertyName).size() == 1) {
+			if (simplePropertyNames.getCollection(simplePropertyName).size() == 1) {
 				propertyDescriptor.setName(simplePropertyName);
 			}
 		}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/ui/AbstractBindingComposite.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/ui/AbstractBindingComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.core.utils.ui;
-
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.internal.core.utils.binding.DataBindManager;
 import org.eclipse.wb.internal.core.utils.binding.IDataEditor;
@@ -96,7 +94,7 @@ public abstract class AbstractBindingComposite extends Composite {
 				return;
 			}
 		}
-		for (Runnable listener : Lists.newArrayList(m_updateListeners)) {
+		for (Runnable listener : new ArrayList<>(m_updateListeners)) {
 			listener.run();
 		}
 	}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/xml/Model.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/xml/Model.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.core.utils.xml;
-
-import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -70,7 +68,7 @@ public final class Model {
 	 * Delivers change event to all the registered listeners.
 	 */
 	public void fireModelChanged(ModelChangedEvent event) {
-		List<IModelChangedListener> listeners = Lists.newArrayList(m_listeners);
+		List<IModelChangedListener> listeners = new ArrayList<>(m_listeners);
 		for (IModelChangedListener listener : listeners) {
 			listener.modelChanged(event);
 		}


### PR DESCRIPTION
In almost all cases, the call of Lists.newArrayList() can be simply replaced with new ArrayList<>().

Occasionally, we use Arrays.asList() to create lists from arrays. But care has to be taken here, because those lists are read-only. If values are written to them afterwards, the constructed list is passed as an argument to an ArrayList.
Note that we use Arrays.asList() instead of List.of(), as latter doesn't allow null elements.

The MapMaker class which is used to create maps with weak keys/values are replaced by the ReferenceMap.

The Multimap class is replaced by the MultiValueMap.