### PR TITLE
Create wbp-factory schema and load model from XML via JAXB

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -32,12 +32,15 @@ The technology is effectively dead and the project no longer actively maintained
 In prevent compilation errors inside the workspace, those components have been
 removed from the project.
 
-### Changes to wbp-component.xml schema
+### Changes to wbp-component.xml & wbp-factory.xml schema
 
 All special characters in the description need to be properly encoded.
 
 Example:
 &lt;b&gt;...&lt;/b&gt;
+
+The wbp-factory.xml files should use the http://www.eclipse.org/wb/WBPComponent
+namespace.
 
 ## 1.14.0 (2023-12)
 

--- a/org.eclipse.wb.core.databinding.xsd/pom.xml
+++ b/org.eclipse.wb.core.databinding.xsd/pom.xml
@@ -42,6 +42,7 @@
 				<configuration>
 					<sources>
 						<source>${basedir}/schema/wbp-component.xsd</source>
+						<source>${basedir}/schema/wbp-factory.xsd</source>
 					</sources>
 					<noGeneratedHeaderComments>true</noGeneratedHeaderComments>
 					<noPackageLevelAnnotations>true</noPackageLevelAnnotations>

--- a/org.eclipse.wb.core.databinding.xsd/schema/wbp-factory.xsd
+++ b/org.eclipse.wb.core.databinding.xsd/schema/wbp-factory.xsd
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:jxb="https://jakarta.ee/xml/ns/jaxb" jxb:version="3.0"
+	targetNamespace="http://www.eclipse.org/wb/WBPComponent"
+	xmlns="http://www.eclipse.org/wb/WBPComponent" elementFormDefault="qualified">
+
+	<xs:annotation>
+		<xs:documentation>Schema for *.wbp-factory.xml descriptions.</xs:documentation>
+	</xs:annotation>
+	
+	<xs:include schemaLocation="wbp-component.xsd" />
+
+	<xs:element name="factory">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="allMethodsAreFactories" type="xs:boolean" nillable="true" />
+				<xs:element name="method" minOccurs="0" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="description" type="xs:string" minOccurs="0" />
+							<xs:element name="tag" type="TagType" minOccurs="0" maxOccurs="unbounded"/>
+							<xs:element name="name" type="xs:string" minOccurs="0">
+								<xs:annotation>
+									<xs:appinfo>
+										<jxb:property name="presentationName"/>
+									</xs:appinfo>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="parameter" type="MethodParameter" minOccurs="0" maxOccurs="unbounded"/>
+							<xs:element name="parameters" minOccurs="0">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="parameter" maxOccurs="unbounded">
+											<xs:complexType>
+												<xs:simpleContent>
+													<xs:extension base="xs:string">
+														<xs:attribute name="name" type="xs:string" use="required"/>
+													</xs:extension>
+												</xs:simpleContent>
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="invocation" minOccurs="0" maxOccurs="unbounded">
+								<xs:complexType mixed="true">
+									<xs:attribute name="signature" use="required"/>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+						<xs:attribute name="name" type="xs:string" use="required"/>
+						<xs:attribute name="order" type="MethodOrderType"/>
+						<xs:attribute name="executable" type="xs:boolean"/>
+						<xs:attribute name="factory" type="xs:boolean"/>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/org.eclipse.wb.core.databinding.xsd/src/org/eclipse/wb/core/databinding/xsd/component/ContextFactory.java
+++ b/org.eclipse.wb.core.databinding.xsd/src/org/eclipse/wb/core/databinding/xsd/component/ContextFactory.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Patrick Ziegler and others
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.wb.core.databinding.xsd.component;
 
 import jakarta.xml.bind.JAXBContext;

--- a/org.eclipse.wb.core.databinding.xsd/src/org/eclipse/wb/core/databinding/xsd/component/jaxb.index
+++ b/org.eclipse.wb.core.databinding.xsd/src/org/eclipse/wb/core/databinding/xsd/component/jaxb.index
@@ -1,1 +1,2 @@
 Component
+Factory

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/ComponentDescriptionHelper.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/ComponentDescriptionHelper.java
@@ -65,8 +65,6 @@ import org.eclipse.wb.internal.core.model.description.rules.MethodsOperationRule
 import org.eclipse.wb.internal.core.model.description.rules.ModelClassRule;
 import org.eclipse.wb.internal.core.model.description.rules.MorphingNoInheritRule;
 import org.eclipse.wb.internal.core.model.description.rules.MorphingTargetRule;
-import org.eclipse.wb.internal.core.model.description.rules.ObjectCreateRule;
-import org.eclipse.wb.internal.core.model.description.rules.ParameterEditorRule;
 import org.eclipse.wb.internal.core.model.description.rules.ParameterTagRule;
 import org.eclipse.wb.internal.core.model.description.rules.PropertyCategoryRule;
 import org.eclipse.wb.internal.core.model.description.rules.PropertyDefaultRule;
@@ -74,7 +72,6 @@ import org.eclipse.wb.internal.core.model.description.rules.PropertyGetterRule;
 import org.eclipse.wb.internal.core.model.description.rules.PropertyTagRule;
 import org.eclipse.wb.internal.core.model.description.rules.PublicFieldPropertiesRule;
 import org.eclipse.wb.internal.core.model.description.rules.SetClassPropertyRule;
-import org.eclipse.wb.internal.core.model.description.rules.SetListedPropertiesRule;
 import org.eclipse.wb.internal.core.model.description.rules.StandardBeanPropertiesAdvancedRule;
 import org.eclipse.wb.internal.core.model.description.rules.StandardBeanPropertiesHiddenRule;
 import org.eclipse.wb.internal.core.model.description.rules.StandardBeanPropertiesNoDefaultValueRule;
@@ -106,7 +103,6 @@ import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jface.resource.ImageDescriptor;
 
-import org.apache.commons.digester3.Digester;
 import org.apache.commons.digester3.Rule;
 import org.apache.commons.lang.StringUtils;
 import org.osgi.framework.Bundle;
@@ -828,14 +824,6 @@ public final class ComponentDescriptionHelper {
 	}
 
 	/**
-	 * Adds {@link Rule}'s for configuring {@link AbstractConfigurableDescription}.
-	 */
-	private static void addConfigurableObjectParametersRules2(Digester digester, String pattern) {
-		digester.addRule(pattern + "/parameter", new ConfigurableObjectParameterRule());
-		digester.addRule(pattern + "/parameter-list", new ConfigurableObjectListParameterRule());
-	}
-
-	/**
 	 * Adds {@link Rule}'s for parsing {@link CreationDescription}'s.
 	 */
 	private static void addCreationRules(CreationDescription creationDescription, Creation creation) throws Exception {
@@ -901,27 +889,6 @@ public final class ComponentDescriptionHelper {
 		for (TagType tag : parameter.getTag()) {
 			acceptSafe(parameterDescription, tag, new ParameterTagRule());
 		}
-	}
-
-	/**
-	 * Adds {@link Rule}'s for parsing {@link ParameterDescription}'s.
-	 */
-	static void addParametersRules2(Digester digester, String pattern, EditorState state) {
-		ClassLoader classLoader = state.getEditorLoader();
-		//
-		digester.addRule(pattern, new ObjectCreateRule(ParameterDescription.class));
-		digester.addRule(pattern, new SetClassPropertyRule(classLoader, "type"));
-		digester.addRule(pattern, new SetListedPropertiesRule(
-				new String[] { "name", "defaultSource", "parent", "child", "property", "parent2", "child2" }));
-		digester.addSetNext(pattern, "addParameter");
-		// editors
-		{
-			String editorPattern = pattern + "/editor";
-			digester.addRule(editorPattern, new ParameterEditorRule(state));
-			addConfigurableObjectParametersRules2(digester, editorPattern);
-		}
-		// tags
-		digester.addRule(pattern + "/tag", new ParameterTagRule());
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -1024,7 +991,7 @@ public final class ComponentDescriptionHelper {
 	 * order to better handle optional model parameters. Does nothing if
 	 * {@code model} is {@code null}.
 	 */
-	private static <U, T> void acceptSafe(U description, T model, FailableBiConsumer<U, T, ?> consumer)
+	static <U, T> void acceptSafe(U description, T model, FailableBiConsumer<U, T, ?> consumer)
 			throws Exception {
 		if (model == null) {
 			return;

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/nls/Messages.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/nls/Messages.java
@@ -68,6 +68,7 @@ public class Messages extends NLS {
 	public static String ExternalizeStringsContributionItem_defaultPackageMessage;
 	public static String ExternalizeStringsContributionItem_defaultPackageTitle;
 	public static String ExternalizeStringsContributionItem_externalizeToolTip;
+	public static String FactoryDescriptionHelper_deprecatedNamespace;
 	public static String FieldSourceNewComposite_fieldGroup;
 	public static String FieldSourceNewComposite_fieldNameLabel;
 	public static String FieldSourceNewComposite_title;

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/nls/messages.properties
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/nls/messages.properties
@@ -62,6 +62,7 @@ EditableSource_renameConfirmYesKeep=Yes, keep existing value
 ExternalizeStringsContributionItem_defaultPackageMessage=Strings within files in the default package cannot be externalized.
 ExternalizeStringsContributionItem_defaultPackageTitle=Can't Externalize
 ExternalizeStringsContributionItem_externalizeToolTip=Externalize strings
+FactoryDescriptionHelper_deprecatedNamespace=The file ''{0}'' should use ''http://www.eclipse.org/wb/WBPComponent'' instead of the default namespace.
 FieldSourceNewComposite_fieldGroup=Field for ResourceBundle instance
 FieldSourceNewComposite_fieldNameLabel=Field name:
 FieldSourceNewComposite_title=ResourceBundle in field

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/ActionFactoryCreationSupport.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/ActionFactoryCreationSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -206,6 +206,7 @@ IActionIconProvider {
 	private static void copyActionProperty(Object action,
 			IWorkbenchAction sourceAction,
 			String propertyName) throws Exception {
+		System.setProperty("org.apache.commons.logging.LogFactory", "org.apache.commons.logging.impl.LogFactoryImpl");
 		PropertyUtilsBean propertyUtils = new PropertyUtilsBean();
 		Object value = propertyUtils.getSimpleProperty(sourceAction, propertyName);
 		if (value instanceof String) {

--- a/org.eclipse.wb.rcp/wbp-meta/3.3/org/eclipse/ui/forms/widgets/FormToolkit.wbp-factory.xml
+++ b/org.eclipse.wb.rcp/wbp-meta/3.3/org/eclipse/ui/forms/widgets/FormToolkit.wbp-factory.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<factory>
+<factory xmlns="http://www.eclipse.org/wb/WBPComponent">
 	<!-- createButton() -->
 	<method name="createButton">
 		<parameter type="org.eclipse.swt.widgets.Composite" parent="true"/>

--- a/org.eclipse.wb.rcp/wbp-meta/org/eclipse/jface/layout/GridDataFactory.wbp-factory.xml
+++ b/org.eclipse.wb.rcp/wbp-meta/org/eclipse/jface/layout/GridDataFactory.wbp-factory.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<factory>
+<factory xmlns="http://www.eclipse.org/wb/WBPComponent">
 	<allMethodsAreFactories>false</allMethodsAreFactories>
 	<method name="swtDefaults" factory="true">
 		<description>Creates a new GridDataFactory initialized with the SWT defaults.</description>

--- a/org.eclipse.wb.rcp/wbp-meta/org/eclipse/jface/layout/GridLayoutFactory.wbp-factory.xml
+++ b/org.eclipse.wb.rcp/wbp-meta/org/eclipse/jface/layout/GridLayoutFactory.wbp-factory.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<factory>
+<factory xmlns="http://www.eclipse.org/wb/WBPComponent">
 	<allMethodsAreFactories>false</allMethodsAreFactories>
 	<method name="swtDefaults" factory="true">
 		<description>Creates a GridLayoutFactory that creates GridLayouts with the default SWT

--- a/org.eclipse.wb.rcp/wbp-meta/org/eclipse/jface/viewers/CheckboxTableViewer.wbp-factory.xml
+++ b/org.eclipse.wb.rcp/wbp-meta/org/eclipse/jface/viewers/CheckboxTableViewer.wbp-factory.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<factory>
+<factory xmlns="http://www.eclipse.org/wb/WBPComponent">
 	<!-- newCheckList() -->
 	<method name="newCheckList">
 		<parameter type="org.eclipse.swt.widgets.Composite" parent="true"/>

--- a/org.eclipse.wb.rcp/wbp-meta/org/eclipse/swt/awt/SWT_AWT.wbp-factory.xml
+++ b/org.eclipse.wb.rcp/wbp-meta/org/eclipse/swt/awt/SWT_AWT.wbp-factory.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<factory>
+
+<factory xmlns="http://www.eclipse.org/wb/WBPComponent">
 	<method name="new_Frame">
 		<parameter type="org.eclipse.swt.widgets.Composite" parent="true"/>
 		<description>Creates a new java.awt.Frame. This frame is the root for the AWT components

--- a/org.eclipse.wb.rcp/wbp-meta/org/eclipse/ui/forms/widgets/FormToolkit.wbp-factory.xml
+++ b/org.eclipse.wb.rcp/wbp-meta/org/eclipse/ui/forms/widgets/FormToolkit.wbp-factory.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<factory>
+
+<factory xmlns="http://www.eclipse.org/wb/WBPComponent">
 	<!-- createButton() -->
 	<method name="createButton">
 		<parameter type="org.eclipse.swt.widgets.Composite" parent="true"/>

--- a/org.eclipse.wb.swing/wbp-meta/javax/swing/Box.wbp-factory.xml
+++ b/org.eclipse.wb.swing/wbp-meta/javax/swing/Box.wbp-factory.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<factory>
+
+<factory xmlns="http://www.eclipse.org/wb/WBPComponent">
 	<!-- Box -->
 	<method name="createHorizontalBox">
 		<description>Creates a Box that displays its components from left to right, using X_AXIS

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/FactoryDescriptionHelperTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/FactoryDescriptionHelperTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -599,7 +599,7 @@ public class FactoryDescriptionHelperTest extends SwingModelTest {
 						"<?xml version='1.0' encoding='UTF-8'?>",
 						"<factory>",
 						"  <method name='createButton'>",
-						"    <description>Some <b>HTML</b> description.</description>",
+						"    <description>Some &lt;b&gt;HTML&lt;/b&gt; description.</description>",
 						"  </method>",
 						"</factory>"));
 		waitForAutoBuild();
@@ -636,7 +636,7 @@ public class FactoryDescriptionHelperTest extends SwingModelTest {
 						"<?xml version='1.0' encoding='UTF-8'?>",
 						"<factory>",
 						"  <method name='createButton'>",
-						"    <description>First. <p attr='value'/> Second.</description>",
+						"    <description>First. &lt;p attr='value'/&gt; Second.</description>",
 						"  </method>",
 						"</factory>"));
 		waitForAutoBuild();
@@ -689,7 +689,7 @@ public class FactoryDescriptionHelperTest extends SwingModelTest {
 		// get FactoryMethodDescription
 		FactoryMethodDescription description =
 				getDescription("test.StaticFactory", "createButton()", true);
-		assertEquals("&#48;&#x31;", description.getDescription());
+		assertEquals("01", description.getDescription());
 	}
 
 	/**


### PR DESCRIPTION
This removes the dependency on Digester3 when processing the wbp-* XML files. Note that there is no formal schema for the wbp-factory files, which is why one was created based on the wbp-component schema and the existing JUnit tests, but it might still be incomplete.

See #638