### PR TITLE
Adapt FlowLayoutEditPolicy methods to use GEF EditPart directly

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/flow/AbstractFlowLayoutEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/flow/AbstractFlowLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,6 @@ import org.eclipse.wb.core.gef.policy.PolicyUtils;
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.draw2d.Polyline;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.requests.AbstractCreateRequest;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
 import org.eclipse.wb.gef.core.requests.CreateRequest;
@@ -27,6 +26,7 @@ import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.draw2d.geometry.Transposer;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.requests.DropRequest;
@@ -81,7 +81,7 @@ public abstract class AbstractFlowLayoutEditPolicy extends LayoutEditPolicy {
 	 * @return the {@link List} of {@link EditPart}'s that can be used as references.
 	 */
 	private List<EditPart> getReferenceChildren(Request request) {
-		List<EditPart> allChildren = getHost().getChildren();
+		List<? extends EditPart> allChildren = getHost().getChildren();
 		ArrayList<EditPart> referenceChildren = new ArrayList<>();
 		//
 		for (EditPart editPart : allChildren) {
@@ -469,7 +469,7 @@ public abstract class AbstractFlowLayoutEditPolicy extends LayoutEditPolicy {
 		if (request instanceof AbstractCreateRequest) {
 			return reference;
 		} else {
-			List<EditPart> selectedEditParts = getHost().getViewer().getSelectedEditParts();
+			List<? extends EditPart> selectedEditParts = getHost().getViewer().getSelectedEditParts();
 			int index = children.indexOf(reference);
 			while (selectedEditParts.contains(reference)) {
 				if (index == children.size() - 1) {

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/generic/FlowContainerLayoutEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/generic/FlowContainerLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,12 +14,12 @@ import org.eclipse.wb.core.gef.policy.layout.flow.ObjectFlowLayoutEditPolicy;
 import org.eclipse.wb.core.gef.policy.selection.NonResizableSelectionEditPolicy;
 import org.eclipse.wb.core.gef.policy.validator.LayoutRequestValidators;
 import org.eclipse.wb.core.model.ObjectInfo;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.gef.graphical.policies.LayoutEditPolicy;
 import org.eclipse.wb.internal.core.model.generic.FlowContainer;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 
 /**
@@ -55,7 +55,7 @@ public final class FlowContainerLayoutEditPolicy extends ObjectFlowLayoutEditPol
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void decorateChild(EditPart child) {
+	protected void decorateChild(org.eclipse.wb.gef.core.EditPart child) {
 		if (m_container.validateComponent(child.getModel())) {
 			child.installEditPolicy(EditPolicy.SELECTION_FEEDBACK_ROLE, new NonResizableSelectionEditPolicy());
 			new SelectionEditPolicyInstaller(m_model, child).decorate();

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/menu/MenuLayoutEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/menu/MenuLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,6 @@ package org.eclipse.wb.internal.core.gef.policy.menu;
 
 import org.eclipse.wb.core.gef.policy.layout.flow.AbstractFlowLayoutEditPolicy;
 import org.eclipse.wb.draw2d.Layer;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
@@ -24,6 +23,7 @@ import org.eclipse.wb.internal.core.model.menu.IMenuItemInfo;
 import org.eclipse.wb.internal.core.model.menu.IMenuPolicy;
 import org.eclipse.wb.internal.core.model.menu.MenuObjectInfoUtils;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 
@@ -133,17 +133,17 @@ public final class MenuLayoutEditPolicy extends AbstractFlowLayoutEditPolicy {
 
 	private final ILayoutRequestValidator VALIDATOR = new ILayoutRequestValidator() {
 		@Override
-		public boolean validateCreateRequest(EditPart host, CreateRequest request) {
+		public boolean validateCreateRequest(org.eclipse.wb.gef.core.EditPart host, CreateRequest request) {
 			return m_policy.validateCreate(request.getNewObject());
 		}
 
 		@Override
-		public boolean validatePasteRequest(EditPart host, PasteRequest request) {
+		public boolean validatePasteRequest(org.eclipse.wb.gef.core.EditPart host, PasteRequest request) {
 			return m_policy.validatePaste(request.getMemento());
 		}
 
 		@Override
-		public boolean validateMoveRequest(EditPart host, ChangeBoundsRequest request) {
+		public boolean validateMoveRequest(org.eclipse.wb.gef.core.EditPart host, ChangeBoundsRequest request) {
 			for (EditPart editPart : request.getEditParts()) {
 				if (!m_policy.validateMove(editPart.getModel())) {
 					return false;
@@ -153,7 +153,7 @@ public final class MenuLayoutEditPolicy extends AbstractFlowLayoutEditPolicy {
 		}
 
 		@Override
-		public boolean validateAddRequest(EditPart host, ChangeBoundsRequest request) {
+		public boolean validateAddRequest(org.eclipse.wb.gef.core.EditPart host, ChangeBoundsRequest request) {
 			return validateMoveRequest(host, request);
 		}
 	};

--- a/org.eclipse.wb.rcp.nebula/src/org/eclipse/wb/internal/rcp/nebula/collapsiblebuttons/CollapsibleButtonsLayoutEditPolicy.java
+++ b/org.eclipse.wb.rcp.nebula/src/org/eclipse/wb/internal/rcp/nebula/collapsiblebuttons/CollapsibleButtonsLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,13 +12,13 @@ package org.eclipse.wb.internal.rcp.nebula.collapsiblebuttons;
 
 import org.eclipse.wb.core.gef.command.EditCommand;
 import org.eclipse.wb.core.gef.policy.layout.flow.AbstractFlowLayoutEditPolicy;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator.LayoutRequestValidatorStubFalse;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
 import org.eclipse.wb.gef.graphical.policies.LayoutEditPolicy;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 
@@ -67,7 +67,7 @@ public final class CollapsibleButtonsLayoutEditPolicy extends AbstractFlowLayout
 	////////////////////////////////////////////////////////////////////////////
 	private static final ILayoutRequestValidator VALIDATOR = new LayoutRequestValidatorStubFalse() {
 		@Override
-		public boolean validateMoveRequest(EditPart host, ChangeBoundsRequest request) {
+		public boolean validateMoveRequest(org.eclipse.wb.gef.core.EditPart host, ChangeBoundsRequest request) {
 			return true;
 		}
 	};

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/jface/DialogButtonBarLayoutEditPolicy.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/jface/DialogButtonBarLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,6 @@ package org.eclipse.wb.internal.rcp.gef.policy.jface;
 
 import org.eclipse.wb.core.gef.command.EditCommand;
 import org.eclipse.wb.core.gef.policy.layout.flow.AbstractFlowLayoutEditPolicy;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
 import org.eclipse.wb.gef.graphical.policies.LayoutEditPolicy;
@@ -21,6 +20,7 @@ import org.eclipse.wb.internal.rcp.model.jface.DialogInfo;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 
@@ -70,7 +70,7 @@ public final class DialogButtonBarLayoutEditPolicy extends AbstractFlowLayoutEdi
 	private static final ILayoutRequestValidator VALIDATOR =
 			new ILayoutRequestValidator.LayoutRequestValidatorStubFalse() {
 		@Override
-		public boolean validateMoveRequest(EditPart host, ChangeBoundsRequest request) {
+		public boolean validateMoveRequest(org.eclipse.wb.gef.core.EditPart host, ChangeBoundsRequest request) {
 			return true;
 		}
 	};

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/jface/action/ToolBarManagerLayoutEditPolicy.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/jface/action/ToolBarManagerLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,13 +13,13 @@ package org.eclipse.wb.internal.rcp.gef.policy.jface.action;
 import org.eclipse.wb.core.gef.command.EditCommand;
 import org.eclipse.wb.core.gef.policy.layout.flow.ObjectFlowLayoutEditPolicy;
 import org.eclipse.wb.core.gef.policy.validator.LayoutRequestValidators;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.gef.graphical.policies.LayoutEditPolicy;
 import org.eclipse.wb.internal.rcp.model.jface.action.ActionContributionItemInfo;
 import org.eclipse.wb.internal.rcp.model.jface.action.ContributionItemInfo;
 import org.eclipse.wb.internal.rcp.model.jface.action.ToolBarManagerInfo;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/rcp/perspective/PageLayoutCreateFolderLayoutEditPolicy.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/rcp/perspective/PageLayoutCreateFolderLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,6 @@ import org.eclipse.wb.core.gef.policy.PolicyUtils;
 import org.eclipse.wb.core.gef.policy.layout.flow.AbstractFlowLayoutEditPolicy;
 import org.eclipse.wb.core.gef.policy.validator.LayoutRequestValidators;
 import org.eclipse.wb.core.model.JavaInfo;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.gef.tree.policies.LayoutEditPolicy;
 import org.eclipse.wb.internal.rcp.model.rcp.PdeUtils.ViewInfo;
@@ -25,6 +24,7 @@ import org.eclipse.wb.internal.rcp.model.rcp.perspective.PageLayoutCreateFolderI
 import org.eclipse.wb.internal.rcp.model.rcp.perspective.shortcuts.FastViewInfo;
 import org.eclipse.wb.internal.rcp.model.rcp.perspective.shortcuts.ViewShortcutInfo;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/rcp/perspective/shortcuts/FastViewContainerLayoutEditPolicy.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/rcp/perspective/shortcuts/FastViewContainerLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,6 @@ package org.eclipse.wb.internal.rcp.gef.policy.rcp.perspective.shortcuts;
 import org.eclipse.wb.core.gef.command.EditCommand;
 import org.eclipse.wb.core.gef.policy.layout.flow.AbstractFlowLayoutEditPolicy;
 import org.eclipse.wb.core.gef.policy.validator.LayoutRequestValidators;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.gef.tree.policies.LayoutEditPolicy;
 import org.eclipse.wb.internal.rcp.gef.policy.rcp.perspective.ViewDropRequest;
@@ -22,6 +21,7 @@ import org.eclipse.wb.internal.rcp.model.rcp.perspective.PageLayoutInfo;
 import org.eclipse.wb.internal.rcp.model.rcp.perspective.shortcuts.FastViewContainerInfo;
 import org.eclipse.wb.internal.rcp.model.rcp.perspective.shortcuts.FastViewInfo;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/rcp/perspective/shortcuts/PerspectiveShortcutContainerLayoutEditPolicy.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/rcp/perspective/shortcuts/PerspectiveShortcutContainerLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,6 @@ package org.eclipse.wb.internal.rcp.gef.policy.rcp.perspective.shortcuts;
 import org.eclipse.wb.core.gef.command.EditCommand;
 import org.eclipse.wb.core.gef.policy.layout.flow.AbstractFlowLayoutEditPolicy;
 import org.eclipse.wb.core.gef.policy.validator.LayoutRequestValidators;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.gef.tree.policies.LayoutEditPolicy;
 import org.eclipse.wb.internal.rcp.gef.policy.rcp.perspective.PerspectiveDropRequest;
@@ -22,6 +21,7 @@ import org.eclipse.wb.internal.rcp.model.rcp.perspective.PageLayoutInfo;
 import org.eclipse.wb.internal.rcp.model.rcp.perspective.shortcuts.PerspectiveShortcutContainerInfo;
 import org.eclipse.wb.internal.rcp.model.rcp.perspective.shortcuts.PerspectiveShortcutInfo;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/rcp/perspective/shortcuts/ViewShortcutContainerLayoutEditPolicy.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/rcp/perspective/shortcuts/ViewShortcutContainerLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,6 @@ package org.eclipse.wb.internal.rcp.gef.policy.rcp.perspective.shortcuts;
 import org.eclipse.wb.core.gef.command.EditCommand;
 import org.eclipse.wb.core.gef.policy.layout.flow.AbstractFlowLayoutEditPolicy;
 import org.eclipse.wb.core.gef.policy.validator.LayoutRequestValidators;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.gef.tree.policies.LayoutEditPolicy;
 import org.eclipse.wb.internal.rcp.gef.policy.rcp.perspective.ViewDropRequest;
@@ -22,6 +21,7 @@ import org.eclipse.wb.internal.rcp.model.rcp.perspective.PageLayoutInfo;
 import org.eclipse.wb.internal.rcp.model.rcp.perspective.shortcuts.ViewShortcutContainerInfo;
 import org.eclipse.wb.internal.rcp.model.rcp.perspective.shortcuts.ViewShortcutInfo;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/MigLayoutSplitEditPolicy.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/MigLayoutSplitEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,6 @@ package org.eclipse.wb.internal.swing.MigLayout.gef;
 
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.gef.graphical.policies.LayoutEditPolicy;
 import org.eclipse.wb.internal.core.utils.check.Assert;
@@ -22,6 +21,7 @@ import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.requests.DropRequest;

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/component/JTabbedPaneLayoutEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/component/JTabbedPaneLayoutEditPolicy.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.gef.policy.component;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.graphical.policies.LayoutEditPolicy;
 import org.eclipse.wb.internal.swing.gef.part.JTabbedPaneTabEditPart;
 import org.eclipse.wb.internal.swing.gef.policy.ComponentFlowLayoutEditPolicy;
@@ -18,6 +17,7 @@ import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.JTabbedPaneInfo;
 import org.eclipse.wb.internal.swing.model.component.JTabbedPaneTabInfo;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/component/JTabbedPaneTabLayoutEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/component/JTabbedPaneTabLayoutEditPolicy.java
@@ -11,7 +11,6 @@
 package org.eclipse.wb.internal.swing.gef.policy.component;
 
 import org.eclipse.wb.core.gef.policy.validator.LayoutRequestValidators;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.gef.graphical.policies.LayoutEditPolicy;
 import org.eclipse.wb.internal.swing.gef.part.JTabbedPaneTabEditPart;
@@ -19,6 +18,7 @@ import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.JTabbedPaneInfo;
 import org.eclipse.wb.internal.swing.model.component.JTabbedPaneTabInfo;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/CardLayoutEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/CardLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,13 +10,13 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.gef.policy.layout;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.gef.graphical.policies.LayoutEditPolicy;
 import org.eclipse.wb.internal.swing.gef.policy.ComponentFlowLayoutEditPolicy;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.layout.CardLayoutInfo;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 
 /**
@@ -63,11 +63,11 @@ public final class CardLayoutEditPolicy extends ComponentFlowLayoutEditPolicy {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void decorateChild(EditPart child) {
+	protected void decorateChild(org.eclipse.wb.gef.core.EditPart child) {
 		Object model = child.getModel();
 		if (m_layout.isManagedObject(model)) {
 			EditPolicy policy = new CardLayoutSelectionEditPolicy(m_layout);
-			child.installEditPolicy(EditPolicy.SELECTION_FEEDBACK_ROLE, policy);
+			child.installEditPolicy(org.eclipse.gef.EditPolicy.SELECTION_FEEDBACK_ROLE, policy);
 		}
 	}
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/GenericFlowLayoutEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/GenericFlowLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,6 @@
 package org.eclipse.wb.internal.swing.gef.policy.layout;
 
 import org.eclipse.wb.core.gef.policy.selection.NonResizableSelectionEditPolicy;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.gef.graphical.policies.LayoutEditPolicy;
 import org.eclipse.wb.internal.core.utils.state.GlobalState;
@@ -19,6 +18,7 @@ import org.eclipse.wb.internal.swing.gef.policy.ComponentFlowLayoutEditPolicy;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.layout.GenericFlowLayoutInfo;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 
 /**
@@ -57,7 +57,7 @@ public abstract class GenericFlowLayoutEditPolicy extends ComponentFlowLayoutEdi
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void decorateChild(EditPart child) {
+	protected void decorateChild(org.eclipse.wb.gef.core.EditPart child) {
 		if (child.getModel() instanceof ComponentInfo) {
 			child.installEditPolicy(EditPolicy.SELECTION_FEEDBACK_ROLE, new NonResizableSelectionEditPolicy());
 		}


### PR DESCRIPTION
This removes the import of our EditPart subclass in favor of the GEF interface.