### PR TITLE
Remove usage of Guava collections from SWT/RCP projects #270

### DIFF
--- a/org.eclipse.wb.rcp.databinding/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp.databinding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.rcp.databinding;singleton:=true
-Bundle-Version: 1.9.400.qualifier
+Bundle-Version: 1.9.500.qualifier
 Bundle-Activator: org.eclipse.wb.internal.rcp.databinding.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/DataBindingsCodeUtils.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/DataBindingsCodeUtils.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.databinding.model;
 
-import com.google.common.collect.Lists;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.databinding.utils.CoreUtils;
@@ -290,7 +288,7 @@ public final class DataBindingsCodeUtils {
 		}
 		//
 		List<Statement> oldStatements =
-				Lists.newArrayList(DomGenerics.statements(mainMethod.getBody()));
+				new ArrayList<>(DomGenerics.statements(mainMethod.getBody()));
 		//
 		Statement displayStatement =
 				editor.addStatement(

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/input/VirtualEditingSupportInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/input/VirtualEditingSupportInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.databinding.model.widgets.input;
-
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.internal.core.databinding.model.IObservePresentation;
 import org.eclipse.wb.internal.core.databinding.ui.editor.IUiContentProvider;
@@ -35,6 +33,7 @@ import org.apache.commons.lang.ClassUtils;
 import org.apache.commons.lang.StringUtils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -290,7 +289,7 @@ public final class VirtualEditingSupportInfo {
 					setClassNameAndProperties(
 							beanClass,
 							m_cellEditorClassName,
-							Lists.newArrayList(m_cellEditorProperty));
+							Arrays.asList(m_cellEditorProperty));
 				}
 			}
 		}
@@ -354,7 +353,7 @@ public final class VirtualEditingSupportInfo {
 					setClassName(CoreUtils.getClassName(elementType));
 				}
 			} else {
-				setClassNameAndProperties(elementType, null, Lists.newArrayList(m_elementProperty));
+				setClassNameAndProperties(elementType, null, Arrays.asList(m_elementProperty));
 			}
 		}
 

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/observables/TextSwtObservableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/observables/TextSwtObservableInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.databinding.model.widgets.observables;
-
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.internal.core.databinding.ui.editor.IUiContentProvider;
 import org.eclipse.wb.internal.core.utils.check.Assert;
@@ -77,11 +75,11 @@ public final class TextSwtObservableInfo extends SwtObservableInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	public List<String> getUpdateEvents() {
-		return Lists.newArrayList(m_updateEvents);
+		return new ArrayList<>(m_updateEvents);
 	}
 
 	public void setUpdateEvents(List<String> updateEvents) {
-		m_updateEvents = Lists.newArrayList(updateEvents);
+		m_updateEvents = new ArrayList<>(updateEvents);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/contentproviders/ObservableDetailUiContentProvider.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/contentproviders/ObservableDetailUiContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.databinding.ui.contentproviders;
-
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.internal.core.databinding.ui.editor.contentproviders.ChooseClassAndPropertiesConfiguration;
 import org.eclipse.wb.internal.core.databinding.ui.editor.contentproviders.ChooseClassAndPropertiesConfiguration.LoadedPropertiesCheckedStrategy;
@@ -26,6 +24,7 @@ import org.eclipse.wb.internal.rcp.databinding.model.widgets.observables.ViewerO
 import org.apache.commons.lang.ClassUtils;
 import org.apache.commons.lang.StringUtils;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -105,7 +104,7 @@ ChooseClassAndTreePropertiesUiContentProvider2 {
 			setClassNameAndProperties(
 					m_observable.getDetailBeanClass(),
 					null,
-					Lists.newArrayList(propertyReference));
+					Arrays.asList(propertyReference));
 			// restore strategy
 			m_configuration.setLoadedPropertiesCheckedStrategy(strategy);
 		}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/FieldEditorPreferencePageInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/FieldEditorPreferencePageInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.jface;
-
-import com.google.common.base.Preconditions;
 
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
@@ -30,6 +28,7 @@ import org.eclipse.wb.internal.core.utils.ast.AstNodeUtils;
 import org.eclipse.wb.internal.core.utils.ast.StatementTarget;
 import org.eclipse.wb.internal.rcp.preferences.IPreferenceConstants;
 
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.Block;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
@@ -40,6 +39,7 @@ import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.apache.commons.lang.StringUtils;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Model for {@link FieldEditorPreferencePage}.
@@ -120,7 +120,7 @@ public final class FieldEditorPreferencePageInfo extends PreferencePageInfo {
 	 * Moves {@link FieldEditorInfo}.
 	 */
 	public void command_MOVE(FieldEditorInfo editor, FieldEditorInfo nextEditor) throws Exception {
-		Preconditions.checkArgument(editor.getParent() == this, editor.getParent());
+		Assert.isLegal(editor.getParent() == this, Objects.toString(editor.getParent()));
 		if (editor.getVariableSupport() instanceof EmptyVariableSupport) {
 			ObjectInfo oldParent = editor.getParent();
 			getBroadcastJava().moveBefore0(editor, oldParent, this);

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/ActionContributionItemInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/ActionContributionItemInfo.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.jface.action;
 
-import com.google.common.collect.Lists;
-
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.broadcast.ObjectInfoDelete;
 import org.eclipse.wb.internal.core.model.creation.CreationSupport;
@@ -29,6 +27,7 @@ import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.IContributionManager;
 import org.eclipse.jface.resource.ImageDescriptor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -103,7 +102,7 @@ public final class ActionContributionItemInfo extends ContributionItemInfo {
 	protected List<Property> getPropertyList() throws Exception {
 		if (isAddAction()) {
 			Property[] actionProperties = getAction().getProperties();
-			return Lists.newArrayList(actionProperties);
+			return new ArrayList<>(List.of(actionProperties));
 		}
 		return super.getPropertyList();
 	}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/PdeUtils.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/PdeUtils.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.rcp;
 
-import com.google.common.collect.Lists;
-
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.utils.IOUtils2;
 import org.eclipse.wb.internal.core.utils.check.Assert;
@@ -55,6 +53,7 @@ import org.osgi.framework.Bundle;
 import java.io.ByteArrayInputStream;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -164,7 +163,7 @@ public final class PdeUtils {
 	 *          the id of plugin.
 	 */
 	public void addPluginImport(final List<String> pluginIds) throws Exception {
-		final List<String> pluginIdsForAdding = Lists.newArrayList(pluginIds);
+		final List<String> pluginIdsForAdding = new ArrayList<>(pluginIds);
 		// check exist imports
 		for (IPluginImport pluginImport : getModel().getPluginBase().getImports()) {
 			pluginIdsForAdding.remove(pluginImport.getId());
@@ -190,7 +189,7 @@ public final class PdeUtils {
 	}
 
 	public void addPluginImport(String... pluginIds) throws Exception {
-		addPluginImport(Lists.newArrayList(pluginIds));
+		addPluginImport(Arrays.asList(pluginIds));
 	}
 
 	/**

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/WorkbenchWindowAdvisorPropertiesProvider.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/WorkbenchWindowAdvisorPropertiesProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.rcp;
-
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.broadcast.GenericPropertyGetValueEx;
@@ -336,7 +334,7 @@ final class WorkbenchWindowAdvisorPropertiesProvider {
 				method =
 						m_windowEditor.addMethodDeclaration(
 								"public void preWindowOpen()",
-								Lists.newArrayList("org.eclipse.ui.application.IWorkbenchWindowConfigurer configurer = getWindowConfigurer();"),
+								List.of("org.eclipse.ui.application.IWorkbenchWindowConfigurer configurer = getWindowConfigurer();"),
 								new BodyDeclarationTarget(m_windowType, false));
 			}
 			return method;

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/AbstractPositionCompositeInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/AbstractPositionCompositeInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.widgets;
-
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.association.AssociationObject;
@@ -32,6 +30,7 @@ import org.eclipse.swt.widgets.Composite;
 
 import org.apache.commons.lang.ArrayUtils;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -118,7 +117,7 @@ public abstract class AbstractPositionCompositeInfo extends CompositeInfo {
 	private final IObjectPresentation m_presentation = new DefaultJavaInfoPresentation(this) {
 		@Override
 		public List<ObjectInfo> getChildrenTree() throws Exception {
-			List<ObjectInfo> children = Lists.newArrayList(super.getChildrenTree());
+			List<ObjectInfo> children = new ArrayList<>(super.getChildrenTree());
 			Set<ControlInfo> positionedControls = new HashSet<>();
 			for (int i = 0; i < m_methods.length; i++) {
 				String method = m_methods[i];

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/AbstractTabFolderInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/AbstractTabFolderInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.widgets;
-
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
@@ -27,6 +25,7 @@ import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.widgets.TabFolder;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -81,7 +80,7 @@ public abstract class AbstractTabFolderInfo extends CompositeInfo {
 	private final IObjectPresentation m_presentation = new DefaultJavaInfoPresentation(this) {
 		@Override
 		public List<ObjectInfo> getChildrenTree() throws Exception {
-			List<ObjectInfo> children = Lists.newArrayList(super.getChildrenTree());
+			List<ObjectInfo> children = new ArrayList<>(super.getChildrenTree());
 			// don't show in tree any Control's
 			for (Iterator<ObjectInfo> I = children.iterator(); I.hasNext();) {
 				ObjectInfo child = I.next();

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/CoolBarInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/CoolBarInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.widgets;
-
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.model.creation.CreationSupport;
@@ -27,6 +25,7 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.CoolBar;
 import org.eclipse.swt.widgets.CoolItem;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -97,14 +96,14 @@ public final class CoolBarInfo extends CompositeInfo {
 	private final IObjectPresentation m_presentation = new DefaultJavaInfoPresentation(this) {
 		@Override
 		public List<ObjectInfo> getChildrenTree() throws Exception {
-			List<ObjectInfo> children = Lists.newArrayList(super.getChildrenTree());
+			List<ObjectInfo> children = new ArrayList<>(super.getChildrenTree());
 			removeItemControls(children);
 			return children;
 		}
 
 		@Override
 		public List<ObjectInfo> getChildrenGraphical() throws Exception {
-			List<ObjectInfo> children = Lists.newArrayList(super.getChildrenGraphical());
+			List<ObjectInfo> children = new ArrayList<>(super.getChildrenGraphical());
 			removeItemControls(children);
 			return children;
 		}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/ExpandBarInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/ExpandBarInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.widgets;
-
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.model.creation.CreationSupport;
@@ -22,6 +20,7 @@ import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 
 import org.eclipse.swt.widgets.ExpandBar;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -75,14 +74,14 @@ public final class ExpandBarInfo extends CompositeInfo {
 	private final IObjectPresentation m_presentation = new DefaultJavaInfoPresentation(this) {
 		@Override
 		public List<ObjectInfo> getChildrenTree() throws Exception {
-			List<ObjectInfo> children = Lists.newArrayList(super.getChildrenTree());
+			List<ObjectInfo> children = new ArrayList<>(super.getChildrenTree());
 			removeItemControls(children);
 			return children;
 		}
 
 		@Override
 		public List<ObjectInfo> getChildrenGraphical() throws Exception {
-			List<ObjectInfo> children = Lists.newArrayList(super.getChildrenGraphical());
+			List<ObjectInfo> children = new ArrayList<>(super.getChildrenGraphical());
 			removeItemControls(children);
 			return children;
 		}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/ToolBarInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/ToolBarInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.model.widgets;
-
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.model.creation.CreationSupport;
@@ -24,6 +22,7 @@ import org.eclipse.wb.internal.swt.support.ControlSupport;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.ToolBar;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -71,14 +70,14 @@ public final class ToolBarInfo extends CompositeInfo {
 	private final IObjectPresentation m_presentation = new DefaultJavaInfoPresentation(this) {
 		@Override
 		public List<ObjectInfo> getChildrenTree() throws Exception {
-			List<ObjectInfo> children = Lists.newArrayList(super.getChildrenTree());
+			List<ObjectInfo> children = new ArrayList<>(super.getChildrenTree());
 			removeItemControls(children);
 			return children;
 		}
 
 		@Override
 		public List<ObjectInfo> getChildrenGraphical() throws Exception {
-			List<ObjectInfo> children = Lists.newArrayList(super.getChildrenGraphical());
+			List<ObjectInfo> children = new ArrayList<>(super.getChildrenGraphical());
 			removeItemControls(children);
 			return children;
 		}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/parser/ParseFactory.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/parser/ParseFactory.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.parser;
 
-import com.google.common.collect.Lists;
-
 import org.eclipse.wb.core.eval.ExecutionFlowDescription;
 import org.eclipse.wb.core.eval.ExecutionFlowUtils;
 import org.eclipse.wb.core.eval.ExecutionFlowUtils2;
@@ -139,8 +137,7 @@ public final class ParseFactory extends org.eclipse.wb.internal.swt.parser.Parse
 		{
 			MethodDeclaration method = ExecutionFlowUtils.getExecutionFlow_entryPoint(typeDeclaration);
 			if (method != null) {
-				List<MethodDeclaration> rootMethods = Lists.newArrayList(method);
-				return new ParseRootContext(null, new ExecutionFlowDescription(rootMethods));
+				return new ParseRootContext(null, new ExecutionFlowDescription(method));
 			}
 		}
 		// check for org.eclipse.ui.IPerspectiveFactory
@@ -224,8 +221,7 @@ public final class ParseFactory extends org.eclipse.wb.internal.swt.parser.Parse
 							ObjectInfoUtils.setNewId(javaInfo);
 							javaInfo.bindToExpression(parameter.getName());
 							// prepare root context
-							List<MethodDeclaration> rootMethods = Lists.newArrayList(method);
-							return new ParseRootContext(javaInfo, new ExecutionFlowDescription(rootMethods));
+							return new ParseRootContext(javaInfo, new ExecutionFlowDescription(method));
 						}
 					}
 				}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/support/ToolkitSupportImpl.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/support/ToolkitSupportImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.support;
-
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.EnvironmentUtils;
@@ -92,7 +90,7 @@ public final class ToolkitSupportImpl implements IToolkitSupport {
 			// prepare returned data
 			menuInfo.m_menuImage = OSSupport.get().getMenuPopupVisualData(menu, bounds);
 			menuInfo.m_menuBounds = new Rectangle(menuInfo.m_menuImage.getBounds());
-			menuInfo.m_itemBounds = Lists.newArrayListWithCapacity(menu.getItemCount());
+			menuInfo.m_itemBounds = new ArrayList<>(menu.getItemCount());
 			// create rectangles from array
 			for (int i = 0; i < menu.getItemCount(); ++i) {
 				Rectangle itemRect =
@@ -232,7 +230,7 @@ public final class ToolkitSupportImpl implements IToolkitSupport {
 	 * {@link org.eclipse.draw2d.geometry.Rectangle}.
 	 */
 	private List<Rectangle> convertRectangles(List<org.eclipse.swt.graphics.Rectangle> rectangles) {
-		List<Rectangle> result = Lists.newArrayListWithCapacity(rectangles.size());
+		List<Rectangle> result = new ArrayList<>(rectangles.size());
 		for (org.eclipse.swt.graphics.Rectangle rectangle : rectangles) {
 			result.add(new Rectangle(rectangle));
 		}

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/LayoutAssistantSupport.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/LayoutAssistantSupport.java
@@ -10,13 +10,12 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swt.model.layout;
 
-import com.google.common.collect.Lists;
-
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.swt.model.ModelMessages;
 import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * SWT provider for layout assistant pages.
@@ -63,8 +62,9 @@ org.eclipse.wb.core.editor.actions.assistant.LayoutAssistantSupport {
 	 * Converts {@link IControlInfo}s into their {@link ILayoutDataInfo}s.
 	 */
 	protected final List<ILayoutDataInfo> getDataList(List<ObjectInfo> objects) {
-		List<ILayoutDataInfo> dataList =
-				Lists.transform(objects, from -> m_layout.getLayoutData2((IControlInfo) from));
+		List<ILayoutDataInfo> dataList = objects.stream() //
+				.map(from -> m_layout.getLayoutData2((IControlInfo) from)) //
+				.collect(Collectors.toList());
 		return dataList;
 	}
 }

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/FormLayoutInfoImplClassic.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/FormLayoutInfoImplClassic.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.swt.model.layout.form;
-
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.editor.actions.assistant.ILayoutAssistantPage;
 import org.eclipse.wb.core.editor.actions.assistant.LayoutAssistantListener;
@@ -713,7 +711,7 @@ public class FormLayoutInfoImplClassic<C extends IControlInfo> extends FormLayou
 					isHorizontal
 					? FormUtils.getLayoutMarginLeft(layout)
 							: FormUtils.getLayoutMarginTop(layout);
-			List<C> controlList = Lists.newArrayList(m_components);
+			List<C> controlList = new ArrayList<>(m_components);
 			int clientSize = t.t(layout.getContainerSize()).width;
 			boolean alternative = DesignerPlugin.isCtrlPressed() && m_components.size() > 2;
 			// calculate sum size of the controls

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/FormLayoutPreferences.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/FormLayoutPreferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.swt.model.layout.form;
-
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.editor.IDesignPageSite;
 import org.eclipse.wb.core.model.ObjectInfo;
@@ -30,6 +28,7 @@ import org.eclipse.jface.util.PropertyChangeEvent;
 
 import org.apache.commons.lang.StringUtils;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -100,11 +99,11 @@ public final class FormLayoutPreferences<C extends IControlInfo> {
 	}
 
 	public List<Integer> getVerticalPercents() {
-		return Lists.newArrayList(loadPercents(KEY_V_PERCENTS));
+		return new ArrayList<>(loadPercents(KEY_V_PERCENTS));
 	}
 
 	public List<Integer> getHorizontalPercents() {
-		return Lists.newArrayList(loadPercents(KEY_H_PERCENTS));
+		return new ArrayList<>(loadPercents(KEY_H_PERCENTS));
 	}
 
 	public int getSnapSensitivity() {

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/actions/PredefinedAnchorsActions.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/actions/PredefinedAnchorsActions.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swt.model.layout.form.actions;
 
-import com.google.common.collect.Lists;
-
 import org.eclipse.wb.draw2d.IPositionConstants;
 import org.eclipse.wb.internal.core.model.util.ObjectInfoAction;
 import org.eclipse.wb.internal.swt.Activator;
@@ -22,6 +20,7 @@ import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 import org.eclipse.jface.action.IContributionManager;
 import org.eclipse.jface.action.Separator;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -49,8 +48,7 @@ public class PredefinedAnchorsActions<C extends IControlInfo> {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	public void contributeActions(C widget, IContributionManager manager) {
-		@SuppressWarnings("unchecked")
-		List<C> selection = Lists.newArrayList(widget);
+		List<C> selection = Arrays.asList(widget);
 		contributeActions(selection, manager);
 	}
 

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/widgets/menu/MenuInfo.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/widgets/menu/MenuInfo.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swt.model.widgets.menu;
 
-import com.google.common.collect.Lists;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.association.AssociationObject;
@@ -63,6 +61,7 @@ import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -263,7 +262,7 @@ public final class MenuInfo extends WidgetInfo implements IAdaptable {
 			ClassInstanceCreation creation = creationSupport.getCreation();
 			NodeTarget target = JavaInfoUtils.getNodeTarget_afterCreation(this);
 			String parentReference = parent.getVariableSupport().getReferenceExpression(target);
-			getEditor().replaceCreationArguments(creation, Lists.newArrayList(parentReference));
+			getEditor().replaceCreationArguments(creation, Arrays.asList(parentReference));
 		}
 	}
 


### PR DESCRIPTION
In almost all cases, the call of Lists.newArrayList() can be simply replaced with new ArrayList<>().

We occasionally have to use Arrays.asList() or List.of(), depending on whether we expect null values and whether the list should be modifiable.