### PR TITLE
[Win32] Repair selection in WindowBuilder palette

### DIFF
--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/RootFigure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/RootFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.Layer;
 
 import org.eclipse.draw2d.DeferredUpdateManager;
+import org.eclipse.draw2d.EventDispatcher;
 import org.eclipse.draw2d.UpdateListener;
 import org.eclipse.draw2d.UpdateManager;
 import org.eclipse.draw2d.geometry.Dimension;
@@ -82,6 +83,11 @@ public class RootFigure extends Figure implements IRootFigure {
 	 */
 	public void setPreferredSizeProvider(IPreferredSizeProvider provider) {
 		m_preferredSizeProvider = provider;
+	}
+
+	@Override
+	public EventDispatcher internalGetEventDispatcher() {
+		return m_figureCanvas.getLightweightSystem().getRootFigure().internalGetEventDispatcher();
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import org.eclipse.wb.draw2d.border.LineBorder;
 import org.eclipse.wb.internal.core.utils.GenericsUtils;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.core.utils.ui.DrawUtils;
+import org.eclipse.wb.internal.draw2d.EventManager;
 import org.eclipse.wb.internal.draw2d.FigureCanvas;
 import org.eclipse.wb.internal.draw2d.TargetFigureFindVisitor;
 
@@ -108,6 +109,7 @@ public final class PaletteComposite extends Composite {
 	////////////////////////////////////////////////////////////////////////////
 	private IPalettePreferences m_preferences;
 	private final FigureCanvas m_figureCanvas;
+	private final EventManager m_eventManager;
 	private final PaletteFigure m_paletteFigure;
 	private final Layer m_feedbackLayer;
 	private final Map<ICategory, CategoryFigure> m_categoryFigures = new HashMap<>();
@@ -133,6 +135,7 @@ public final class PaletteComposite extends Composite {
 			m_figureCanvas = new FigureCanvas(this, SWT.V_SCROLL);
 			m_figureCanvas.getRootFigure().setBackgroundColor(COLOR_PALETTE_BACKGROUND);
 			m_figureCanvas.getRootFigure().setForegroundColor(COLOR_TEXT_ENABLED);
+			m_eventManager = (EventManager) m_figureCanvas.getRootFigure().internalGetEventDispatcher();
 		}
 		// add palette figure (layer)
 		m_paletteFigure = new PaletteFigure();
@@ -427,7 +430,7 @@ public final class PaletteComposite extends Composite {
 					if (event.button == 1) {
 						if (m_mouseOnTitle) {
 							m_mouseDown = true;
-							setCapture(true);
+							m_eventManager.setCapture(CategoryFigure.this);
 							m_downPoint = new Point(event.x, event.y);
 						}
 					}
@@ -437,7 +440,7 @@ public final class PaletteComposite extends Composite {
 				public void mouseReleased(MouseEvent event) {
 					if (event.button == 1) {
 						m_mouseDown = false;
-						setCapture(false);
+						m_eventManager.setCapture(null);
 						//
 						if (m_moving) {
 							m_moving = false;
@@ -755,7 +758,7 @@ public final class PaletteComposite extends Composite {
 						m_mouseDown = true;
 						m_mouseInside = true;
 						// track moving
-						setCapture(true);
+						m_eventManager.setCapture(EntryFigure.this);
 						m_downPoint = new Point(event.x, event.y);
 						m_moving = false;
 						//
@@ -767,7 +770,7 @@ public final class PaletteComposite extends Composite {
 				public void mouseReleased(MouseEvent event) {
 					if (event.button == 1 && m_mouseDown) {
 						m_mouseDown = false;
-						setCapture(false);
+						m_eventManager.setCapture(null);
 						//
 						if (m_moving) {
 							move_eraseFeedback();


### PR DESCRIPTION
The deselection of the palette entries is not registered on Windows. While the entry can be selected, it remains selected even if other entries are chosen.

This is because the setCapture() method in Figure was removed and therefore those method calls in the PaletteComposite now reference the Control method instead. The reason this doesn't affect Linux is because here this is a no-op method.

Amends 360a0a678fb52b7a8e33b5fbb97de7967e6cc069