### PR TITLE
[Draw2D] Paint property values using Graphics instead of GC object

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/BooleanObjectPropertyEditor.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/BooleanObjectPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,7 @@ import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
 import org.eclipse.wb.internal.core.utils.ui.DrawUtils;
 
-import org.eclipse.swt.graphics.GC;
+import org.eclipse.draw2d.Graphics;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
 
@@ -45,25 +45,25 @@ public final class BooleanObjectPropertyEditor extends PropertyEditor {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public void paint(Property property, GC gc, int x, int y, int width, int height) throws Exception {
+	public void paint(Property property, Graphics graphics, int x, int y, int width, int height) throws Exception {
 		Object value = property.getValue();
 		if (value instanceof Boolean) {
 			boolean booleanValue = ((Boolean) value).booleanValue();
 			Image image = booleanValue ? m_trueImage : m_falseImage;
 			String text = Boolean.toString(booleanValue);
-			paint(gc, x, y, width, height, text, image);
+			paint(graphics, x, y, width, height, text, image);
 		}
 		if (value == null) {
 			Image image = m_nullImage;
 			String text = "null";
-			paint(gc, x, y, width, height, text, image);
+			paint(graphics, x, y, width, height, text, image);
 		}
 	}
 
-	private void paint(GC gc, int x, int y, int width, int height, String text, Image image) {
+	private void paint(Graphics graphics, int x, int y, int width, int height, String text, Image image) {
 		// draw image
 		{
-			DrawUtils.drawImageCV(gc, image, x, y, height);
+			DrawUtils.drawImageCV(graphics, image, x, y, height);
 			// prepare new position/width
 			int imageWidth = image.getBounds().width + 2;
 			x += imageWidth;
@@ -71,7 +71,7 @@ public final class BooleanObjectPropertyEditor extends PropertyEditor {
 		}
 		// draw text
 		{
-			DrawUtils.drawStringCV(gc, text, x, y, width, height);
+			DrawUtils.drawStringCV(graphics, text, x, y, width, height);
 		}
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/BooleanPropertyEditor.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/BooleanPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,7 @@ import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
 import org.eclipse.wb.internal.core.utils.ui.DrawUtils;
 
-import org.eclipse.swt.graphics.GC;
+import org.eclipse.draw2d.Graphics;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
 
@@ -46,32 +46,32 @@ public final class BooleanPropertyEditor extends PropertyEditor {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public void paint(Property property, GC gc, int x, int y, int width, int height) throws Exception {
+	public void paint(Property property, Graphics graphics, int x, int y, int width, int height) throws Exception {
 		Object value = property.getValue();
 		if (value instanceof Boolean) {
 			boolean booleanValue = ((Boolean) value).booleanValue();
 			Image image = booleanValue ? m_trueImage : m_falseImage;
 			String text = Boolean.toString(booleanValue);
-			paint(gc, x, y, width, height, image, text);
+			paint(graphics, x, y, width, height, image, text);
 		} else {
-			paint(gc, x, y, width, height, m_unknownImage, "unknown");
+			paint(graphics, x, y, width, height, m_unknownImage, "unknown");
 		}
 	}
 
 	/**
 	 * Paints {@link Image} and text.
 	 */
-	private void paint(GC gc, int x, int y, int width, int height, Image image, String text) {
+	private void paint(Graphics graphics, int x, int y, int width, int height, Image image, String text) {
 		// draw image
 		{
-			DrawUtils.drawImageCV(gc, image, x, y, height);
+			DrawUtils.drawImageCV(graphics, image, x, y, height);
 			// prepare new position/width
 			int imageWidth = image.getBounds().width + 2;
 			x += imageWidth;
 			width -= imageWidth;
 		}
 		// draw text
-		DrawUtils.drawStringCV(gc, text, x, y, width, height);
+		DrawUtils.drawStringCV(graphics, text, x, y, width, height);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/PropertyEditor.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/PropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ import org.eclipse.wb.internal.core.model.property.editor.presentation.PropertyE
 import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
 import org.eclipse.wb.internal.core.utils.IAdaptable;
 
+import org.eclipse.draw2d.Graphics;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.graphics.GC;
@@ -45,7 +46,7 @@ public abstract class PropertyEditor implements IAdaptable {
 	/**
 	 * Paints given {@link Property} given rectangle <code>(x, y, width, height)</code> of {@link GC}.
 	 */
-	public abstract void paint(Property property, GC gc, int x, int y, int width, int height)
+	public abstract void paint(Property property, Graphics graphics, int x, int y, int width, int height)
 			throws Exception;
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/TextDisplayPropertyEditor.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/TextDisplayPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,7 @@ import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
 import org.eclipse.wb.internal.core.model.property.table.PropertyTooltipProvider;
 import org.eclipse.wb.internal.core.utils.ui.DrawUtils;
 
-import org.eclipse.swt.graphics.GC;
+import org.eclipse.draw2d.Graphics;
 
 /**
  * Abstract {@link PropertyEditor} for displaying text as {@link Property} value in
@@ -31,10 +31,10 @@ public abstract class TextDisplayPropertyEditor extends PropertyEditor {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public void paint(Property property, GC gc, int x, int y, int width, int height) throws Exception {
+	public void paint(Property property, Graphics graphics, int x, int y, int width, int height) throws Exception {
 		String text = getText(property);
 		if (text != null) {
-			DrawUtils.drawStringCV(gc, text, x, y, width, height);
+			DrawUtils.drawStringCV(graphics, text, x, y, width, height);
 		}
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/table/PropertyTable.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/table/PropertyTable.java
@@ -20,10 +20,13 @@ import org.eclipse.wb.internal.core.model.property.editor.PropertyEditor;
 import org.eclipse.wb.internal.core.model.property.editor.complex.IComplexPropertyEditor;
 import org.eclipse.wb.internal.core.model.property.editor.presentation.PropertyEditorPresentation;
 import org.eclipse.wb.internal.core.utils.check.Assert;
+import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.core.utils.ui.DrawUtils;
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Cursors;
+import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.SWTGraphics;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.ISelectionProvider;
@@ -1214,7 +1217,14 @@ public class PropertyTable extends Canvas implements ISelectionProvider {
 				int x = m_splitter + 4;
 				int w = width - x - MARGIN_RIGHT;
 				// paint value
-				property.getEditor().paint(property, gc, x, y, w, height);
+				Graphics graphics = new SWTGraphics(gc);
+				try {
+					property.getEditor().paint(property, graphics, x, y, w, height);
+				} finally {
+					// update clipping
+					ReflectionUtils.invokeMethod(graphics, "checkGC()");
+					graphics.dispose();
+				}
 			}
 		} catch (Throwable e) {
 			DesignerPlugin.log(e);

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/beans/ComboPropertyEditor.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/beans/ComboPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,7 @@ import org.eclipse.wb.internal.core.model.property.editor.IValueSourcePropertyEd
 import org.eclipse.wb.internal.core.model.property.editor.PropertyEditor;
 import org.eclipse.wb.internal.core.model.property.editor.presentation.PropertyEditorPresentation;
 
-import org.eclipse.swt.graphics.GC;
+import org.eclipse.draw2d.Graphics;
 
 /**
  * The {@link PropertyEditor} wrapper for tag's based AWT {@link java.beans.PropertyEditor}.
@@ -88,8 +88,8 @@ IValueSourcePropertyEditor {
 	}
 
 	@Override
-	public void paint(Property property, GC gc, int x, int y, int width, int height) throws Exception {
-		m_editorWrapper.paint(property, gc, x, y, width, height);
+	public void paint(Property property, Graphics graphics, int x, int y, int width, int height) throws Exception {
+		m_editorWrapper.paint(property, graphics, x, y, width, height);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/beans/PropertyEditorWrapper.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/beans/PropertyEditorWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,11 +23,11 @@ import org.eclipse.wb.internal.swing.model.ModelMessages;
 import org.eclipse.wb.internal.swing.utils.SwingImageUtils;
 import org.eclipse.wb.internal.swing.utils.SwingUtils;
 
+import org.eclipse.draw2d.Graphics;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.FontData;
-import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 
 import org.apache.commons.lang3.StringUtils;
@@ -132,13 +132,13 @@ public final class PropertyEditorWrapper {
 		return m_presentation;
 	}
 
-	public void paint(Property property, GC gc, int x, int y, int width, int height) throws Exception {
+	public void paint(Property property, Graphics graphics, int x, int y, int width, int height) throws Exception {
 		configure(property);
 		m_propertyEditor.setValue(property.getValue());
 		// paint
 		if (m_propertyEditor.isPaintable()) {
-			Image image = paintValue(gc, width, height).createImage();
-			gc.drawImage(image, x, y);
+			Image image = paintValue(graphics, width, height).createImage();
+			graphics.drawImage(image, x, y);
 			image.dispose();
 			return;
 		}
@@ -146,18 +146,18 @@ public final class PropertyEditorWrapper {
 		{
 			String text = m_propertyEditor.getAsText();
 			if (!StringUtils.isEmpty(text)) {
-				DrawUtils.drawStringCV(gc, text, x, y, width, height);
+				DrawUtils.drawStringCV(graphics, text, x, y, width, height);
 			}
 		}
 	}
 
-	private ImageDescriptor paintValue(GC gc, int width, int height) throws Exception {
+	private ImageDescriptor paintValue(Graphics graphics, int width, int height) throws Exception {
 		// create AWT graphics
 		BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
 		Graphics2D graphics2D = (Graphics2D) image.getGraphics();
 		// prepare color's
-		Color background = gc.getBackground();
-		Color foreground = gc.getForeground();
+		Color background = graphics.getBackgroundColor();
+		Color foreground = graphics.getForegroundColor();
 		// fill graphics
 		graphics2D.setColor(SwingUtils.getAWTColor(background));
 		graphics2D.fillRect(0, 0, width, height);
@@ -165,7 +165,7 @@ public final class PropertyEditorWrapper {
 		graphics2D.setBackground(SwingUtils.getAWTColor(background));
 		graphics2D.setColor(SwingUtils.getAWTColor(foreground));
 		// set font
-		FontData[] fontData = gc.getFont().getFontData();
+		FontData[] fontData = graphics.getFont().getFontData();
 		String name = fontData.length > 0 ? fontData[0].getName() : "Arial";
 		graphics2D.setFont(new java.awt.Font(name,
 				java.awt.Font.PLAIN,

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/beans/TextPropertyEditor.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/beans/TextPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,7 @@ import org.eclipse.wb.internal.core.model.property.editor.PropertyEditor;
 import org.eclipse.wb.internal.core.model.property.editor.presentation.PropertyEditorPresentation;
 import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
 
-import org.eclipse.swt.graphics.GC;
+import org.eclipse.draw2d.Graphics;
 import org.eclipse.swt.graphics.Point;
 
 /**
@@ -116,7 +116,7 @@ IClipboardSourceProvider {
 	}
 
 	@Override
-	public void paint(Property property, GC gc, int x, int y, int width, int height) throws Exception {
-		m_editorWrapper.paint(property, gc, x, y, width, height);
+	public void paint(Property property, Graphics graphics, int x, int y, int width, int height) throws Exception {
+		m_editorWrapper.paint(property, graphics, x, y, width, height);
 	}
 }

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/color/ColorPropertyEditor.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/color/ColorPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,6 +33,7 @@ import org.eclipse.wb.internal.swing.model.ModelMessages;
 
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.Graphics;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.QualifiedName;
@@ -42,7 +43,6 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CLabel;
 import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Composite;
@@ -93,7 +93,7 @@ public final class ColorPropertyEditor extends PropertyEditor {
 	}
 
 	@Override
-	public void paint(Property property, GC gc, int x, int y, int width, int height)
+	public void paint(Property property, Graphics graphics, int x, int y, int width, int height)
 			throws Exception {
 		Object value = property.getValue();
 		if (value instanceof java.awt.Color) {
@@ -103,8 +103,8 @@ public final class ColorPropertyEditor extends PropertyEditor {
 				Color swtColor =
 						new Color(null, awtColor.getRed(), awtColor.getGreen(), awtColor.getBlue());
 				//
-				Color oldBackground = gc.getBackground();
-				Color oldForeground = gc.getForeground();
+				Color oldBackground = graphics.getBackgroundColor();
+				Color oldForeground = graphics.getForegroundColor();
 				try {
 					int width_c = SAMPLE_SIZE;
 					int height_c = SAMPLE_SIZE;
@@ -118,22 +118,22 @@ public final class ColorPropertyEditor extends PropertyEditor {
 					}
 					// fill
 					{
-						gc.setBackground(swtColor);
-						gc.fillRectangle(x_c, y_c, width_c, height_c);
+						graphics.setBackgroundColor(swtColor);
+						graphics.fillRectangle(x_c, y_c, width_c, height_c);
 					}
 					// draw line
-					gc.setForeground(ColorConstants.gray);
-					gc.drawRectangle(x_c, y_c, width_c, height_c);
+					graphics.setForegroundColor(ColorConstants.gray);
+					graphics.drawRectangle(x_c, y_c, width_c, height_c);
 				} finally {
-					gc.setBackground(oldBackground);
-					gc.setForeground(oldForeground);
+					graphics.setBackgroundColor(oldBackground);
+					graphics.setForegroundColor(oldForeground);
 					swtColor.dispose();
 				}
 			}
 			// draw color text
 			{
 				String text = getText(property);
-				DrawUtils.drawStringCV(gc, text, x, y, width, height);
+				DrawUtils.drawStringCV(graphics, text, x, y, width, height);
 			}
 		}
 	}

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/property/editor/color/ColorPropertyEditor.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/property/editor/color/ColorPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -44,6 +44,7 @@ import org.eclipse.wb.internal.swt.support.SwtSupport;
 
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.Graphics;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.QualifiedName;
@@ -54,7 +55,6 @@ import org.eclipse.jface.resource.ResourceManager;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Composite;
@@ -125,15 +125,15 @@ public final class ColorPropertyEditor extends PropertyEditor implements IClipbo
 	}
 
 	@Override
-	public void paint(Property property, GC gc, int x, int y, int width, int height)
+	public void paint(Property property, Graphics graphics, int x, int y, int width, int height)
 			throws Exception {
 		Object value = property.getValue();
 		if (value != Property.UNKNOWN_VALUE && value != null) {
 			Color color = ColorSupport.getColor(value);
 			// draw color sample
 			{
-				Color oldBackground = gc.getBackground();
-				Color oldForeground = gc.getForeground();
+				Color oldBackground = graphics.getBackgroundColor();
+				Color oldForeground = graphics.getForegroundColor();
 				try {
 					int width_c = SAMPLE_SIZE;
 					int height_c = SAMPLE_SIZE;
@@ -147,22 +147,22 @@ public final class ColorPropertyEditor extends PropertyEditor implements IClipbo
 					}
 					// fill
 					{
-						gc.setBackground(color);
-						gc.fillRectangle(x_c, y_c, width_c, height_c);
+						graphics.setBackgroundColor(color);
+						graphics.fillRectangle(x_c, y_c, width_c, height_c);
 					}
 					// draw line
-					gc.setForeground(ColorConstants.gray);
-					gc.drawRectangle(x_c, y_c, width_c, height_c);
+					graphics.setForegroundColor(ColorConstants.gray);
+					graphics.drawRectangle(x_c, y_c, width_c, height_c);
 				} finally {
-					gc.setBackground(oldBackground);
-					gc.setForeground(oldForeground);
+					graphics.setBackgroundColor(oldBackground);
+					graphics.setForegroundColor(oldForeground);
 					color.dispose();
 				}
 			}
 			// draw color text
 			{
 				String text = getText(property);
-				DrawUtils.drawStringCV(gc, text, x, y, width, height);
+				DrawUtils.drawStringCV(graphics, text, x, y, width, height);
 			}
 		}
 	}


### PR DESCRIPTION
In preparation of converting the property table into a proper GEF viewer, the dependent classes need to be adjusted to use the Draw2D API.

This change only wraps the GC object in a Graphics object, which is is then passed as an argument to the property editors. Internally, this Graphics object then calls the corresponding GC methods.

In the future, this Graphics object is supplied by the viewer when painting the Draw2D figures and no longer needs to be constructed by us.