### PR TITLE
Support of lambda expressions for listeners #176

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,27 @@ code.
 
 ## 1.15.0 (2024-03)
 
+### Support of lambda expressions for event Listeners
+
+It is now possible to use lambda expressions to implement (event) listeners,
+in addition to anonymous classes.
+
+Example:
+addHelpListener(e -> {
+   ...
+});
+
+With limited functionality, it is also possible to use factory methods
+used by e.g. SWT.
+
+The name of the factory method is expected to be of the form
+`&lt;method&gt;Adapter(Consumer&lt;Event&gt; c)`
+
+Example:
+addMouseListener(MouseListener.mouseUpAdapter(e -> {
+   ...
+}));
+
 ### Deprecation and removal of XWT editor
 
 The technology is effectively dead and the project no longer actively maintained.

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/event/ListenerInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/event/ListenerInfo.java
@@ -17,6 +17,7 @@ import org.apache.commons.collections.map.MultiValueMap;
 import org.apache.commons.lang.StringUtils;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -252,6 +253,9 @@ final class ListenerInfo {
 	 */
 	private boolean isListenerMethod(Method method) {
 		if (method.isBridge()) {
+			return false;
+		}
+		if (Modifier.isStatic(method.getModifiers())) {
 			return false;
 		}
 		if (ReflectionUtils.isAbstract(method)) {

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/LambdaTypeDeclaration.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/LambdaTypeDeclaration.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Patrick Ziegler and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.internal.core.utils.ast;
+
+import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
+
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+
+import java.lang.reflect.Constructor;
+
+/**
+ * Wrapper class for creating instances of {@code LambdaTypeStub} without
+ * explicitly referencing the class. Doing so may cause problems because this
+ * class is contributed by our JDT fragment.
+ */
+public final class LambdaTypeDeclaration {
+	private static Class<?> m_class;
+
+	private LambdaTypeDeclaration() {
+	}
+
+	public static TypeDeclaration create(Expression expression, IMethodBinding methodBinding) {
+		try {
+			if (m_class == null) {
+				m_class = TypeDeclaration.class.getClassLoader().loadClass("org.eclipse.jdt.core.dom.LambdaTypeStub");
+			}
+			Constructor<?> constructor = m_class.getConstructor(Expression.class, IMethodBinding.class);
+			return (TypeDeclaration) constructor.newInstance(expression, methodBinding);
+		} catch (Throwable e) {
+			throw ReflectionUtils.propagate(e);
+		}
+	}
+}

--- a/org.eclipse.wb.jdt.fragment/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.jdt.fragment/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-Version: 1.9.2.qualifier
 Bundle-Localization: fragment
-Fragment-Host: org.eclipse.jdt.core;bundle-version="3.0.0"
+Fragment-Host: org.eclipse.jdt.core;bundle-version="3.37.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ClassPath: .
 Export-Package: org.eclipse.jdt.core.dom

--- a/org.eclipse.wb.jdt.fragment/src/org/eclipse/jdt/core/dom/LambdaMethodStub.java
+++ b/org.eclipse.wb.jdt.fragment/src/org/eclipse/jdt/core/dom/LambdaMethodStub.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Patrick Ziegler and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.dom;
+
+/**
+ * Wrapper method to handle listeners that are expressed via lambda
+ * expressions.<br>
+ * Example: <code>event -&gt; { ... }</code>
+ */
+public class LambdaMethodStub extends MethodDeclaration {
+	private final Expression m_lambdaExpression;
+	private final IMethodBinding m_lambdaMethod;
+	private final Block m_lambdaBody;
+
+	public LambdaMethodStub(Expression lambdaExpression, IMethodBinding lambdaMethod) {
+		super(lambdaExpression.getAST());
+		m_lambdaExpression = lambdaExpression;
+		m_lambdaMethod = lambdaMethod;
+		// stub, not relevant for listener hook
+		m_lambdaBody = new Block(lambdaExpression.getAST());
+		setSourceRange(m_lambdaExpression.getStartPosition(), m_lambdaExpression.getLength());
+		setParent(m_lambdaExpression, m_lambdaExpression.getLocationInParent());
+	}
+
+	@Override
+	void accept0(ASTVisitor visitor) {
+		m_lambdaExpression.accept0(visitor);
+	}
+
+	@Override
+	void appendDebugString(StringBuilder buffer) {
+		m_lambdaExpression.appendDebugString(buffer);
+	}
+
+	@Override
+	public IMethodBinding resolveBinding() {
+		return m_lambdaMethod;
+	}
+
+	@Override
+	public Block getBody() {
+		return m_lambdaBody;
+	}
+}

--- a/org.eclipse.wb.jdt.fragment/src/org/eclipse/jdt/core/dom/LambdaTypeStub.java
+++ b/org.eclipse.wb.jdt.fragment/src/org/eclipse/jdt/core/dom/LambdaTypeStub.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Patrick Ziegler and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.dom;
+
+import java.util.List;
+
+/**
+ * Wrapper class to handle the anonymous types that are implicitly created by
+ * lambda expressions.
+ */
+public class LambdaTypeStub extends TypeDeclaration {
+	private final Expression m_expression;
+	private final MethodDeclaration m_method;
+
+	public LambdaTypeStub(Expression expression, IMethodBinding method) {
+		this(expression, new LambdaMethodStub(expression, method));
+	}
+
+	private LambdaTypeStub(Expression expression, MethodDeclaration lambdaMethod) {
+		super(expression.getAST());
+		m_expression = expression;
+		m_method = lambdaMethod;
+		setSourceRange(expression.getStartPosition(), expression.getLength());
+		setParent(expression, expression.getLocationInParent());
+	}
+
+	////////////////////////////////////////////////////////////////////////////
+	//
+	// TypeDeclaration
+	//
+	////////////////////////////////////////////////////////////////////////////
+	@Override
+	void accept0(ASTVisitor visitor) {
+		m_expression.accept0(visitor);
+	}
+
+	@Override
+	@SuppressWarnings("rawtypes")
+	public List bodyDeclarations() {
+		return List.of(m_method);
+	}
+
+	@Override
+	void appendDebugString(StringBuilder buffer) {
+		m_expression.appendDebugString(buffer);
+	}
+
+	@Override
+	ITypeBinding internalResolveBinding() {
+		return m_expression.resolveTypeBinding();
+	}
+
+}

--- a/org.eclipse.wb.tests/pom.xml
+++ b/org.eclipse.wb.tests/pom.xml
@@ -62,6 +62,12 @@
 								<id>org.eclipse.wb.os.feature</id>
 								<versionRange>0.0.0</versionRange>
 							</requirement>
+						<!-- Required for JDT fragment to workk-->
+							<requirement>
+								<type>eclipse-plugin</type>
+								<id>org.eclipse.wb.jdt.fragment</id>
+								<versionRange>0.0.0</versionRange>
+							</requirement>
 						</extraRequirements>
 					</dependency-resolution>
 				</configuration>

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/EventsPropertyTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/EventsPropertyTest.java
@@ -3380,6 +3380,74 @@ public class EventsPropertyTest extends SwingModelTest implements IPreferenceCon
 	}
 
 	@Test
+	public void test_understandLambda() throws Exception {
+		ContainerInfo panel =
+				parseContainer(
+						"class Test extends JPanel {",
+						"  Test() {",
+						"    this.addMouseWheelListener((event) -> {});",
+						"  }",
+						"}");
+		DesignPageSite.Helper.setSite(panel, DesignPageSite.EMPTY);
+		// prepare properties
+		Property propertyChangeProperty = getEventsListenerMethod(panel, "mouseWheel", "moved");
+		assertEquals("line 7", getPropertyText(propertyChangeProperty));
+	}
+
+	@Test
+	public void test_understandLambda_noBlock() throws Exception {
+		ContainerInfo panel =
+				parseContainer(
+						"class Test extends JPanel {",
+						"  Test() {",
+						"    this.addMouseWheelListener((event) -> System.out.println(event));",
+						"  }",
+						"}");
+		DesignPageSite.Helper.setSite(panel, DesignPageSite.EMPTY);
+		// prepare properties
+		Property propertyChangeProperty = getEventsListenerMethod(panel, "mouseWheel", "moved");
+		assertEquals("line 7", getPropertyText(propertyChangeProperty));
+	}
+
+	@Test
+	public void test_understandLambda_doubleColon() throws Exception {
+		ContainerInfo panel =
+				parseContainer(
+						"class Test extends JPanel {",
+						"  Test() {",
+						"    this.addMouseWheelListener(System.out::println);",
+						"  }",
+						"}");
+		DesignPageSite.Helper.setSite(panel, DesignPageSite.EMPTY);
+		// prepare properties
+		Property propertyChangeProperty = getEventsListenerMethod(panel, "mouseWheel", "moved");
+		assertEquals("line 7", getPropertyText(propertyChangeProperty));
+	}
+
+	@Test
+	public void test_understandLambda_factory() throws Exception {
+		ContainerInfo panel =
+				parseContainer(
+						"class Test extends JPanel {",
+						"  Test() {",
+						"    this.addMouseWheelListener(mouseWheelMovedAdapter((event) -> {}));",
+						"  }",
+						"  static MouseWheelListener mouseWheelMovedAdapter(java.util.function.Consumer<MouseWheelEvent> c) {",
+						"    return new MouseAdapter() {",
+						"      @Override",
+						"      public void mouseWheelMoved(MouseWheelEvent e) {",
+						"        c.accept(e);",
+						"      }",
+						"    };",
+						"  }",
+						"}");
+		DesignPageSite.Helper.setSite(panel, DesignPageSite.EMPTY);
+		// prepare properties
+		Property propertyChangeProperty = getEventsListenerMethod(panel, "mouseWheel", "moved");
+		assertEquals("line 7", getPropertyText(propertyChangeProperty));
+	}
+
+	@Test
 	public void test_contextMenu() throws Exception {
 		ContainerInfo panel =
 				parseContainer(


### PR DESCRIPTION
WindowBuilder should now be able to recognize lambda expressions that are used to implement (event) listeners.

Example:
addHelpListener(e -> {
   ...
});

With limited functionality, it is also possible to use factory methods used by e.g. SWT.

Example:
addMouseListener(MouseListener.mouseUp(e -> {
   ...
}));