### PR TITLE
[Draw2D] Harmonize setBounds method with downstream Figure

### DIFF
--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
@@ -14,9 +14,7 @@ import org.eclipse.wb.internal.draw2d.FigureCanvas;
 import org.eclipse.wb.internal.draw2d.FigureVisitor;
 import org.eclipse.wb.internal.draw2d.ICustomTooltipProvider;
 
-import org.eclipse.draw2d.FigureListener;
 import org.eclipse.draw2d.Graphics;
-import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Rectangle;
 
@@ -50,18 +48,6 @@ public class Figure extends org.eclipse.draw2d.Figure {
 	@Override
 	public <T extends Object> Iterator<T> getListeners(Class<T> listenerClass) {
 		return super.getListeners(listenerClass);
-	}
-
-	/**
-	 * Notifies any {@link IFigureListener IFigureListeners} listening to this {@link Figure} that it
-	 * has moved.
-	 */
-	@Override
-	protected void fireMoved() {
-		Iterator<FigureListener> listeners = getListeners(FigureListener.class);
-		if (listeners != null) {
-			listeners.forEachRemaining(figureListener -> figureListener.figureMoved(this));
-		}
 	}
 
 	/**
@@ -351,31 +337,6 @@ public class Figure extends org.eclipse.draw2d.Figure {
 	 */
 	@Override
 	protected void paintClientArea(Graphics graphics) {
-	}
-
-	////////////////////////////////////////////////////////////////////////////
-	//
-	// Bounds
-	//
-	////////////////////////////////////////////////////////////////////////////
-
-
-	/**
-	 * Sets the bounds of this Figure to the Rectangle <i>rect</i>.
-	 */
-	@Override
-	public void setBounds(Rectangle bounds) {
-		if (!this.bounds.equals(bounds)) {
-			// calc repaint rectangle
-			Rectangle dirtyArea = this.bounds.getUnion(bounds);
-			// change bounds
-			this.bounds.setBounds(bounds);
-			// send move event
-			fireMoved();
-			// reset state
-			revalidate();
-			repaint(dirtyArea);
-		}
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
@@ -343,6 +343,7 @@ public final class PaletteComposite extends Composite {
 				CategoryFigure categoryFigure = (CategoryFigure) I.next();
 				y += categoryFigure.layout(y, width);
 			}
+			revalidate();
 		}
 	}
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigurePaintingTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigurePaintingTest.java
@@ -105,16 +105,16 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		//
 		// check reset state during add(Figure, Rectangle) child figure with not empty bounds
 		testFigure.add(new Figure(), new Rectangle(1, 2, 3, 4));
-		expectedLogger.log("invalidate");
-		expectedLogger.log("repaint(0, 0, 4, 6)");
+		expectedLogger.log("repaint(10, 11, 0, 0)"); // erase
+		expectedLogger.log("repaint(1, 2, 3, 4)");
 		expectedLogger.log("invalidate");
 		expectedLogger.log("repaint(11, 13, 3, 4)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check reset state during add(Figure, Rectangle, int) child figure with not empty bounds
 		testFigure.add(new Figure(), new Rectangle(1, 2, 3, 4), -1);
-		expectedLogger.log("invalidate");
-		expectedLogger.log("repaint(0, 0, 4, 6)");
+		expectedLogger.log("repaint(10, 11, 0, 0)"); // erase
+		expectedLogger.log("repaint(1, 2, 3, 4)");
 		expectedLogger.log("invalidate");
 		expectedLogger.log("repaint(11, 13, 3, 4)");
 		m_actualLogger.assertEquals(expectedLogger);
@@ -154,8 +154,8 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		//
 		// check reset state during setBounds()
 		testFigure.setBounds(new Rectangle(1, 2, 3, 4));
-		expectedLogger.log("invalidate");
-		expectedLogger.log("repaint(0, 0, 4, 6)");
+		expectedLogger.log("repaint(0, 0, 0, 0)"); // erase
+		expectedLogger.log("repaint(1, 2, 3, 4)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check no reset state during setBounds() if bounds not change
@@ -168,13 +168,13 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		//
 		// check reset state during setSize(int, int)
 		testFigure.setSize(1, 5);
-		expectedLogger.log("invalidate");
-		expectedLogger.log("repaint(1, 2, 3, 5)");
+		expectedLogger.log("repaint(1, 2, 3, 4)"); // erase
+		expectedLogger.log("repaint(1, 2, 1, 5)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check reset state during setSize(Dimension)
 		testFigure.setSize(new Dimension(11, 12));
-		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(1, 2, 1, 5)"); // erase
 		expectedLogger.log("repaint(1, 2, 11, 12)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
@@ -188,14 +188,14 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		//
 		// check reset state during setLocation(int, int)
 		testFigure.setLocation(new Point(3, 7));
-		expectedLogger.log("invalidate");
-		expectedLogger.log("repaint(1, 2, 13, 17)");
+		expectedLogger.log("repaint(1, 2, 11, 12)"); // erase
+		expectedLogger.log("repaint(3, 7, 11, 12)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check reset state during setLocation(Point)
 		testFigure.setLocation(new Point());
-		expectedLogger.log("invalidate");
-		expectedLogger.log("repaint(0, 0, 14, 19)");
+		expectedLogger.log("repaint(3, 7, 11, 12)"); // erase
+		expectedLogger.log("repaint(0, 0, 11, 12)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check no reset state during setLocation(Point) if bounds not change


### PR DESCRIPTION
Note that we now need to specifically call revalidate() for the PaletteComposite, as e.g. expanding or collapsing a category may also change the height of the whole palette.
Failing to do so would move entries outside of the scrollable area.