### PR TITLE
Consider SimRel Orbit repository when calculating the modular targlet

### DIFF
--- a/setups/WindowBuilder.setup
+++ b/setups/WindowBuilder.setup
@@ -143,13 +143,13 @@
           <repository
               url="https://download.eclipse.org/releases/${eclipse.target.platform.latest}"/>
           <repository
+              url="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/${eclipse.target.platform.latest}"/>
+          <repository
               url="https://download.eclipse.org/cbi/updates/license"/>
           <repository
               url="https://download.eclipse.org/nebula/snapshot/"/>
           <repository
               url="https://download.eclipse.org/nebula/incubation/snapshot/"/>
-          <repository
-              url="https://download.eclipse.org/tools/gef/classic/latest/"/>
         </repositoryList>
       </targlet>
       <composedTarget>wb-mvn</composedTarget>


### PR DESCRIPTION
Dependencies like commons-collections4 are not part of the latest release repository yet. We need to also include the latest Orbit repository.

This also removes the GEF nightly repository. Instead, we fall back to the SimRel release.