### PR TITLE
[GEF] Adapt ILayoutRequestValudator methods to use GEF EditPart directly

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/policy/nonvisual/NonVisualValidator.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/policy/nonvisual/NonVisualValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,6 @@
 package org.eclipse.wb.internal.core.gef.policy.nonvisual;
 
 import org.eclipse.wb.core.model.JavaInfo;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
 import org.eclipse.wb.gef.core.requests.CreateRequest;
@@ -24,6 +23,8 @@ import org.eclipse.wb.internal.core.model.description.ComponentDescription;
 import org.eclipse.wb.internal.core.preferences.IPreferenceConstants;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
+
+import org.eclipse.gef.EditPart;
 
 import org.apache.commons.lang3.StringUtils;
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gefTree/policy/ArrayObjectRequestValidator.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gefTree/policy/ArrayObjectRequestValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,6 @@
 package org.eclipse.wb.internal.core.gefTree.policy;
 
 import org.eclipse.wb.core.model.JavaInfo;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
 import org.eclipse.wb.gef.core.requests.CreateRequest;
@@ -21,6 +20,8 @@ import org.eclipse.wb.internal.core.model.variable.EmptyVariableSupport;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
+
+import org.eclipse.gef.EditPart;
 
 /**
  * Implementation of {@link ILayoutRequestValidator} for validate items for <i>array object</i>.

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/policies/ILayoutRequestValidator.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/policies/ILayoutRequestValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,11 +10,11 @@
  *******************************************************************************/
 package org.eclipse.wb.gef.core.policies;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
 import org.eclipse.wb.gef.core.requests.CreateRequest;
 import org.eclipse.wb.gef.core.requests.PasteRequest;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 
 /**

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/validator/AbstractLayoutRequestValidator.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/validator/AbstractLayoutRequestValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.core.gef.policy.validator;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
 import org.eclipse.wb.gef.core.requests.CreateRequest;
@@ -20,6 +19,8 @@ import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.state.GlobalState;
 import org.eclipse.wb.internal.core.utils.state.ILayoutRequestValidatorHelper;
+
+import org.eclipse.gef.EditPart;
 
 import java.util.List;
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/validator/AbstractModelClassLayoutRequestValidator.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/validator/AbstractModelClassLayoutRequestValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,9 +10,10 @@
  *******************************************************************************/
 package org.eclipse.wb.core.gef.policy.validator;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.internal.core.model.description.IComponentDescription;
+
+import org.eclipse.gef.EditPart;
 
 /**
  * Abstract implementation of {@link ILayoutRequestValidator} for specific type of model objects.

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/validator/BorderOfChildLayoutRequestValidator.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/validator/BorderOfChildLayoutRequestValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,6 @@ package org.eclipse.wb.core.gef.policy.validator;
 
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
 import org.eclipse.wb.gef.core.requests.CreateRequest;
@@ -23,6 +22,7 @@ import org.eclipse.wb.internal.core.utils.state.IParametersProvider;
 
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.requests.DropRequest;
 
 import java.util.List;
@@ -119,7 +119,7 @@ public final class BorderOfChildLayoutRequestValidator implements ILayoutRequest
 	}
 
 	private static boolean isChildOf_selectedEditPart(EditPart child) {
-		List<EditPart> selectedEditParts = child.getViewer().getSelectedEditParts();
+		List<? extends EditPart> selectedEditParts = child.getViewer().getSelectedEditParts();
 		return selectedEditParts.size() == 1 && areParentChild(selectedEditParts.get(0), child);
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/validator/CachingLayoutRequestValidator.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/validator/CachingLayoutRequestValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,12 +10,12 @@
  *******************************************************************************/
 package org.eclipse.wb.core.gef.policy.validator;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
 import org.eclipse.wb.gef.core.requests.CreateRequest;
 import org.eclipse.wb.gef.core.requests.PasteRequest;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 
 import java.util.HashMap;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/validator/CompatibleLayoutRequestValidator.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/validator/CompatibleLayoutRequestValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,13 +10,14 @@
  *******************************************************************************/
 package org.eclipse.wb.core.gef.policy.validator;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.internal.core.model.description.IComponentDescription;
 import org.eclipse.wb.internal.core.model.util.ScriptUtils;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.state.GlobalState;
+
+import org.eclipse.gef.EditPart;
 
 import org.apache.commons.lang3.StringUtils;
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/validator/ComponentClassLayoutRequestValidator.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/validator/ComponentClassLayoutRequestValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,11 +10,12 @@
  *******************************************************************************/
 package org.eclipse.wb.core.gef.policy.validator;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.internal.core.model.description.IComponentDescription;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.core.utils.state.GlobalState;
+
+import org.eclipse.gef.EditPart;
 
 /**
  * {@link ILayoutRequestValidator} that checks that "child" has required component class.

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/validator/LayoutRequestValidators.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/validator/LayoutRequestValidators.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,12 +10,12 @@
  *******************************************************************************/
 package org.eclipse.wb.core.gef.policy.validator;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
 import org.eclipse.wb.gef.core.requests.CreateRequest;
 import org.eclipse.wb.gef.core.requests.PasteRequest;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 
 /**

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/generic/AbstractContainerRequestValidator.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/generic/AbstractContainerRequestValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.gef.policy.layout.generic;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
 import org.eclipse.wb.gef.core.requests.CreateRequest;
@@ -20,6 +19,8 @@ import org.eclipse.wb.internal.core.model.generic.AbstractContainer;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.state.GlobalState;
+
+import org.eclipse.gef.EditPart;
 
 import java.util.List;
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/menu/MenuLayoutEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/menu/MenuLayoutEditPolicy.java
@@ -133,17 +133,17 @@ public final class MenuLayoutEditPolicy extends AbstractFlowLayoutEditPolicy {
 
 	private final ILayoutRequestValidator VALIDATOR = new ILayoutRequestValidator() {
 		@Override
-		public boolean validateCreateRequest(org.eclipse.wb.gef.core.EditPart host, CreateRequest request) {
+		public boolean validateCreateRequest(EditPart host, CreateRequest request) {
 			return m_policy.validateCreate(request.getNewObject());
 		}
 
 		@Override
-		public boolean validatePasteRequest(org.eclipse.wb.gef.core.EditPart host, PasteRequest request) {
+		public boolean validatePasteRequest(EditPart host, PasteRequest request) {
 			return m_policy.validatePaste(request.getMemento());
 		}
 
 		@Override
-		public boolean validateMoveRequest(org.eclipse.wb.gef.core.EditPart host, ChangeBoundsRequest request) {
+		public boolean validateMoveRequest(EditPart host, ChangeBoundsRequest request) {
 			for (EditPart editPart : request.getEditParts()) {
 				if (!m_policy.validateMove(editPart.getModel())) {
 					return false;
@@ -153,7 +153,7 @@ public final class MenuLayoutEditPolicy extends AbstractFlowLayoutEditPolicy {
 		}
 
 		@Override
-		public boolean validateAddRequest(org.eclipse.wb.gef.core.EditPart host, ChangeBoundsRequest request) {
+		public boolean validateAddRequest(EditPart host, ChangeBoundsRequest request) {
 			return validateMoveRequest(host, request);
 		}
 	};

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/menu/SubmenuAwareLayoutEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/menu/SubmenuAwareLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,6 @@ import org.eclipse.wb.core.gef.policy.PolicyUtils;
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.draw2d.Layer;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
@@ -29,6 +28,7 @@ import org.eclipse.wb.internal.core.model.menu.IMenuObjectInfo;
 import org.eclipse.wb.internal.core.model.menu.MenuObjectInfoUtils;
 
 import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.requests.DropRequest;
 
@@ -78,7 +78,7 @@ public final class SubmenuAwareLayoutEditPolicy extends LayoutEditPolicy {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public EditPart getTargetEditPart(Request request) {
+	public org.eclipse.wb.gef.core.EditPart getTargetEditPart(Request request) {
 		// check that we understand this request
 		if (!isRequestCondition(request)) {
 			return null;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gefTree/policy/menu/MenuItemLayoutEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gefTree/policy/menu/MenuItemLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,6 @@ package org.eclipse.wb.internal.core.gefTree.policy.menu;
 
 import org.eclipse.wb.core.gef.command.EditCommand;
 import org.eclipse.wb.core.model.ObjectInfo;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
 import org.eclipse.wb.gef.core.requests.CreateRequest;
@@ -21,6 +20,7 @@ import org.eclipse.wb.gef.tree.policies.LayoutEditPolicy;
 import org.eclipse.wb.internal.core.model.menu.IMenuItemInfo;
 import org.eclipse.wb.internal.core.model.menu.IMenuPolicy;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 
@@ -54,7 +54,7 @@ public class MenuItemLayoutEditPolicy extends LayoutEditPolicy {
 	//
 	/////////////////////////////////////////////////////////////////////
 	@Override
-	protected boolean isGoodReferenceChild(Request request, EditPart editPart) {
+	protected boolean isGoodReferenceChild(Request request, org.eclipse.wb.gef.core.EditPart editPart) {
 		return false;
 	}
 
@@ -84,7 +84,7 @@ public class MenuItemLayoutEditPolicy extends LayoutEditPolicy {
 	}
 
 	@Override
-	protected Command getMoveCommand(final List<EditPart> moveParts, final Object referenceObject) {
+	protected Command getMoveCommand(final List<org.eclipse.wb.gef.core.EditPart> moveParts, final Object referenceObject) {
 		return new EditCommand(m_itemInfo) {
 			@Override
 			public void executeEdit() throws Exception {
@@ -96,7 +96,7 @@ public class MenuItemLayoutEditPolicy extends LayoutEditPolicy {
 	}
 
 	@Override
-	protected Command getAddCommand(List<EditPart> addParts, Object referenceObject) {
+	protected Command getAddCommand(List<org.eclipse.wb.gef.core.EditPart> addParts, Object referenceObject) {
 		return getMoveCommand(addParts, referenceObject);
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gefTree/policy/menu/MenuLayoutEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gefTree/policy/menu/MenuLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,6 @@ package org.eclipse.wb.internal.core.gefTree.policy.menu;
 
 import org.eclipse.wb.core.gef.command.EditCommand;
 import org.eclipse.wb.core.model.ObjectInfo;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
 import org.eclipse.wb.gef.core.requests.CreateRequest;
@@ -21,6 +20,7 @@ import org.eclipse.wb.gef.tree.policies.LayoutEditPolicy;
 import org.eclipse.wb.internal.core.model.menu.IMenuInfo;
 import org.eclipse.wb.internal.core.model.menu.IMenuPolicy;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 
@@ -55,7 +55,7 @@ public final class MenuLayoutEditPolicy extends LayoutEditPolicy {
 	//
 	/////////////////////////////////////////////////////////////////////
 	@Override
-	protected boolean isGoodReferenceChild(Request request, EditPart editPart) {
+	protected boolean isGoodReferenceChild(Request request, org.eclipse.wb.gef.core.EditPart editPart) {
 		return true;
 	}
 
@@ -85,7 +85,7 @@ public final class MenuLayoutEditPolicy extends LayoutEditPolicy {
 	}
 
 	@Override
-	protected Command getMoveCommand(final List<EditPart> moveParts, final Object referenceObject) {
+	protected Command getMoveCommand(final List<org.eclipse.wb.gef.core.EditPart> moveParts, final Object referenceObject) {
 		return new EditCommand(m_menuInfo) {
 			@Override
 			public void executeEdit() throws Exception {
@@ -97,7 +97,7 @@ public final class MenuLayoutEditPolicy extends LayoutEditPolicy {
 	}
 
 	@Override
-	protected Command getAddCommand(List<EditPart> addParts, Object referenceObject) {
+	protected Command getAddCommand(List<org.eclipse.wb.gef.core.EditPart> addParts, Object referenceObject) {
 		return getMoveCommand(addParts, referenceObject);
 	}
 

--- a/org.eclipse.wb.rcp.nebula/src/org/eclipse/wb/internal/rcp/nebula/collapsiblebuttons/CollapsibleButtonsLayoutEditPolicy.java
+++ b/org.eclipse.wb.rcp.nebula/src/org/eclipse/wb/internal/rcp/nebula/collapsiblebuttons/CollapsibleButtonsLayoutEditPolicy.java
@@ -67,7 +67,7 @@ public final class CollapsibleButtonsLayoutEditPolicy extends AbstractFlowLayout
 	////////////////////////////////////////////////////////////////////////////
 	private static final ILayoutRequestValidator VALIDATOR = new LayoutRequestValidatorStubFalse() {
 		@Override
-		public boolean validateMoveRequest(org.eclipse.wb.gef.core.EditPart host, ChangeBoundsRequest request) {
+		public boolean validateMoveRequest(EditPart host, ChangeBoundsRequest request) {
 			return true;
 		}
 	};

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/jface/DialogButtonBarLayoutEditPolicy.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/jface/DialogButtonBarLayoutEditPolicy.java
@@ -70,7 +70,7 @@ public final class DialogButtonBarLayoutEditPolicy extends AbstractFlowLayoutEdi
 	private static final ILayoutRequestValidator VALIDATOR =
 			new ILayoutRequestValidator.LayoutRequestValidatorStubFalse() {
 		@Override
-		public boolean validateMoveRequest(org.eclipse.wb.gef.core.EditPart host, ChangeBoundsRequest request) {
+		public boolean validateMoveRequest(EditPart host, ChangeBoundsRequest request) {
 			return true;
 		}
 	};

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/menu/MenuBarDropLayoutEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/menu/MenuBarDropLayoutEditPolicy.java
@@ -13,7 +13,6 @@ package org.eclipse.wb.internal.swing.gef.policy.menu;
 import org.eclipse.wb.core.gef.command.EditCommand;
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.border.LineBorder;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator.LayoutRequestValidatorStubFalse;
 import org.eclipse.wb.gef.core.requests.CreateRequest;
@@ -28,6 +27,7 @@ import org.eclipse.draw2d.TextUtilities;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/menu/MenuPopupDropLayoutEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/menu/MenuPopupDropLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,6 @@ import org.eclipse.wb.core.gef.policy.layout.LayoutPolicyUtils2;
 import org.eclipse.wb.core.gef.policy.layout.LayoutPolicyUtils2.IPasteProcessor;
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
 import org.eclipse.wb.gef.core.requests.CreateRequest;
@@ -29,6 +28,7 @@ import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.menu.JMenuBarInfo;
 import org.eclipse.wb.internal.swing.model.component.menu.JPopupMenuInfo;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/menu/MenuBarDropLayoutEditPolicy.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/menu/MenuBarDropLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,6 @@ import org.eclipse.wb.core.gef.part.AbstractComponentEditPart;
 import org.eclipse.wb.core.gef.part.menu.MenuEditPartFactory;
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.border.LineBorder;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator.LayoutRequestValidatorStubFalse;
 import org.eclipse.wb.gef.core.requests.CreateRequest;
@@ -34,6 +33,7 @@ import org.eclipse.draw2d.TextUtilities;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.swt.graphics.FontMetrics;

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gefTree/policy/menu/MenuBarDropLayoutEditPolicy.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gefTree/policy/menu/MenuBarDropLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,6 @@
 package org.eclipse.wb.internal.swt.gefTree.policy.menu;
 
 import org.eclipse.wb.core.gef.command.EditCommand;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator.LayoutRequestValidatorStubFalse;
 import org.eclipse.wb.gef.core.requests.CreateRequest;
@@ -19,6 +18,7 @@ import org.eclipse.wb.gef.tree.policies.LayoutEditPolicy;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 import org.eclipse.wb.internal.swt.model.widgets.menu.MenuInfo;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 
@@ -51,7 +51,7 @@ public class MenuBarDropLayoutEditPolicy extends LayoutEditPolicy {
 	}
 
 	@Override
-	protected boolean isGoodReferenceChild(Request request, EditPart editPart) {
+	protected boolean isGoodReferenceChild(Request request, org.eclipse.wb.gef.core.EditPart editPart) {
 		return false;
 	}
 


### PR DESCRIPTION
This removes the import of our EditPart subclass in favor of the GEF interface.