### PR TITLE
Process the (standard bean) properties of a component via JAXB

### DIFF
--- a/org.eclipse.wb.core.databinding.xsd/schema/wbp-component.xsd
+++ b/org.eclipse.wb.core.databinding.xsd/schema/wbp-component.xsd
@@ -145,9 +145,12 @@
 				<!-- method based property (single parameter) -->
 				<xs:element name="method-single-property" minOccurs="0" maxOccurs="unbounded">
 					<xs:complexType>
-						<xs:group ref="PropertyConfigurationElements"/>
-						<xs:attribute name="title" type="xs:string" use="required"/>
-						<xs:attribute name="method" type="xs:string" use="required"/>
+						<xs:complexContent>
+							<xs:extension base="PropertyConfigurationElements">
+								<xs:attribute name="title" type="xs:string" use="required"/>
+								<xs:attribute name="method" type="xs:string" use="required"/>
+							</xs:extension>
+						</xs:complexContent>
 					</xs:complexType>
 				</xs:element>
 				<!-- method based property (multiple parameters) -->
@@ -263,28 +266,11 @@
 
 	<!-- PropertyEditor type -->
 	<xs:complexType name="PropertyEditor">
-		<xs:sequence>
-			<xs:element name="parameter" minOccurs="0" maxOccurs="unbounded">
-				<xs:complexType>
-					<xs:simpleContent>
-						<xs:extension base="xs:string">
-							<xs:attribute name="name" type="xs:string" use="required"/>
-						</xs:extension>
-					</xs:simpleContent>
-				</xs:complexType>
-			</xs:element>
-			<xs:element name="parameter-list" minOccurs="0" maxOccurs="unbounded">
-				<xs:complexType>
-					<xs:simpleContent>
-						<xs:extension base="xs:string">
-							<xs:attribute name="name" type="xs:string" use="required"/>
-						</xs:extension>
-					</xs:simpleContent>
-				</xs:complexType>
-			</xs:element>
-		</xs:sequence>
-		<!-- attributes -->
-		<xs:attribute name="id" type="EditorId" use="required"/>
+		<xs:complexContent>
+			<xs:extension base="ParameterBaseType">
+				<xs:attribute name="id" type="EditorId" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
 	</xs:complexType>
 
 
@@ -309,41 +295,26 @@
 
 	<!-- ConfigurableProperty type -->
 	<xs:complexType name="ConfigurablePropertyType">
-		<xs:sequence>
-			<xs:element name="parameter" minOccurs="0" maxOccurs="unbounded">
-				<xs:complexType>
-					<xs:simpleContent>
-						<xs:extension base="xs:string">
-							<xs:attribute name="name" type="xs:string" use="required"/>
-						</xs:extension>
-					</xs:simpleContent>
-				</xs:complexType>
-			</xs:element>
-			<xs:element name="parameter-list" minOccurs="0" maxOccurs="unbounded">
-				<xs:complexType>
-					<xs:simpleContent>
-						<xs:extension base="xs:string">
-							<xs:attribute name="name" type="xs:string" use="required"/>
-						</xs:extension>
-					</xs:simpleContent>
-				</xs:complexType>
-			</xs:element>
-		</xs:sequence>
-		<!-- attributes -->
-		<xs:attribute name="id" type="xs:string" use="required"/>
-		<xs:attribute name="title" type="xs:string" use="required"/>
+		<xs:complexContent>
+			<xs:extension base="ParameterBaseType">
+				<xs:attribute name="id" type="xs:string" use="required"/>
+				<xs:attribute name="title" type="xs:string" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
 	</xs:complexType>
 
 
 
 	<!-- PropertyConfiguration type -->
 	<xs:complexType name="PropertyConfiguration">
-		<xs:group ref="PropertyConfigurationElements"/>
-		<!-- attributes -->
-		<xs:attribute name="id" type="PropertyId" use="required"/>
+		<xs:complexContent>
+			<xs:extension base="PropertyConfigurationElements">
+				<xs:attribute name="id" type="PropertyId" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
 	</xs:complexType>
 	
-	<xs:group name="PropertyConfigurationElements">
+	<xs:complexType name="PropertyConfigurationElements">
 		<xs:sequence>
 			<!-- category -->
 			<xs:element name="category" minOccurs="0">
@@ -373,7 +344,7 @@
 				</xs:complexType>
 			</xs:element>
 		</xs:sequence>
-	</xs:group>
+	</xs:complexType>
 	
 
 	<!-- Tag type -->
@@ -475,6 +446,29 @@
 				<xs:complexType>
 					<xs:attribute name="class" type="ClassName" use="required"/>
 					<xs:attribute name="creationId" type="xs:string"/>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="ParameterBaseType">
+		<xs:sequence>
+			<xs:element name="parameter" minOccurs="0" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:simpleContent>
+						<xs:extension base="xs:string">
+							<xs:attribute name="name" type="xs:string" use="required"/>
+						</xs:extension>
+					</xs:simpleContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="parameter-list" minOccurs="0" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:simpleContent>
+						<xs:extension base="xs:string">
+							<xs:attribute name="name" type="xs:string" use="required"/>
+						</xs:extension>
+					</xs:simpleContent>
 				</xs:complexType>
 			</xs:element>
 		</xs:sequence>

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/ConfigurableObjectListParameterRule.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/ConfigurableObjectListParameterRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,19 +10,23 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description.rules;
 
+import org.eclipse.wb.core.databinding.xsd.component.ParameterBaseType;
+import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper.FailableBiConsumer;
 import org.eclipse.wb.internal.core.model.description.internal.AbstractConfigurableDescription;
+import org.eclipse.wb.internal.core.model.description.internal.PropertyEditorDescription;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 
-import org.apache.commons.digester3.Rule;
 import org.xml.sax.Attributes;
 
 /**
- * The {@link Rule} that sets value of {@link AbstractConfigurableDescription} parameter.
+ * The {@link FailableBiConsumer} that sets value of
+ * {@link AbstractConfigurableDescription} parameter.
  *
  * @author scheglov_ke
  * @coverage core.model.description
  */
-public final class ConfigurableObjectListParameterRule extends AbstractDesignerRule {
+public final class ConfigurableObjectListParameterRule extends AbstractDesignerRule
+		implements FailableBiConsumer<PropertyEditorDescription, ParameterBaseType.ParameterList, Exception> {
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Rule
@@ -46,5 +50,14 @@ public final class ConfigurableObjectListParameterRule extends AbstractDesignerR
 	public void end(String namespace, String name) throws Exception {
 		AbstractConfigurableDescription description = (AbstractConfigurableDescription) getDigester().peek();
 		description.addListParameter(m_name, m_value);
+	}
+
+	@Override
+	public void accept(PropertyEditorDescription editorDescription, ParameterBaseType.ParameterList parameterList)
+			throws Exception {
+		String name = parameterList.getName();
+		String value = parameterList.getValue();
+		Assert.isNotNull(value, "Body text for <" + name + "> required.");
+		editorDescription.addListParameter(name, value);
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/ConfigurableObjectParameterRule.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/ConfigurableObjectParameterRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,20 +10,23 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description.rules;
 
+import org.eclipse.wb.core.databinding.xsd.component.ParameterBaseType;
+import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper.FailableBiConsumer;
 import org.eclipse.wb.internal.core.model.description.internal.AbstractConfigurableDescription;
+import org.eclipse.wb.internal.core.model.description.internal.PropertyEditorDescription;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 
-import org.apache.commons.digester3.Rule;
 import org.xml.sax.Attributes;
 
 /**
- * The {@link Rule} that sets value of {@link AbstractConfigurableDescription}
- * parameter.
+ * The {@link FailableBiConsumer} that sets value of
+ * {@link AbstractConfigurableDescription} parameter.
  *
  * @author scheglov_ke
  * @coverage core.model.description
  */
-public final class ConfigurableObjectParameterRule extends AbstractDesignerRule {
+public final class ConfigurableObjectParameterRule extends AbstractDesignerRule
+		implements FailableBiConsumer<PropertyEditorDescription, ParameterBaseType.Parameter, Exception> {
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Rule
@@ -47,5 +50,14 @@ public final class ConfigurableObjectParameterRule extends AbstractDesignerRule 
 	public void end(String namespace, String name) throws Exception {
 		AbstractConfigurableDescription description = (AbstractConfigurableDescription) getDigester().peek();
 		description.addParameter(m_name, m_value);
+	}
+
+	@Override
+	public void accept(PropertyEditorDescription editorDescription, ParameterBaseType.Parameter parameter)
+			throws Exception {
+		String name = parameter.getName();
+		String value = parameter.getValue();
+		Assert.isNotNull(value, "Body text for <" + name + "> required.");
+		editorDescription.addParameter(name, value);
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/MethodPropertyRule.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/MethodPropertyRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,11 +10,13 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description.rules;
 
+import org.eclipse.wb.core.databinding.xsd.component.Component.MethodProperty;
 import org.eclipse.wb.internal.core.model.description.ComponentDescription;
 import org.eclipse.wb.internal.core.model.description.GenericPropertyDescription;
 import org.eclipse.wb.internal.core.model.description.MethodDescription;
 import org.eclipse.wb.internal.core.model.description.ParameterDescription;
 import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper;
+import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper.FailableBiConsumer;
 import org.eclipse.wb.internal.core.model.property.accessor.ExpressionAccessor;
 import org.eclipse.wb.internal.core.model.property.accessor.MethodInvocationAccessor;
 import org.eclipse.wb.internal.core.model.property.accessor.MethodInvocationArgumentAccessor;
@@ -25,26 +27,23 @@ import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
 import org.eclipse.jdt.core.IJavaProject;
 
-import org.apache.commons.digester3.Rule;
-import org.xml.sax.Attributes;
-
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
- * The {@link Rule} that adds {@link GenericPropertyDescription} for method with one or more
- * parameters.
+ * The {@link FailableBiConsumer} that adds {@link GenericPropertyDescription}
+ * for method with one or more parameters.
  * <p>
  * For example "Forms API" <code>FormText</code> has method
- * <code>setText(String,boolean,boolean)</code>. So, we need some way to describe in
- * <code>*.wbp-component.xml</code> that we need to create property for this method with
- * sub-properties for each parameter.
+ * <code>setText(String,boolean,boolean)</code>. So, we need some way to
+ * describe in <code>*.wbp-component.xml</code> that we need to create property
+ * for this method with sub-properties for each parameter.
  *
  * @author scheglov_ke
  * @coverage core.model.description
  */
-public final class MethodPropertyRule extends AbstractDesignerRule {
+public final class MethodPropertyRule implements FailableBiConsumer<ComponentDescription, MethodProperty, Exception> {
 	private final IJavaProject m_javaProject;
 
 	////////////////////////////////////////////////////////////////////////////
@@ -62,12 +61,11 @@ public final class MethodPropertyRule extends AbstractDesignerRule {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public void begin(String namespace, String name, Attributes attributes) throws Exception {
-		ComponentDescription componentDescription = (ComponentDescription) getDigester().peek();
+	public void accept(ComponentDescription componentDescription, MethodProperty methodProperty) throws Exception {
 		Class<?> componentClass = componentDescription.getComponentClass();
 		// prepare method attributes
-		String propertyTitle = getRequiredAttribute(name, attributes, "title");
-		String methodSignature = getRequiredAttribute(name, attributes, "method");
+		String propertyTitle = methodProperty.getTitle();
+		String methodSignature = methodProperty.getMethod();
 		String propertyId = methodSignature;
 		// prepare Method
 		Method method = ReflectionUtils.getMethodBySignature(componentClass, methodSignature);

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/PropertyCategoryRule.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/PropertyCategoryRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,46 +10,45 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description.rules;
 
+import org.eclipse.wb.core.databinding.xsd.component.PropertyConfiguration;
 import org.eclipse.wb.internal.core.model.description.GenericPropertyDescription;
+import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper.FailableBiConsumer;
 import org.eclipse.wb.internal.core.model.property.category.PropertyCategory;
 
-import org.apache.commons.digester3.Rule;
-import org.xml.sax.Attributes;
-
 /**
- * The {@link Rule} that sets {@link PropertyCategory} of current {@link GenericPropertyDescription}
- * .
+ * The {@link FailableBiConsumer} that sets {@link PropertyCategory} of current
+ * {@link GenericPropertyDescription} .
  *
  * @author scheglov_ke
  * @coverage core.model.description
  */
-public final class PropertyCategoryRule extends Rule {
+public final class PropertyCategoryRule
+		implements FailableBiConsumer<GenericPropertyDescription, PropertyConfiguration.Category, Exception> {
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Rule
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public void begin(String namespace, String name, Attributes attributes) throws Exception {
+	public void accept(GenericPropertyDescription propertyDescription, PropertyConfiguration.Category category)
+			throws Exception {
 		// prepare category
-		PropertyCategory category;
+		PropertyCategory propertyCategory;
 		{
-			String categoryTitle = attributes.getValue("value");
+			String categoryTitle = category.getValue().value();
 			if ("preferred".equals(categoryTitle)) {
-				category = PropertyCategory.PREFERRED;
+				propertyCategory = PropertyCategory.PREFERRED;
 			} else if ("normal".equals(categoryTitle)) {
-				category = PropertyCategory.NORMAL;
+				propertyCategory = PropertyCategory.NORMAL;
 			} else if ("advanced".equals(categoryTitle)) {
-				category = PropertyCategory.ADVANCED;
+				propertyCategory = PropertyCategory.ADVANCED;
 			} else if ("hidden".equals(categoryTitle)) {
-				category = PropertyCategory.HIDDEN;
+				propertyCategory = PropertyCategory.HIDDEN;
 			} else {
 				throw new IllegalArgumentException("Unknown category " + categoryTitle);
 			}
 		}
 		// set category
-		GenericPropertyDescription propertyDescription =
-				(GenericPropertyDescription) getDigester().peek();
-		propertyDescription.setCategory(category);
+		propertyDescription.setCategory(propertyCategory);
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/PropertyDefaultRule.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/PropertyDefaultRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,21 +10,21 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description.rules;
 
+import org.eclipse.wb.core.databinding.xsd.component.PropertyConfiguration;
 import org.eclipse.wb.internal.core.model.description.GenericPropertyDescription;
+import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper.FailableBiConsumer;
 import org.eclipse.wb.internal.core.model.util.ScriptUtils;
 
-import org.apache.commons.digester3.Rule;
-import org.xml.sax.Attributes;
-
 /**
- * The {@link Rule} that sets the default value of current
+ * The {@link FailableBiConsumer} that sets the default value of current
  * {@link GenericPropertyDescription}. Right now it supports fairly limited set
  * of expressions: boolean literals.
  *
  * @author scheglov_ke
  * @coverage core.model.description
  */
-public final class PropertyDefaultRule extends Rule {
+public final class PropertyDefaultRule
+		implements FailableBiConsumer<GenericPropertyDescription, PropertyConfiguration.DefaultValue, Exception> {
 	private final ClassLoader m_classLoader;
 
 	////////////////////////////////////////////////////////////////////////////
@@ -42,9 +42,9 @@ public final class PropertyDefaultRule extends Rule {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public void begin(String namespace, String name, Attributes attributes) throws Exception {
-		GenericPropertyDescription propertyDescription = (GenericPropertyDescription) getDigester().peek();
-		String text = attributes.getValue("value");
+	public void accept(GenericPropertyDescription propertyDescription, PropertyConfiguration.DefaultValue defaultValue)
+			throws Exception {
+		String text = defaultValue.getValue();
 		propertyDescription.setDefaultValue(getValue(text));
 	}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/PropertyGetterRule.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/PropertyGetterRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,39 +10,43 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description.rules;
 
+import org.eclipse.wb.core.databinding.xsd.component.PropertyConfiguration;
 import org.eclipse.wb.internal.core.model.description.ComponentDescription;
 import org.eclipse.wb.internal.core.model.description.GenericPropertyDescription;
+import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper.FailableBiConsumer;
 import org.eclipse.wb.internal.core.model.property.accessor.ExpressionAccessor;
 import org.eclipse.wb.internal.core.model.property.accessor.SetterAccessor;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
-import org.apache.commons.digester3.Rule;
-import org.xml.sax.Attributes;
-
 import java.lang.reflect.Method;
 
 /**
- * The {@link Rule} to set "getter" for {@link SetterAccessor}.
+ * The {@link FailableBiConsumer} to set "getter" for {@link SetterAccessor}.
  *
  * @author scheglov_ke
  * @coverage core.model.description
  */
-public final class PropertyGetterRule extends Rule {
+public final class PropertyGetterRule
+		implements FailableBiConsumer<GenericPropertyDescription, PropertyConfiguration.Getter, Exception> {
+	private final ComponentDescription m_componentDescription;
+
+	public PropertyGetterRule(ComponentDescription componentDescription) {
+		m_componentDescription = componentDescription;
+	}
+
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Rule
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public void begin(String namespace, String name, Attributes attributes) throws Exception {
-		ComponentDescription componentDescription = (ComponentDescription) getDigester().peek(1);
-		GenericPropertyDescription propertyDescription =
-				(GenericPropertyDescription) getDigester().peek();
-		String getterName = attributes.getValue("name");
-		Method getter = ReflectionUtils.getMethod(componentDescription.getComponentClass(), getterName);
+	public void accept(GenericPropertyDescription propertyDescription, PropertyConfiguration.Getter getter)
+			throws Exception {
+		String getterName = getter.getName();
+		Method getterMethod = ReflectionUtils.getMethod(m_componentDescription.getComponentClass(), getterName);
 		for (ExpressionAccessor accessor : propertyDescription.getAccessorsList()) {
 			if (accessor instanceof SetterAccessor setterAccessor) {
-				setterAccessor.setGetter(getter);
+				setterAccessor.setGetter(getterMethod);
 			}
 		}
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/PropertyTagRule.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/PropertyTagRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,29 +10,28 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description.rules;
 
+import org.eclipse.wb.core.databinding.xsd.component.PropertyConfiguration;
 import org.eclipse.wb.internal.core.model.description.GenericPropertyDescription;
-
-import org.apache.commons.digester3.Rule;
-import org.xml.sax.Attributes;
+import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper.FailableBiConsumer;
 
 /**
- * The {@link Rule} that sets a tag for current
+ * The {@link FailableBiConsumer} that sets a tag for current
  * {@link GenericPropertyDescription}.
  *
  * @author scheglov_ke
  * @coverage core.model.description
  */
-public final class PropertyTagRule extends AbstractDesignerRule {
+public final class PropertyTagRule
+		implements FailableBiConsumer<GenericPropertyDescription, PropertyConfiguration.Tag, Exception> {
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Rule
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public void begin(String namespace, String name, Attributes attributes) throws Exception {
-		GenericPropertyDescription propertyDescription = (GenericPropertyDescription) getDigester().peek();
-		String tagName = getRequiredAttribute(name, attributes, "name");
-		String tagValue = getRequiredAttribute(name, attributes, "value");
+	public void accept(GenericPropertyDescription propertyDescription, PropertyConfiguration.Tag tag) throws Exception {
+		String tagName = tag.getName();
+		String tagValue = tag.getValue();
 		propertyDescription.putTag(tagName, tagValue);
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/StandardBeanPropertiesAdvancedRule.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/StandardBeanPropertiesAdvancedRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,21 +10,26 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description.rules;
 
+import org.eclipse.wb.core.databinding.xsd.component.Component.PropertiesAdvanced;
 import org.eclipse.wb.internal.core.model.description.GenericPropertyDescription;
+import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper.FailableBiConsumer;
 import org.eclipse.wb.internal.core.model.property.category.PropertyCategory;
 
-import org.apache.commons.digester3.Rule;
-import org.xml.sax.Attributes;
-
 /**
- * The {@link Rule} that sets {@link PropertyCategory#ADVANCED} for standard bean properties.
+ * The {@link FailableBiConsumer} that sets {@link PropertyCategory#ADVANCED}
+ * for standard bean properties.
  *
  * @author scheglov_ke
  * @coverage core.model.description
  */
 public final class StandardBeanPropertiesAdvancedRule extends StandardBeanPropertiesFlaggedRule {
 	@Override
-	protected void configure(GenericPropertyDescription propertyDescription, Attributes attributes) {
+	protected void configure(GenericPropertyDescription propertyDescription) {
 		propertyDescription.setCategory(PropertyCategory.ADVANCED);
+	}
+
+	@Override
+	protected String getNames(Object properties) {
+		return ((PropertiesAdvanced) properties).getNames();
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/StandardBeanPropertiesFlaggedRule.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/StandardBeanPropertiesFlaggedRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,31 +12,31 @@ package org.eclipse.wb.internal.core.model.description.rules;
 
 import org.eclipse.wb.internal.core.model.description.ComponentDescription;
 import org.eclipse.wb.internal.core.model.description.GenericPropertyDescription;
+import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper.FailableBiConsumer;
 
-import org.apache.commons.digester3.Rule;
 import org.apache.commons.lang.StringUtils;
-import org.xml.sax.Attributes;
 
 /**
- * The {@link Rule} that allows to set options for standard bean properties.
+ * The {@link FailableBiConsumer} that allows to set options for standard bean
+ * properties.
  *
  * @author scheglov_ke
  * @coverage core.model.description
  */
-public abstract class StandardBeanPropertiesFlaggedRule extends AbstractDesignerRule {
+public abstract class StandardBeanPropertiesFlaggedRule
+		implements FailableBiConsumer<ComponentDescription, Object, Exception> {
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Rule
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public final void begin(String namespace, String tagName, Attributes attributes)
+	public final void accept(ComponentDescription componentDescription, Object properties)
 			throws Exception {
-		ComponentDescription componentDescription = (ComponentDescription) getDigester().peek();
 		// prepare names
 		String[] names;
 		{
-			String namesString = getRequiredAttribute(tagName, attributes, "names");
+			String namesString = getNames(properties);
 			names = StringUtils.split(namesString);
 		}
 		// check names
@@ -44,7 +44,7 @@ public abstract class StandardBeanPropertiesFlaggedRule extends AbstractDesigner
 			for (GenericPropertyDescription propertyDescription : componentDescription.getProperties()) {
 				String id = propertyDescription.getId();
 				if (matchPropertyId(id, name)) {
-					configure(propertyDescription, attributes);
+					configure(propertyDescription);
 				}
 			}
 		}
@@ -58,8 +58,12 @@ public abstract class StandardBeanPropertiesFlaggedRule extends AbstractDesigner
 	/**
 	 * Configures given {@link GenericPropertyDescription}.
 	 */
-	protected abstract void configure(GenericPropertyDescription propertyDescription,
-			Attributes attributes);
+	protected abstract void configure(GenericPropertyDescription propertyDescription);
+
+	/**
+	 * Extracts the names of the given property.
+	 */
+	protected abstract String getNames(Object properties);
 
 	////////////////////////////////////////////////////////////////////////////
 	//

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/StandardBeanPropertiesHiddenRule.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/StandardBeanPropertiesHiddenRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,21 +10,26 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description.rules;
 
+import org.eclipse.wb.core.databinding.xsd.component.Component.PropertiesHidden;
 import org.eclipse.wb.internal.core.model.description.GenericPropertyDescription;
+import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper.FailableBiConsumer;
 import org.eclipse.wb.internal.core.model.property.category.PropertyCategory;
 
-import org.apache.commons.digester3.Rule;
-import org.xml.sax.Attributes;
-
 /**
- * The {@link Rule} that sets {@link PropertyCategory#HIDDEN} for standard bean properties.
+ * The {@link FailableBiConsumer} that sets {@link PropertyCategory#HIDDEN} for
+ * standard bean properties.
  *
  * @author scheglov_ke
  * @coverage core.model.description
  */
 public final class StandardBeanPropertiesHiddenRule extends StandardBeanPropertiesFlaggedRule {
 	@Override
-	protected void configure(GenericPropertyDescription propertyDescription, Attributes attributes) {
+	protected void configure(GenericPropertyDescription propertyDescription) {
 		propertyDescription.setCategory(PropertyCategory.HIDDEN);
+	}
+
+	@Override
+	protected String getNames(Object properties) {
+		return ((PropertiesHidden) properties).getNames();
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/StandardBeanPropertiesNoDefaultValueRule.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/StandardBeanPropertiesNoDefaultValueRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,24 +10,26 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description.rules;
 
+import org.eclipse.wb.core.databinding.xsd.component.Component.PropertiesNoDefaultValue;
 import org.eclipse.wb.internal.core.model.description.GenericPropertyDescription;
+import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper.FailableBiConsumer;
 import org.eclipse.wb.internal.core.model.property.accessor.ExpressionAccessor;
 
-import org.apache.commons.digester3.Rule;
-import org.xml.sax.Attributes;
-
 /**
- * The {@link Rule} that sets {@link ExpressionAccessor#NO_DEFAULT_VALUE_TAG} for standard bean
- * properties.
+ * The {@link FailableBiConsumer} that sets
+ * {@link ExpressionAccessor#NO_DEFAULT_VALUE_TAG} for standard bean properties.
  *
  * @author scheglov_ke
  * @coverage core.model.description
  */
-public final class StandardBeanPropertiesNoDefaultValueRule
-extends
-StandardBeanPropertiesFlaggedRule {
+public final class StandardBeanPropertiesNoDefaultValueRule extends StandardBeanPropertiesFlaggedRule {
 	@Override
-	protected void configure(GenericPropertyDescription propertyDescription, Attributes attributes) {
+	protected void configure(GenericPropertyDescription propertyDescription) {
 		propertyDescription.putTag(ExpressionAccessor.NO_DEFAULT_VALUE_TAG, "true");
+	}
+
+	@Override
+	protected String getNames(Object properties) {
+		return ((PropertiesNoDefaultValue) properties).getNames();
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/StandardBeanPropertiesNormalRule.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/StandardBeanPropertiesNormalRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,21 +10,26 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description.rules;
 
+import org.eclipse.wb.core.databinding.xsd.component.Component.PropertiesNormal;
 import org.eclipse.wb.internal.core.model.description.GenericPropertyDescription;
+import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper.FailableBiConsumer;
 import org.eclipse.wb.internal.core.model.property.category.PropertyCategory;
 
-import org.apache.commons.digester3.Rule;
-import org.xml.sax.Attributes;
-
 /**
- * The {@link Rule} that sets {@link PropertyCategory#NORMAL} for standard bean properties.
+ * The {@link FailableBiConsumer} that sets {@link PropertyCategory#NORMAL} for
+ * standard bean properties.
  *
  * @author scheglov_ke
  * @coverage core.model.description
  */
 public final class StandardBeanPropertiesNormalRule extends StandardBeanPropertiesFlaggedRule {
 	@Override
-	protected void configure(GenericPropertyDescription propertyDescription, Attributes attributes) {
+	protected void configure(GenericPropertyDescription propertyDescription) {
 		propertyDescription.setCategory(PropertyCategory.NORMAL);
+	}
+
+	@Override
+	protected String getNames(Object properties) {
+		return ((PropertiesNormal) properties).getNames();
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/StandardBeanPropertiesPreferredRule.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/StandardBeanPropertiesPreferredRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,21 +10,26 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description.rules;
 
+import org.eclipse.wb.core.databinding.xsd.component.Component.PropertiesPreferred;
 import org.eclipse.wb.internal.core.model.description.GenericPropertyDescription;
+import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper.FailableBiConsumer;
 import org.eclipse.wb.internal.core.model.property.category.PropertyCategory;
 
-import org.apache.commons.digester3.Rule;
-import org.xml.sax.Attributes;
-
 /**
- * The {@link Rule} that sets {@link PropertyCategory#PREFERRED} for standard bean properties.
+ * The {@link FailableBiConsumer} that sets {@link PropertyCategory#PREFERRED}
+ * for standard bean properties.
  *
  * @author scheglov_ke
  * @coverage core.model.description
  */
 public final class StandardBeanPropertiesPreferredRule extends StandardBeanPropertiesFlaggedRule {
 	@Override
-	protected void configure(GenericPropertyDescription propertyDescription, Attributes attributes) {
+	protected void configure(GenericPropertyDescription propertyDescription) {
 		propertyDescription.setCategory(PropertyCategory.PREFERRED);
+	}
+
+	@Override
+	protected String getNames(Object properties) {
+		return ((PropertiesPreferred) properties).getNames();
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/StandardBeanPropertiesRule.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/StandardBeanPropertiesRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ import org.eclipse.wb.internal.core.model.description.ComponentDescription;
 import org.eclipse.wb.internal.core.model.description.GenericPropertyDescription;
 import org.eclipse.wb.internal.core.model.description.MethodDescription;
 import org.eclipse.wb.internal.core.model.description.ParameterDescription;
+import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper.FailableBiConsumer;
 import org.eclipse.wb.internal.core.model.description.helpers.DescriptionPropertiesHelper;
 import org.eclipse.wb.internal.core.model.property.accessor.SetterAccessor;
 import org.eclipse.wb.internal.core.model.property.category.PropertyCategory;
@@ -21,29 +22,25 @@ import org.eclipse.wb.internal.core.model.property.converter.ExpressionConverter
 import org.eclipse.wb.internal.core.model.property.editor.PropertyEditor;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
-import org.apache.commons.digester3.Rule;
-import org.xml.sax.Attributes;
-
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Method;
 import java.util.List;
 
 /**
- * The {@link Rule} that adds standard properties for <code>set/getXXX</code>
- * methods.
+ * The {@link FailableBiConsumer} that adds standard properties for
+ * <code>set/getXXX</code> methods.
  *
  * @author scheglov_ke
  * @coverage core.model.description
  */
-public final class StandardBeanPropertiesRule extends Rule {
+public final class StandardBeanPropertiesRule implements FailableBiConsumer<ComponentDescription, Object, Exception> {
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Rule
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public void begin(String namespace, String name, Attributes attributes) throws Exception {
-		ComponentDescription componentDescription = (ComponentDescription) getDigester().peek();
+	public void accept(ComponentDescription componentDescription, Object object) throws Exception {
 		List<PropertyDescriptor> descriptors = ReflectionUtils
 				.getPropertyDescriptors(componentDescription.getBeanInfo(), componentDescription.getComponentClass());
 		componentDescription.setPropertyDescriptors(descriptors);
@@ -85,7 +82,7 @@ public final class StandardBeanPropertiesRule extends Rule {
 	/**
 	 * Adds single {@link GenericPropertyDescription} for given methods.
 	 */
-	static GenericPropertyDescription addSingleProperty(ComponentDescription componentDescription, String title,
+	public static GenericPropertyDescription addSingleProperty(ComponentDescription componentDescription, String title,
 			Method setMethod, Method getMethod) throws Exception {
 		// make setMethod() executable
 		MethodDescription methodDescription = componentDescription.addMethod(setMethod);

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/StandardBeanPropertyTagRule.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/rules/StandardBeanPropertyTagRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,35 +10,34 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.description.rules;
 
+import org.eclipse.wb.core.databinding.xsd.component.Component.PropertyTag;
 import org.eclipse.wb.internal.core.model.description.ComponentDescription;
 import org.eclipse.wb.internal.core.model.description.GenericPropertyDescription;
-
-import org.apache.commons.digester3.Rule;
-import org.xml.sax.Attributes;
+import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper.FailableBiConsumer;
 
 /**
- * The {@link Rule} that adds some tag for standard bean property, created by
- * {@link StandardBeanPropertiesRule}.
+ * The {@link FailableBiConsumer} that adds some tag for standard bean property,
+ * created by {@link StandardBeanPropertiesRule}.
  *
  * @author scheglov_ke
  * @coverage core.model.description
  */
-public final class StandardBeanPropertyTagRule extends AbstractDesignerRule {
+public final class StandardBeanPropertyTagRule
+		implements FailableBiConsumer<ComponentDescription, PropertyTag, Exception> {
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Rule
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public void begin(String namespace, String name, Attributes attributes) throws Exception {
-		String propertyName = getRequiredAttribute(name, attributes, "name");
+	public void accept(ComponentDescription componentDescription, PropertyTag propertyTag) throws Exception {
+		String propertyName = propertyTag.getName();
 		// check all properties
-		ComponentDescription componentDescription = (ComponentDescription) getDigester().peek();
 		for (GenericPropertyDescription propertyDescription : componentDescription.getProperties()) {
 			String id = propertyDescription.getId();
 			if (StandardBeanPropertiesFlaggedRule.matchPropertyId(id, propertyName)) {
-				String tag = getRequiredAttribute(name, attributes, "tag");
-				String value = getRequiredAttribute(name, attributes, "value");
+				String tag = propertyTag.getTag();
+				String value = propertyTag.getValue();
 				propertyDescription.putTag(tag, value);
 			}
 		}


### PR DESCRIPTION
The "parameter" and "parameter-list" elements of the property editor and configurable type have been moved to a common sub-type so that they can both be handled by the same method.

The "PropertyConfigurationElements" group has been converted to a complex type, extended by both the "PropertyConfiguration" and "MethodSingleProperty" type, in order to be handled by the same method.

The rules have been adapted to accept both Digester3 and JAXB instructions. This is because they are still used to process other properties, which still use Digester3, which would then inflate the amount of change that needs to be done per commit.

See #638