### PR TITLE
[Draw2D] Remove data field in Figure with GEF VisualPartMap

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/core/gef/policy/TabOrderContainerEditPolicy.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/core/gef/policy/TabOrderContainerEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -99,7 +99,7 @@ public final class TabOrderContainerEditPolicy extends GraphicalEditPolicy {
 			m_indexFeedbacks.add(feedback);
 			// register feedback with edit part, so we can click on number feedback as
 			// well as on EditPart's main figure
-			feedback.setData(part);
+			viewer.getVisualPartMap().put(feedback.getLabel(), part);
 			// set background
 			feedback.setBackground(ColorConstants.yellow);
 			if (child == selectedChild) {

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,7 +33,6 @@ import java.util.List;
 public class Figure extends org.eclipse.draw2d.Figure {
 	private Figure m_parent;
 	private List<Figure> m_children;
-	private Object m_data;
 	private String m_toolTipText;
 	private ICustomTooltipProvider m_customTooltipProvider;
 
@@ -344,19 +343,6 @@ public class Figure extends org.eclipse.draw2d.Figure {
 	// Properties
 	//
 	////////////////////////////////////////////////////////////////////////////
-	/**
-	 * Get user define data.
-	 */
-	public Object getData() {
-		return m_data;
-	}
-
-	/**
-	 * Set user define data.
-	 */
-	public void setData(Object data) {
-		m_data = data;
-	}
 
 	/**
 	 * Returns the receiver's tool tip text, or <code>null</code> if it has not been set.

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/GraphicalEditPart.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/GraphicalEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.tools.DragEditPartTracker;
 import org.eclipse.wb.gef.core.tools.Tool;
 
+import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.Request;
 
 /**
@@ -67,7 +68,9 @@ public abstract class GraphicalEditPart extends EditPart {
 		if (!graphicalChildPart.addSelfVisual(index)) {
 			getContentPane().add(graphicalChildPart.getFigure(), index);
 		}
-		graphicalChildPart.getFigure().setData(childPart);
+		EditPartViewer graphicalChildViewer = graphicalChildPart.getViewer();
+		Figure graphicalChildFigure = graphicalChildPart.getFigure();
+		graphicalChildViewer.getVisualPartMap().put(graphicalChildFigure, childPart);
 	}
 
 	/**
@@ -88,7 +91,9 @@ public abstract class GraphicalEditPart extends EditPart {
 		if (!graphicalChildPart.removeSelfVisual()) {
 			getContentPane().remove(graphicalChildPart.getFigure());
 		}
-		graphicalChildPart.getFigure().setData(null);
+		EditPartViewer graphicalChildViewer = graphicalChildPart.getViewer();
+		Figure graphicalChildFigure = graphicalChildPart.getFigure();
+		graphicalChildViewer.getVisualPartMap().remove(graphicalChildFigure);
 	}
 
 	/**

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/core/TargetEditPartFindVisitor.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/core/TargetEditPartFindVisitor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,8 @@ import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.internal.draw2d.FigureCanvas;
 import org.eclipse.wb.internal.draw2d.TargetFigureFindVisitor;
 
+import org.eclipse.gef.EditPartViewer;
+
 /**
  * This class use to find {@link EditPart} under mouse.
  *
@@ -22,13 +24,16 @@ import org.eclipse.wb.internal.draw2d.TargetFigureFindVisitor;
  * @coverage gef.core
  */
 public class TargetEditPartFindVisitor extends TargetFigureFindVisitor {
+	private final EditPartViewer m_viewer;
+
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Constructor
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public TargetEditPartFindVisitor(FigureCanvas canvas, int x, int y) {
+	public TargetEditPartFindVisitor(FigureCanvas canvas, int x, int y, EditPartViewer viewer) {
 		super(canvas, x, y);
+		m_viewer = viewer;
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -51,10 +56,10 @@ public class TargetEditPartFindVisitor extends TargetFigureFindVisitor {
 	/**
 	 * Extract {@link EditPart} from given {@link Figure}.
 	 */
-	protected static EditPart extractEditPart(Figure figure) {
+	protected EditPart extractEditPart(Figure figure) {
 		EditPart editPart = null;
 		while (editPart == null && figure != null) {
-			editPart = (EditPart) figure.getData();
+			editPart = (EditPart) m_viewer.getVisualPartMap().get(figure);
 			figure = figure.getParent();
 		}
 		return editPart;

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/graphical/GraphicalViewer.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/graphical/GraphicalViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -179,7 +179,7 @@ public class GraphicalViewer extends AbstractEditPartViewer {
 			final Collection<EditPart> exclude,
 			final IConditional conditional,
 			String layer) {
-		TargetEditPartFindVisitor visitor = new TargetEditPartFindVisitor(m_canvas, x, y) {
+		TargetEditPartFindVisitor visitor = new TargetEditPartFindVisitor(m_canvas, x, y, this) {
 			@Override
 			protected boolean acceptVisit(Figure figure) {
 				for (EditPart editPart : exclude) {

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/figure/TextFeedback.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/figure/TextFeedback.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -112,11 +112,8 @@ public final class TextFeedback {
 		m_label.setLocation(location);
 	}
 
-	/**
-	 * Set user defined data.
-	 */
-	public void setData(Object data) {
-		m_label.setData(data);
+	public Label getLabel() {
+		return m_label;
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/SubmenuAwareEditPart.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/SubmenuAwareEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,13 +13,15 @@ package org.eclipse.wb.internal.core.gef.part.menu;
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
-import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.core.gef.policy.menu.MenuSelectionEditPolicy;
 import org.eclipse.wb.internal.core.gef.policy.menu.SubmenuAwareLayoutEditPolicy;
 import org.eclipse.wb.internal.core.model.menu.IMenuInfo;
 import org.eclipse.wb.internal.core.model.menu.IMenuObjectInfo;
 import org.eclipse.wb.internal.core.model.menu.MenuObjectInfoUtils;
+
+import org.eclipse.gef.EditPartViewer;
+import org.eclipse.gef.EditPolicy;
 
 import java.util.Collections;
 import java.util.List;
@@ -61,8 +63,10 @@ public abstract class SubmenuAwareEditPart extends MenuObjectEditPart {
 		// The workaround is to override this method and forcibly
 		// add figure with default index.
 		GraphicalEditPart graphicalPart = (GraphicalEditPart) childPart;
-		getContentPane().add(graphicalPart.getFigure());
-		graphicalPart.getFigure().setData(childPart);
+		EditPartViewer graphicalViewer = graphicalPart.getViewer();
+		Figure graphicalFigure = graphicalPart.getFigure();
+		getContentPane().add(graphicalFigure);
+		graphicalViewer.getVisualPartMap().put(graphicalFigure, childPart);
 	}
 
 	/////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigureTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigureTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -615,7 +615,6 @@ public class FigureTest extends Draw2dFigureTestCase {
 		assertFalse(testFigure.isOpaque());
 		assertTrue(testFigure.isVisible());
 		assertNull(testFigure.getToolTipText());
-		assertNull(testFigure.getData());
 	}
 
 	@Test
@@ -766,30 +765,6 @@ public class FigureTest extends Draw2dFigureTestCase {
 		// check set 'null' tooltip
 		testFigure.setToolTipText(null);
 		assertNull(testFigure.getToolTipText());
-	}
-
-	@Test
-	public void test_data() throws Exception {
-		Figure testFigure = new Figure();
-		//
-		// check user data for new Figure
-		assertNull(testFigure.getData());
-		//
-		// check set user data
-		testFigure.setData("zzz");
-		assertEquals("zzz", testFigure.getData());
-		//
-		// check set other user data
-		testFigure.setData(3);
-		assertEquals(3, testFigure.getData());
-		//
-		// check set user data itself
-		testFigure.setData(testFigure);
-		assertSame(testFigure, testFigure.getData());
-		//
-		// check set 'null' user data
-		testFigure.setData(null);
-		assertNull(testFigure.getData());
 	}
 
 	////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
We use the data field to keep track of the EditPart corresponding to a given Figure. The same functionality is provided by the VisualPartMap of the EditPartViewer interface.