### PR TITLE
Second batch for migration from Digester3 to JAXB

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -32,6 +32,13 @@ The technology is effectively dead and the project no longer actively maintained
 In prevent compilation errors inside the workspace, those components have been
 removed from the project.
 
+### Changes to wbp-component.xml schema
+
+All special characters in the description need to be properly encoded.
+
+Example:
+&lt;b&gt;...&lt;/b&gt;
+
 ## 1.14.0 (2023-12)
 
 ### Deprecation of SWTResourceManager

--- a/org.eclipse.wb.core.databinding.xsd/schema/wbp-component.xsd
+++ b/org.eclipse.wb.core.databinding.xsd/schema/wbp-component.xsd
@@ -48,7 +48,7 @@
 				<!-- order -->
 				<xs:element name="order" minOccurs="0" type="xs:string" />
 				<!-- description -->
-				<xs:element name="description" minOccurs="0"/>
+				<xs:element name="description" minOccurs="0" type="xs:string"/>
 				<!-- creation -->
 				<xs:element name="creation-default" type="Creation" minOccurs="0"/>
 				<xs:element name="creation" type="Creation" minOccurs="0" maxOccurs="unbounded"/>

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/ComponentDescriptionHelper.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/ComponentDescriptionHelper.java
@@ -13,6 +13,8 @@ package org.eclipse.wb.internal.core.model.description.helpers;
 import org.eclipse.wb.core.databinding.xsd.component.Component;
 import org.eclipse.wb.core.databinding.xsd.component.ContextFactory;
 import org.eclipse.wb.core.databinding.xsd.component.Creation;
+import org.eclipse.wb.core.databinding.xsd.component.ExposingRuleType;
+import org.eclipse.wb.core.databinding.xsd.component.ExposingRulesType;
 import org.eclipse.wb.core.databinding.xsd.component.MorphingType;
 import org.eclipse.wb.core.databinding.xsd.component.TagType;
 import org.eclipse.wb.core.databinding.xsd.component.TypeParameterType;
@@ -110,6 +112,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.Unmarshaller;
 
 /**
@@ -629,6 +632,15 @@ public final class ComponentDescriptionHelper {
 		{
 			acceptSafe(componentDescription, component.getDescription(), ComponentDescription::setDescription);
 		}
+		// exposed children
+		{
+			if (component.getExposingRules() != null) {
+				ExposingRulesType exposingRules = component.getExposingRules();
+				for (JAXBElement<ExposingRuleType> exposingRule : exposingRules.getExcludeOrInclude()) {
+					acceptSafe(componentDescription, exposingRule, new ExposingRulesRule());
+				}
+			}
+		}
 	}
 
 	/**
@@ -679,12 +691,6 @@ public final class ComponentDescriptionHelper {
 			digester.addRule(pattern + "/method", new MethodOrderMethodRule());
 			digester.addRule(pattern + "/methods", new MethodOrderMethodsRule());
 			digester.addRule(pattern + "/methods/s", new MethodOrderMethodsSignatureRule());
-		}
-		// exposed children
-		{
-			String pattern = "component/exposing-rules";
-			digester.addRule(pattern + "/include", new ExposingRulesRule());
-			digester.addRule(pattern + "/exclude", new ExposingRulesRule());
 		}
 		// methods-exclude, methods-include
 		{

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/ComponentDescriptionHelper.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/ComponentDescriptionHelper.java
@@ -666,6 +666,15 @@ public final class ComponentDescriptionHelper {
 				}
 			}
 		}
+		// untyped parameters
+		{
+			Component.Parameters parameters = component.getParameters();
+			if (parameters != null) {
+				for (Component.Parameters.Parameter parameter : parameters.getParameter()) {
+					componentDescription.addParameter(parameter.getName(), parameter.getValue());
+				}
+			}
+		}
 	}
 
 	/**
@@ -708,13 +717,6 @@ public final class ComponentDescriptionHelper {
 					new SetListedPropertiesRule(new String[] { "order" }, new String[] { "orderSpecification" }));
 			digester.addRule(pattern + "/tag", new MethodTagRule());
 			addParametersRules(digester, pattern + "/parameter", state);
-		}
-		// untyped parameters
-		{
-			String pattern = "component/parameters/parameter";
-			digester.addCallMethod(pattern, "addParameter", 2);
-			digester.addCallParam(pattern, 0, "name");
-			digester.addCallParam(pattern, 1);
 		}
 		addPropertiesRules(digester, state);
 		addConfigurablePropertiesRules(digester, state);

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/ExposingRulesRule.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/ExposingRulesRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,33 +10,36 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description.rules;
 
+import org.eclipse.wb.core.databinding.xsd.component.ExposingRuleType;
 import org.eclipse.wb.internal.core.model.description.ComponentDescription;
 import org.eclipse.wb.internal.core.model.description.ExposingMethodRule;
 import org.eclipse.wb.internal.core.model.description.ExposingPackageRule;
 import org.eclipse.wb.internal.core.model.description.ExposingRule;
+import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper.FailableBiConsumer;
 
-import org.apache.commons.digester3.Rule;
-import org.xml.sax.Attributes;
+import jakarta.xml.bind.JAXBElement;
 
 /**
- * The {@link Rule} that adds include/exclude rules for exposed children.
+ * The {@link FailableBiConsumer} that adds include/exclude rules for exposed
+ * children.
  *
  * @author scheglov_ke
  * @coverage core.model.description
  */
-public final class ExposingRulesRule extends AbstractDesignerRule {
+public final class ExposingRulesRule
+		implements FailableBiConsumer<ComponentDescription, JAXBElement<ExposingRuleType>, Exception> {
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Rule
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public void begin(String namespace, String name, Attributes attributes) throws Exception {
-		ComponentDescription componentDescription = (ComponentDescription) getDigester().peek();
+	public void accept(ComponentDescription componentDescription, JAXBElement<ExposingRuleType> jaxb) throws Exception {
 		// prepare attributes
-		boolean include = "include".equals(name);
-		String packageName = attributes.getValue("package");
-		String methodName = attributes.getValue("method");
+		ExposingRuleType exposingRule = jaxb.getValue();
+		boolean include = "include".equals(jaxb.getName().getLocalPart());
+		String packageName = exposingRule.getPackage();
+		String methodName = exposingRule.getMethod();
 		// add expose rules
 		if (packageName != null) {
 			ExposingRule rule = new ExposingPackageRule(include, packageName);

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/MethodOrderDefaultRule.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/MethodOrderDefaultRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,28 +10,31 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description.rules;
 
+import org.eclipse.wb.core.databinding.xsd.component.DefaultMethodOrderType;
+import org.eclipse.wb.core.databinding.xsd.component.MethodsOrderType;
 import org.eclipse.wb.internal.core.model.description.ComponentDescription;
+import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper.FailableBiConsumer;
 import org.eclipse.wb.internal.core.model.order.MethodOrder;
 
-import org.apache.commons.digester3.Rule;
-import org.xml.sax.Attributes;
-
 /**
- * The {@link Rule} that sets {@link ComponentDescription#setDefaultMethodOrder(MethodOrder)}.
+ * The {@link FailableBiConsumer} that sets
+ * {@link ComponentDescription#setDefaultMethodOrder(MethodOrder)}.
  *
  * @author scheglov_ke
  * @coverage core.model.description
  */
-public final class MethodOrderDefaultRule extends AbstractDesignerRule {
+public final class MethodOrderDefaultRule
+		implements FailableBiConsumer<ComponentDescription, MethodsOrderType.Default, Exception> {
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Rule
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public void begin(String namespace, String name, Attributes attributes) throws Exception {
-		ComponentDescription componentDescription = (ComponentDescription) getDigester().peek();
-		String specification = getRequiredAttribute(name, attributes, "order");
+	public void accept(ComponentDescription componentDescription, MethodsOrderType.Default defaultMethod)
+			throws Exception {
+		DefaultMethodOrderType order = defaultMethod.getOrder();
+		String specification = order.value();
 		componentDescription.setDefaultMethodOrder(MethodOrder.parse(specification));
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/MethodOrderMethodRule.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/MethodOrderMethodRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,39 +10,39 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description.rules;
 
+import org.eclipse.wb.core.databinding.xsd.component.MethodsOrderType;
 import org.eclipse.wb.internal.core.model.description.ComponentDescription;
 import org.eclipse.wb.internal.core.model.description.MethodDescription;
+import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper.FailableBiConsumer;
 import org.eclipse.wb.internal.core.model.order.MethodOrder;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 
-import org.apache.commons.digester3.Rule;
-import org.xml.sax.Attributes;
-
 /**
- * The {@link Rule} that {@link MethodOrder} for single {@link MethodDescription}.
+ * The {@link FailableBiConsumer} that {@link MethodOrder} for single
+ * {@link MethodDescription}.
  *
  * @author scheglov_ke
  * @coverage core.model.description
  */
-public final class MethodOrderMethodRule extends AbstractDesignerRule {
+public final class MethodOrderMethodRule
+		implements FailableBiConsumer<ComponentDescription, MethodsOrderType.Method, Exception> {
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Rule
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public void begin(String namespace, String name, Attributes attributes) throws Exception {
+	public void accept(ComponentDescription componentDescription, MethodsOrderType.Method method) throws Exception {
 		// prepare order
 		MethodOrder order;
 		{
-			String specification = getRequiredAttribute(name, attributes, "order");
+			String specification = method.getOrder();
 			order = MethodOrder.parse(specification);
 		}
 		// prepare method
 		MethodDescription methodDescription;
 		{
-			String signature = getRequiredAttribute(name, attributes, "signature");
-			ComponentDescription componentDescription = (ComponentDescription) getDigester().peek();
+			String signature = method.getSignature();
 			methodDescription = componentDescription.getMethod(signature);
 			Assert.isNotNull(
 					methodDescription,

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/InvocationChainCreationSupportTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/InvocationChainCreationSupportTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -72,12 +72,8 @@ public class InvocationChainCreationSupportTest extends SwingModelTest {
 						"<?xml version='1.0' encoding='UTF-8'?>",
 						"<component xmlns='http://www.eclipse.org/wb/WBPComponent'>",
 						"  <parameters>",
-						"    <parameter name='invocationChain: getWrapper().getButton()'>",
-						"      javax.swing.JButton",
-						"    </parameter>",
-						"    <parameter name='invocationChain: getWrapper().getButton_1()'>",
-						"      javax.swing.JButton",
-						"    </parameter>",
+						"    <parameter name='invocationChain: getWrapper().getButton()'>javax.swing.JButton</parameter>",
+						"    <parameter name='invocationChain: getWrapper().getButton_1()'>javax.swing.JButton</parameter>",
 						"    <parameter name='invocationChain: getWrapper().getButton_2()'/>",
 						"  </parameters>",
 						"</component>"));

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/description/ComponentDescriptionHelperTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/description/ComponentDescriptionHelperTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -415,7 +415,7 @@ public class ComponentDescriptionHelperTest extends SwingModelTest {
 		setFileContent("wbp-meta/test/MyPanel.wbp-component.xml",
 				getSource("<?xml version='1.0' encoding='UTF-8'?>",
 						"<component xmlns='http://www.eclipse.org/wb/WBPComponent'>",
-						"  <description>My <b>cool</b> description</description>", "</component>"));
+						"  <description>My &lt;b&gt;cool&lt;/b&gt; description</description>", "</component>"));
 		waitForAutoBuild();
 		// parse
 		ContainerInfo panel = parseContainer("// filler filler filler", "public class Test extends MyPanel {",


### PR DESCRIPTION
This change migrates handling of the component description, exposing rules, method order and in-/exclusions, as well as the untyped parameters to JAXB.

#638 