### PR TITLE
Remove usage of Guava collections from Swing projects #270

### DIFF
--- a/org.eclipse.wb.swing.databinding/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing.databinding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swing.databinding;singleton:=true
-Bundle-Version: 1.9.400.qualifier
+Bundle-Version: 1.9.500.qualifier
 Bundle-Activator: org.eclipse.wb.internal.swing.databinding.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/decorate/BeanDecorationInfo.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/model/decorate/BeanDecorationInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.databinding.model.decorate;
-
-import com.google.common.collect.Sets;
 
 import org.eclipse.wb.internal.core.databinding.ui.decorate.IObserveDecorator;
 
@@ -47,19 +45,19 @@ public final class BeanDecorationInfo {
 	////////////////////////////////////////////////////////////////////////////
 	void setPreferredProperties(String[] properties) {
 		if (!ArrayUtils.isEmpty(properties)) {
-			m_preferred = Sets.newHashSet(properties);
+			m_preferred = Set.of(properties);
 		}
 	}
 
 	void setAdvancedProperties(String[] properties) {
 		if (!ArrayUtils.isEmpty(properties)) {
-			m_advanced = Sets.newHashSet(properties);
+			m_advanced = Set.of(properties);
 		}
 	}
 
 	void setHiddenProperties(String[] properties) {
 		if (!ArrayUtils.isEmpty(properties)) {
-			m_hidden = Sets.newHashSet(properties);
+			m_hidden = Set.of(properties);
 		}
 	}
 

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/property/BindingsProperty.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/property/BindingsProperty.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.databinding.ui.property;
 
-import com.google.common.collect.Lists;
-
 import org.eclipse.wb.internal.core.databinding.model.IBindingInfo;
 import org.eclipse.wb.internal.core.databinding.model.IObserveDecoration;
 import org.eclipse.wb.internal.core.databinding.model.IObserveInfo;
@@ -33,6 +31,7 @@ import org.eclipse.wb.internal.swing.databinding.ui.providers.BindingLabelProvid
 
 import org.eclipse.jface.action.IMenuManager;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -74,7 +73,7 @@ public class BindingsProperty extends AbstractBindingsProperty {
 		}
 		//
 		List<IObserveInfo> observes =
-				Lists.newArrayList(m_context.observeObject.getChildren(ChildrenContext.ChildrenForPropertiesTable));
+				new ArrayList<>(m_context.observeObject.getChildren(ChildrenContext.ChildrenForPropertiesTable));
 		for (Iterator<IObserveInfo> I = observes.iterator(); I.hasNext();) {
 			if (!includeProperty(I.next())) {
 				I.remove();

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/AbsoluteLayoutEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/AbsoluteLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.gef.policy.layout;
-
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.gef.command.EditCommand;
 import org.eclipse.wb.core.model.IAbstractComponentInfo;
@@ -104,7 +102,7 @@ public final class AbsoluteLayoutEditPolicy extends AbsoluteBasedLayoutEditPolic
 	@Override
 	public List<ComponentInfo> getAllComponents() {
 		List<ComponentInfo> components = m_layout.getContainer().getChildrenComponents();
-		return Lists.newArrayList(components);
+		return new ArrayList<>(components);
 	}
 
 	@Override

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/bean/AbstractActionInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/bean/AbstractActionInfo.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.model.bean;
 
-import com.google.common.collect.Iterables;
-
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.broadcast.JavaInfoAddProperties;
 import org.eclipse.wb.internal.core.model.creation.CreationSupport;
@@ -159,9 +157,8 @@ public class AbstractActionInfo extends ActionInfo {
 			return null;
 		}
 		// create property
-		return new GenericPropertyImpl(this, title, Iterables.toArray(
-				accessors,
-				ExpressionAccessor.class), Property.UNKNOWN_VALUE, converter, editor);
+		return new GenericPropertyImpl(this, title, accessors.toArray(ExpressionAccessor[]::new),
+				Property.UNKNOWN_VALUE, converter, editor);
 	}
 
 	private List<ExpressionAccessor> getAccessors(String keyName) throws Exception {

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/gbl/AbstractGridBagLayoutInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/gbl/AbstractGridBagLayoutInfo.java
@@ -12,7 +12,6 @@ package org.eclipse.wb.internal.swing.model.layout.gbl;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.editor.actions.assistant.AbstractAssistantPage;
 import org.eclipse.wb.core.gef.policy.layout.grid.IGridInfo;
@@ -58,6 +57,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import javax.swing.JLabel;
 import javax.swing.JTable;
@@ -107,8 +107,9 @@ public abstract class AbstractGridBagLayoutInfo extends LayoutInfo implements IP
 			@Override
 			protected AbstractAssistantPage createConstraintsPage(Composite parent,
 					List<ObjectInfo> objects) {
-				List<AbstractGridBagConstraintsInfo> constraints =
-						Lists.transform(objects, from -> getConstraints((ComponentInfo) from));
+				List<AbstractGridBagConstraintsInfo> constraints = objects.stream() //
+						.map(from -> getConstraints((ComponentInfo) from)) //
+						.collect(Collectors.toList());
 				return new GridBagConstraintsAssistantPage(parent, constraints);
 			}
 		};

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/parser/ParseFactory.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/parser/ParseFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *    Google, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.parser;
-
-import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.eval.ExecutionFlowDescription;
 import org.eclipse.wb.core.eval.ExecutionFlowUtils;
@@ -108,7 +106,7 @@ public class ParseFactory extends AbstractParseFactory {
 		{
 			MethodDeclaration method = ExecutionFlowUtils.getExecutionFlow_entryPoint(typeDeclaration);
 			if (method != null) {
-				List<MethodDeclaration> rootMethods = Lists.newArrayList(method);
+				List<MethodDeclaration> rootMethods = new ArrayList<>(List.of(method));
 				return new ParseRootContext(null, new ExecutionFlowDescription(rootMethods));
 			}
 		}


### PR DESCRIPTION
Minor occurrences of collections and iterables which can be easilly expressed using native Java methods.