### PR TITLE
Initial batch for migration from Digester3 to JAXB

### DIFF
--- a/org.eclipse.wb.core.databinding.xsd/schema/wbp-component.xsd
+++ b/org.eclipse.wb.core.databinding.xsd/schema/wbp-component.xsd
@@ -203,7 +203,7 @@
 				</xs:complexType>
 			</xs:element>
 			<!-- description -->
-			<xs:element name="description" minOccurs="0"/>
+			<xs:element name="description" minOccurs="0" type="xs:string"/>
 			<!-- XML -->
 			<!-- attribute -->
 			<xs:element name="x-attribute" type="XAttributeType" minOccurs="0" maxOccurs="unbounded"/>

--- a/org.eclipse.wb.core.databinding.xsd/schema/wbp-component.xsd
+++ b/org.eclipse.wb.core.databinding.xsd/schema/wbp-component.xsd
@@ -46,7 +46,7 @@
 					</xs:complexType>
 				</xs:element>
 				<!-- order -->
-				<xs:element name="order" minOccurs="0"/>
+				<xs:element name="order" minOccurs="0" type="xs:string" />
 				<!-- description -->
 				<xs:element name="description" minOccurs="0"/>
 				<!-- creation -->

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/ComponentDescriptionHelper.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/ComponentDescriptionHelper.java
@@ -596,6 +596,10 @@ public final class ComponentDescriptionHelper {
 			throws Exception {
 		acceptSafe(componentDescription, component.getToolkit(), new ToolkitRule());
 		acceptSafe(componentDescription, component.getModel(), new ModelClassRule());
+		// component order
+		{
+			acceptSafe(componentDescription, component.getOrder(), ComponentDescription::setOrder);
+		}
 	}
 
 	/**
@@ -604,12 +608,6 @@ public final class ComponentDescriptionHelper {
 	private static void addRules(Digester digester, AstEditor editor, Class<?> componentClass) {
 		EditorState state = EditorState.get(editor);
 		ILoadingContext context = EditorStateLoadingContext.get(state);
-		// component order
-		{
-			String pattern = "component/order";
-			digester.addCallMethod(pattern, "setOrder", 1);
-			digester.addCallParam(pattern, 0);
-		}
 		// standard bean properties
 		{
 			digester.addRule("component/standard-bean-properties", new StandardBeanPropertiesRule());

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/ComponentDescriptionHelper.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/ComponentDescriptionHelper.java
@@ -13,6 +13,7 @@ package org.eclipse.wb.internal.core.model.description.helpers;
 import org.eclipse.wb.core.databinding.xsd.component.Component;
 import org.eclipse.wb.core.databinding.xsd.component.ContextFactory;
 import org.eclipse.wb.core.databinding.xsd.component.Creation;
+import org.eclipse.wb.core.databinding.xsd.component.MorphingType;
 import org.eclipse.wb.core.databinding.xsd.component.TagType;
 import org.eclipse.wb.core.databinding.xsd.component.TypeParameterType;
 import org.eclipse.wb.core.databinding.xsd.component.TypeParametersType;
@@ -632,6 +633,17 @@ public final class ComponentDescriptionHelper {
 				componentDescription.setCreationDefault(creationDescription);
 			}
 		}
+		// morphing targets
+		{
+			MorphingType morphingTargets = component.getMorphTargets();
+			if (morphingTargets != null) {
+				MorphingType morphingType = component.getMorphTargets();
+				acceptSafe(componentDescription, morphingType.getNoInherit(), new MorphingNoInheritRule());
+				for (MorphingType.MorphTarget morphTarget : morphingType.getMorphTarget()) {
+					acceptSafe(componentDescription, morphTarget, new MorphingTargetRule(state));
+				}
+			}
+		}
 	}
 
 	/**
@@ -658,15 +670,6 @@ public final class ComponentDescriptionHelper {
 		// public field properties
 		{
 			digester.addRule("component/public-field-properties", new PublicFieldPropertiesRule());
-		}
-		// morphing targets
-		{
-			String pattern = "component/morphTargets/morphTarget";
-			digester.addRule(pattern, new MorphingTargetRule(state));
-		}
-		{
-			String pattern = "component/morphTargets/noInherit";
-			digester.addRule(pattern, new MorphingNoInheritRule());
 		}
 		// description text
 		{

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/CreationTagRule.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/CreationTagRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,28 +10,27 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description.rules;
 
+import org.eclipse.wb.core.databinding.xsd.component.TagType;
 import org.eclipse.wb.internal.core.model.description.CreationDescription;
-
-import org.apache.commons.digester3.Rule;
-import org.xml.sax.Attributes;
+import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper.FailableBiConsumer;
 
 /**
- * The {@link Rule} that adds some tag for {@link CreationDescription}.
+ * The {@link FailableBiConsumer} that adds some tag for
+ * {@link CreationDescription}.
  *
  * @author sablin_aa
  * @coverage core.model.description
  */
-public final class CreationTagRule extends AbstractDesignerRule {
+public final class CreationTagRule implements FailableBiConsumer<CreationDescription, TagType, Exception> {
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Rule
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public void begin(String namespace, String name, Attributes attributes) throws Exception {
-		String tag = getRequiredAttribute(name, attributes, "name");
-		String value = getRequiredAttribute(name, attributes, "value");
-		CreationDescription creationDescription = (CreationDescription) getDigester().peek();
+	public void accept(CreationDescription creationDescription, TagType tagType) throws Exception {
+		String tag = tagType.getName();
+		String value = tagType.getValue();
 		creationDescription.putTag(tag, value);
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/CreationTypeParametersRule.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/CreationTypeParametersRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,29 +10,29 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description.rules;
 
+import org.eclipse.wb.core.databinding.xsd.component.TypeParameterType;
 import org.eclipse.wb.internal.core.model.description.CreationDescription;
-
-import org.apache.commons.digester3.Rule;
-import org.xml.sax.Attributes;
+import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper.FailableBiConsumer;
 
 /**
- * The {@link Rule} that adds type parameter (generic) descriptions for {@link CreationDescription}.
+ * The {@link FailableBiConsumer} that adds type parameter (generic)
+ * descriptions for {@link CreationDescription}.
  *
  * @author sablin_aa
  * @coverage core.model.description
  */
-public final class CreationTypeParametersRule extends AbstractDesignerRule {
+public final class CreationTypeParametersRule
+		implements FailableBiConsumer<CreationDescription, TypeParameterType, Exception> {
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Rule
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public void begin(String namespace, String elementName, Attributes attributes) throws Exception {
-		String name = getRequiredAttribute(elementName, attributes, "name");
-		String type = getRequiredAttribute(elementName, attributes, "type");
-		String description = getRequiredAttribute(elementName, attributes, "title");
-		CreationDescription creationDescription = (CreationDescription) getDigester().peek();
+	public void accept(CreationDescription creationDescription, TypeParameterType parameterType) throws Exception {
+		String name = parameterType.getName();
+		String type = parameterType.getType();
+		String description = parameterType.getTitle();
 		creationDescription.setTypeParameter(name, type, description);
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/ModelClassRule.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/ModelClassRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,31 +10,30 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description.rules;
 
+import org.eclipse.wb.core.databinding.xsd.component.Component.Model;
 import org.eclipse.wb.internal.core.model.description.ComponentDescription;
+import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper.FailableBiConsumer;
 import org.eclipse.wb.internal.core.model.description.helpers.DescriptionHelper;
 
-import org.apache.commons.digester3.Rule;
-import org.xml.sax.Attributes;
-
 /**
- * The {@link Rule} that sets model class for {@link ComponentDescription}.
+ * The {@link FailableBiConsumer} that sets model class for
+ * {@link ComponentDescription}.
  *
  * @author scheglov_ke
  * @coverage core.model.description
  */
-public final class ModelClassRule extends Rule {
+public final class ModelClassRule implements FailableBiConsumer<ComponentDescription, Model, Exception> {
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Rule
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public void begin(String namespace, String name, Attributes attributes) throws Exception {
+	public void accept(ComponentDescription componentDescription, Model model) throws Exception {
 		// prepare model Class
-		String className = attributes.getValue("class");
+		String className = model.getClazz();
 		Class<?> modelClass = DescriptionHelper.loadModelClass(className);
 		// set model Class
-		ComponentDescription componentDescription = (ComponentDescription) getDigester().peek();
 		componentDescription.setModelClass(modelClass);
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/MorphingNoInheritRule.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/MorphingNoInheritRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,27 +12,24 @@ package org.eclipse.wb.internal.core.model.description.rules;
 
 import org.eclipse.wb.internal.core.model.description.ComponentDescription;
 import org.eclipse.wb.internal.core.model.description.MorphingTargetDescription;
-
-import org.apache.commons.digester3.Rule;
-import org.xml.sax.Attributes;
+import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper.FailableBiConsumer;
 
 /**
- * The {@link Rule} that remove all existed (inherited) {@link MorphingTargetDescription}'s from
- * {@link ComponentDescription}.
+ * The {@link FailableBiConsumer} that remove all existed (inherited)
+ * {@link MorphingTargetDescription}'s from {@link ComponentDescription}.
  *
  * @author sablin_aa
  * @coverage core.model.description
  */
-public final class MorphingNoInheritRule extends Rule {
+public final class MorphingNoInheritRule implements FailableBiConsumer<ComponentDescription, Object, Exception> {
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Rule
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public void begin(String namespace, String name, Attributes attributes) throws Exception {
+	public void accept(ComponentDescription componentDescription, Object object) throws Exception {
 		// clear morphing targets
-		ComponentDescription componentDescription = (ComponentDescription) getDigester().peek();
 		componentDescription.clearMorphingTargets();
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/MorphingTargetRule.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/MorphingTargetRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,21 +10,21 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description.rules;
 
+import org.eclipse.wb.core.databinding.xsd.component.MorphingType.MorphTarget;
 import org.eclipse.wb.internal.core.model.description.ComponentDescription;
 import org.eclipse.wb.internal.core.model.description.MorphingTargetDescription;
+import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper.FailableBiConsumer;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.state.EditorState;
 
-import org.apache.commons.digester3.Rule;
-import org.xml.sax.Attributes;
-
 /**
- * The {@link Rule} that adds {@link MorphingTargetDescription} to {@link ComponentDescription}.
+ * The {@link FailableBiConsumer} that adds {@link MorphingTargetDescription} to
+ * {@link ComponentDescription}.
  *
  * @author scheglov_ke
  * @coverage core.model.description
  */
-public final class MorphingTargetRule extends Rule {
+public final class MorphingTargetRule implements FailableBiConsumer<ComponentDescription, MorphTarget, Exception> {
 	private final EditorState m_state;
 	private final ClassLoader m_classLoader;
 
@@ -44,24 +44,24 @@ public final class MorphingTargetRule extends Rule {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public void begin(String namespace, String name, Attributes attributes) throws Exception {
+	public void accept(ComponentDescription componentDescription, MorphTarget morphTarget) throws Exception {
 		try {
-			addTarget(attributes);
+			addTarget(componentDescription, morphTarget);
 		} catch (ClassNotFoundException e) {
 		}
 	}
 
-	private void addTarget(Attributes attributes) throws ClassNotFoundException {
-		String creationId = attributes.getValue("creationId");
+	private void addTarget(ComponentDescription componentDescription, MorphTarget morphTarget)
+			throws ClassNotFoundException {
+		String creationId = morphTarget.getCreationId();
 		// prepare class
 		Class<?> clazz;
 		{
-			String className = attributes.getValue("class");
+			String className = morphTarget.getClazz();
 			Assert.isNotNull(className);
 			clazz = m_classLoader.loadClass(className);
 		}
 		// add morphing target
-		ComponentDescription componentDescription = (ComponentDescription) getDigester().peek();
 		componentDescription.addMorphingTarget(new MorphingTargetDescription(clazz, creationId));
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/ToolkitRule.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/ToolkitRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,29 +10,29 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description.rules;
 
+import org.eclipse.wb.core.databinding.xsd.component.Component.Toolkit;
 import org.eclipse.wb.internal.core.model.description.ComponentDescription;
 import org.eclipse.wb.internal.core.model.description.ToolkitDescription;
+import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper.FailableBiConsumer;
 import org.eclipse.wb.internal.core.model.description.helpers.DescriptionHelper;
 
-import org.apache.commons.digester3.Rule;
-import org.xml.sax.Attributes;
-
 /**
- * The {@link Rule} that sets {@link ToolkitDescription} for {@link ComponentDescription}.
+ * The {@link FailableBiConsumer} that sets {@link ToolkitDescription} for
+ * {@link ComponentDescription}.
  *
  * @author scheglov_ke
  * @coverage core.model.description
  */
-public final class ToolkitRule extends AbstractDesignerRule {
+public final class ToolkitRule implements FailableBiConsumer<ComponentDescription, Toolkit, Exception> {
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Rule
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public void begin(String namespace, String name, Attributes attributes) throws Exception {
-		ComponentDescription componentDescription = (ComponentDescription) getDigester().peek();
-		String toolkitId = getRequiredAttribute(name, attributes, "id");
-		componentDescription.setToolkit(DescriptionHelper.getToolkit(toolkitId));
+	public void accept(ComponentDescription componentDescription, Toolkit toolkit) throws Exception {
+		String toolkitId = toolkit.getId();
+		ToolkitDescription toolkitDescription = DescriptionHelper.getToolkit(toolkitId);
+		componentDescription.setToolkit(toolkitDescription);
 	}
 }


### PR DESCRIPTION
Due to the complexity and required amount of change, each component is going to be migrated by a separate commit (as much as possible).

This is the first set of changes, consisting of the component toolkit, model, order creations and morphing targets.

#638 