### PR TITLE
Set JLS to latest (from Java 5 to Java 21)

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/nonvisual/ArrayObjectInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/nonvisual/ArrayObjectInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -58,7 +58,7 @@ public final class ArrayObjectInfo extends AbstractArrayObjectInfo {
 	public ArrayObjectInfo(AstEditor editor, String caption, ArrayCreation creation) throws Exception {
 		this(editor, caption, ReflectionUtils.getClassByName(
 				EditorState.get(editor).getEditorLoader(),
-				creation.getType().getComponentType().resolveBinding().getQualifiedName()), creation);
+				creation.getType().getElementType().resolveBinding().getQualifiedName()), creation);
 	}
 
 	public ArrayCreation getCreation() {

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/parser/JavaInfoParser.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/parser/JavaInfoParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -832,7 +832,7 @@ public final class JavaInfoParser implements IJavaInfoParseResolver {
 								// array parameter
 								Expression parameterExpression = arguments[parameterDescription.getIndex()];
 								if (parameterJavaInfo == null && parameterExpression instanceof ArrayCreation creation) {
-									if (creation.getType().getComponentType().isSimpleType()) {
+									if (creation.getType().getElementType().isSimpleType()) {
 										// prepare ArrayObjectInfo
 										bindChild_MethodInvocationParameter_ArrayCreation(
 												invocation,

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/DomGenerics.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/DomGenerics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -34,7 +34,6 @@ import org.eclipse.jdt.core.dom.Initializer;
 import org.eclipse.jdt.core.dom.Javadoc;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
-import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.core.dom.ParameterizedType;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jdt.core.dom.Statement;
@@ -136,8 +135,8 @@ public class DomGenerics {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@SuppressWarnings("unchecked")
-	public static List<Name> thrownExceptions(MethodDeclaration methodDeclaration) {
-		return methodDeclaration.thrownExceptions();
+	public static List<Type> thrownExceptionTypes(MethodDeclaration methodDeclaration) {
+		return methodDeclaration.thrownExceptionTypes();
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/core/CodeUtils.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/core/CodeUtils.java
@@ -101,7 +101,7 @@ public class CodeUtils {
 			IJavaProject javaProject,
 			String unitName) {
 		org.eclipse.jdt.core.dom.ASTParser parser =
-				org.eclipse.jdt.core.dom.ASTParser.newParser(AST.JLS3);
+				org.eclipse.jdt.core.dom.ASTParser.newParser(AST.getJLSLatest());
 		parser.setSource(source.toCharArray());
 		parser.setProject(javaProject);
 		parser.setCompilerOptions(ProjectUtils.getOptions(javaProject));

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/AbstractJavaTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/AbstractJavaTest.java
@@ -25,6 +25,7 @@ import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
 import org.eclipse.jdt.core.dom.Block;
 import org.eclipse.jdt.core.dom.BodyDeclaration;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.Dimension;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.ExpressionStatement;
 import org.eclipse.jdt.core.dom.FieldDeclaration;
@@ -324,7 +325,9 @@ public abstract class AbstractJavaTest extends AbstractJavaProjectTest {
 				// check positions for parent/child
 				{
 					ASTNode parent = node.getParent();
-					if (parent != null) {
+					// TODO The source and length is lost for dimensions when cloned.
+					// See: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1786
+					if (parent != null && !(node instanceof Dimension)) {
 						int begin = AstNodeUtils.getSourceBegin(node);
 						int end = AstNodeUtils.getSourceEnd(node);
 						int parent_begin = AstNodeUtils.getSourceBegin(parent);


### PR DESCRIPTION
This allows WindowBuilder to process new language features such as lambdas.