### PR TITLE
Fix sporadic NullPointerException in VariableUtils

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/variable/ExposedFieldVariableSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/variable/ExposedFieldVariableSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,7 @@ import org.eclipse.wb.internal.core.model.JavaInfoUtils;
 import org.eclipse.wb.internal.core.utils.ast.NodeTarget;
 import org.eclipse.wb.internal.core.utils.ast.StatementTarget;
 
-import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.NamingConventions;
 import org.eclipse.jdt.core.dom.Statement;
 
 import org.apache.commons.lang3.StringUtils;
@@ -74,8 +74,7 @@ public final class ExposedFieldVariableSupport extends AbstractNoNameVariableSup
 		name =
 				new VariableUtils(m_javaInfo).stripPrefixSuffix(
 						name,
-						JavaCore.CODEASSIST_FIELD_PREFIXES,
-						JavaCore.CODEASSIST_FIELD_SUFFIXES);
+						NamingConventions.VK_INSTANCE_FIELD);
 		name = StringUtils.capitalize(name);
 		return m_hostJavaInfo.getVariableSupport().getComponentName() + name;
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/variable/FieldUniqueVariableSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/variable/FieldUniqueVariableSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,7 @@ import org.eclipse.wb.internal.core.utils.ast.NodeTarget;
 import org.eclipse.wb.internal.core.utils.ast.StatementTarget;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 
-import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.NamingConventions;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.Assignment;
 import org.eclipse.jdt.core.dom.Block;
@@ -127,10 +127,8 @@ public final class FieldUniqueVariableSupport extends FieldVariableSupport {
 				m_utils.convertName(
 						assignment.getStartPosition(),
 						getName(),
-						JavaCore.CODEASSIST_FIELD_PREFIXES,
-						JavaCore.CODEASSIST_FIELD_SUFFIXES,
-						JavaCore.CODEASSIST_LOCAL_PREFIXES,
-						JavaCore.CODEASSIST_LOCAL_SUFFIXES,
+						NamingConventions.VK_INSTANCE_FIELD,
+						NamingConventions.VK_LOCAL,
 						m_declaration);
 		setName(localName);
 		// replace "this.fieldName" with "localName"

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/variable/FieldVariableSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/variable/FieldVariableSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,7 @@ import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.utils.ast.AstNodeUtils;
 import org.eclipse.wb.internal.core.utils.ast.NodeTarget;
 
-import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.NamingConventions;
 import org.eclipse.jdt.core.dom.Block;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.FieldDeclaration;
@@ -60,8 +60,7 @@ public abstract class FieldVariableSupport extends AbstractSimpleVariableSupport
 	public String getComponentName() {
 		return m_utils.stripPrefixSuffix(
 				getName(),
-				JavaCore.CODEASSIST_FIELD_PREFIXES,
-				JavaCore.CODEASSIST_FIELD_SUFFIXES);
+				NamingConventions.VK_INSTANCE_FIELD);
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -118,8 +117,7 @@ public abstract class FieldVariableSupport extends AbstractSimpleVariableSupport
 	String decorateTextName(String newName) {
 		return m_utils.addPrefixSuffix(
 				newName,
-				JavaCore.CODEASSIST_FIELD_PREFIXES,
-				JavaCore.CODEASSIST_FIELD_SUFFIXES);
+				NamingConventions.VK_INSTANCE_FIELD);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/variable/LazyVariableSupportUtils.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/variable/LazyVariableSupportUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,7 +22,7 @@ import org.eclipse.wb.internal.core.utils.ast.StatementTarget;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
-import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.NamingConventions;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.Assignment;
 import org.eclipse.jdt.core.dom.Block;
@@ -336,8 +336,7 @@ public final class LazyVariableSupportUtils {
 		String strippedFieldName =
 				new VariableUtils(javaInfo).stripPrefixSuffix(
 						fieldName,
-						JavaCore.CODEASSIST_FIELD_PREFIXES,
-						JavaCore.CODEASSIST_FIELD_SUFFIXES);
+						NamingConventions.VK_INSTANCE_FIELD);
 		return "get" + StringUtils.capitalize(strippedFieldName);
 	}
 


### PR DESCRIPTION
Use the JDT NamingConventions class for adding or removing the prefix and/or suffix of a given variable name. This avoids having to explicitly load the project-specific prefix/suffix properties.

Resolves #717