### PR TITLE
Switch to JAXB-OSGi from JAXB-Core + JAXB-Impl

### DIFF
--- a/org.eclipse.wb.dependencies.feature_feature/feature.xml
+++ b/org.eclipse.wb.dependencies.feature_feature/feature.xml
@@ -168,11 +168,7 @@
          version="0.0.0"/>
 
    <plugin
-         id="com.sun.xml.bind.jaxb-core"
-         version="0.0.0"/>
-
-   <plugin
-         id="com.sun.xml.bind.jaxb-impl"
+         id="com.sun.xml.bind.jaxb-osgi"
          version="0.0.0"/>
 
 </feature>

--- a/target-platform/mvn/wb-mvn.target
+++ b/target-platform/mvn/wb-mvn.target
@@ -6,13 +6,7 @@
 			<dependencies>
 				<dependency>
 					<groupId>com.sun.xml.bind</groupId>
-					<artifactId>jaxb-core</artifactId>
-					<version>4.0.4</version>
-					<type>jar</type>
-				</dependency>
-				<dependency>
-					<groupId>com.sun.xml.bind</groupId>
-					<artifactId>jaxb-impl</artifactId>
+					<artifactId>jaxb-osgi</artifactId>
 					<version>4.0.4</version>
 					<type>jar</type>
 				</dependency>


### PR DESCRIPTION
Other SimRel projects currently use JAXB 2.3.9. In order to avoid having duplicate 3rd party libraries in the future, we should use the same artifact (albeit in a newer version).