### PR TITLE
[Draw2D] Remove redundant cursor methods in Figure

### DIFF
--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
@@ -20,7 +20,6 @@ import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Rectangle;
-import org.eclipse.swt.graphics.Cursor;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -38,7 +37,6 @@ public class Figure extends org.eclipse.draw2d.Figure {
 	private Figure m_parent;
 	private List<Figure> m_children;
 	private Border m_border;
-	private Cursor m_cursor;
 	private Object m_data;
 	private String m_toolTipText;
 	private ICustomTooltipProvider m_customTooltipProvider;
@@ -262,16 +260,6 @@ public class Figure extends org.eclipse.draw2d.Figure {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * Updates the cursor.
-	 */
-	protected void updateCursor() {
-		Figure parent = getParent();
-		if (parent != null && isVisible()) {
-			parent.updateCursor();
-		}
-	}
-
-	/**
 	 * If the argument is <code>true</code>, causes the receiver to have all mouse events delivered to
 	 * it until the method is called with <code>false</code> as the argument.
 	 */
@@ -474,25 +462,6 @@ public class Figure extends org.eclipse.draw2d.Figure {
 				revalidate();
 				repaint();
 			}
-		}
-	}
-
-	/**
-	 * @return The Cursor used when the mouse is over this Figure
-	 */
-	@Override
-	public Cursor getCursor() {
-		return m_cursor;
-	}
-
-	/**
-	 * Sets the cursor.
-	 */
-	@Override
-	public void setCursor(Cursor cursor) {
-		if (m_cursor != cursor) {
-			m_cursor = cursor;
-			updateCursor();
 		}
 	}
 

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/RootFigure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/RootFigure.java
@@ -173,14 +173,6 @@ public class RootFigure extends Figure implements IRootFigure {
 	}
 
 	/**
-	 * Updates the cursor over {@link EventManager}.
-	 */
-	@Override
-	protected void updateCursor() {
-		m_eventManager.updateCursor();
-	}
-
-	/**
 	 * Sets capture figure over {@link EventManager}.
 	 */
 	@Override

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/RootFigureTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/RootFigureTest.java
@@ -148,10 +148,6 @@ public class RootFigureTest extends Draw2dFigureTestCase {
 			@Override
 			public void repaint(int x, int y, int width, int height) {
 			}
-
-			@Override
-			protected void updateCursor() {
-			}
 		};
 		testRoot.addLayer(layer1);
 		testRoot.addLayer(layer2);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/TestCaseRootFigure.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/TestCaseRootFigure.java
@@ -13,8 +13,10 @@ package org.eclipse.wb.tests.draw2d;
 import org.eclipse.wb.internal.draw2d.RootFigure;
 import org.eclipse.wb.tests.gef.TestLogger;
 
+import org.eclipse.draw2d.EventDispatcher;
 import org.eclipse.draw2d.GraphicsSource;
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.SWTEventDispatcher;
 import org.eclipse.draw2d.UpdateManager;
 import org.eclipse.draw2d.geometry.Rectangle;
 
@@ -24,6 +26,7 @@ import org.eclipse.draw2d.geometry.Rectangle;
  */
 public class TestCaseRootFigure extends RootFigure {
 	private final UpdateManager m_testManager;
+	private final EventDispatcher m_eventDispatcher;
 	private final TestLogger m_logger;
 
 	////////////////////////////////////////////////////////////////////////////
@@ -67,6 +70,14 @@ public class TestCaseRootFigure extends RootFigure {
 				// Not relevant for testing...
 			}
 		};
+		m_eventDispatcher = new SWTEventDispatcher() {
+			@Override
+			public void updateCursor() {
+				if (m_logger != null) {
+					m_logger.log("updateCursor");
+				}
+			}
+		};
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -89,14 +100,12 @@ public class TestCaseRootFigure extends RootFigure {
 	}
 
 	@Override
-	protected void updateCursor() {
-		if (m_logger != null) {
-			m_logger.log("updateCursor");
-		}
+	public UpdateManager getUpdateManager() {
+		return m_testManager;
 	}
 
 	@Override
-	public UpdateManager getUpdateManager() {
-		return m_testManager;
+	public EventDispatcher internalGetEventDispatcher() {
+		return m_eventDispatcher;
 	}
 }


### PR DESCRIPTION
Use getCursor() and setCursor() of the root figure instead. For updateCursor(), call EventDispatcher method directly.