### PR TITLE
Add jakarta namespace to root context parser for E4 parts

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/core/ProjectUtils.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/core/ProjectUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -451,7 +451,7 @@ public final class ProjectUtils {
 		}
 		symbolicNames.add(pluginId);
 		// E4 support
-		symbolicNames.add("javax.annotation");
+		symbolicNames.add("jakarta.annotation-api");
 		symbolicNames.add("org.eclipse.e4.ui.di");
 		return symbolicNames;
 	}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/parser/ParseFactory.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/parser/ParseFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -200,7 +200,8 @@ public final class ParseFactory extends org.eclipse.wb.internal.swt.parser.Parse
 			IAnnotationBinding[] annotations = method.resolveBinding().getAnnotations();
 			for (IAnnotationBinding annotation : annotations) {
 				String annotationName = annotation.getAnnotationType().getQualifiedName();
-				if ("javax.annotation.PostConstruct".equals(annotationName)) {
+				if ("jakarta.annotation.PostConstruct".equals(annotationName)
+						|| "javax.annotation.PostConstruct".equals(annotationName)) {
 					for (SingleVariableDeclaration parameter : DomGenerics.parameters(method)) {
 						if (AstNodeUtils.isSuccessorOf(
 								parameter.getType().resolveBinding(),

--- a/org.eclipse.wb.rcp/templates/e4/ViewPart.jvt
+++ b/org.eclipse.wb.rcp/templates/e4/ViewPart.jvt
@@ -1,5 +1,5 @@
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.e4.ui.di.Focus;
 


### PR DESCRIPTION
Eclipse IDE 4.30 added support for jakarta.annotation and jakarta.inject packages (https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.platform.doc.user%2FwhatsNew%2Fplatform_whatsnew.html&cp%3D0_6_1&anchor=GeneralUpdates) which are now the default and added as dependencies to E4 RCP application plugins created with the PDE plugin wizard:

![image](https://github.com/eclipse-windowbuilder/windowbuilder/assets/85511748/712baecc-b84b-47c9-9fa0-fa8ca675c4a9)

As a consequence, the root context parser needs to check for jakarta.annotation in addition to javax.annotation.

The WindowBuilder > SWTDesigner > Eclipse 4 > ViewPart wizard template should follow the IDE SDK 4.30 change to jakarta instead of javax and use the new namespace as well.