### PR TITLE
[SimRel] Prepare workspace for 2024-06 release

### DIFF
--- a/org.eclipse.wb.core.databinding.xsd/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core.databinding.xsd/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.core.databinding.xsd;singleton:=true
 Bundle-Vendor: %providerName
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.100.qualifier
 Export-Package: org.eclipse.wb.core.databinding.xsd.component
 Import-Package: jakarta.xml.bind;version="[3.0.0,5.0.0)",
  jakarta.xml.bind.annotation;version="[3.0.0,5.0.0)",

--- a/org.eclipse.wb.core.databinding.xsd/pom.xml
+++ b/org.eclipse.wb.core.databinding.xsd/pom.xml
@@ -13,6 +13,7 @@
 	<artifactId>org.eclipse.wb.core.databinding.xsd</artifactId>
 	<packaging>eclipse-plugin</packaging>
 	<name>[bundle] WindowBuilder XSD Core</name>
+	<version>1.0.100-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.eclipse.wb</groupId>
@@ -49,6 +50,32 @@
 					<packageName>org.eclipse.wb.core.databinding.xsd.component</packageName>
 					<outputDirectory>${basedir}/src-gen</outputDirectory>
 				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.glassfish.jaxb</groupId>
+						<artifactId>jaxb-xjc</artifactId>
+						<version>4.0.5</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+			<!-- Obsolete once https://github.com/eclipse-ee4j/jaxb-ri/pull/1796 is merged-->
+			<plugin>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<version>3.1.0</version>
+				<executions>
+					<execution>
+						<id>replace-timestamp</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<target>
+								<replaceregexp file="${basedir}/src-gen/META-INF/JAXB/episode_xjc.xjb" flags="m" match="^Generated on:.*$" replace="Generated on: [replaced by maven-antrun-plugin]"/>
+							</target>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/org.eclipse.wb.core.feature_feature/feature.xml
+++ b/org.eclipse.wb.core.feature_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.core.feature"
       label="%featureName"
-      version="1.15.0.qualifier"
+      version="1.16.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.wb.core">
 

--- a/org.eclipse.wb.core.java.feature_feature/feature.xml
+++ b/org.eclipse.wb.core.java.feature_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.core.java.feature"
       label="%featureName"
-      version="1.15.0.qualifier"
+      version="1.16.0.qualifier"
       provider-name="%providerName">
 
    <description>

--- a/org.eclipse.wb.core.ui.feature_feature/feature.xml
+++ b/org.eclipse.wb.core.ui.feature_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.core.ui.feature"
       label="%featureName"
-      version="1.15.0.qualifier"
+      version="1.16.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.wb.core.ui">
 

--- a/org.eclipse.wb.dependencies.feature_feature/feature.xml
+++ b/org.eclipse.wb.dependencies.feature_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.dependencies.feature"
       label="%featureName"
-      version="1.15.0.qualifier"
+      version="1.16.0.qualifier"
       provider-name="%providerName">
 
    <description>

--- a/org.eclipse.wb.doc.user.feature_feature/feature.xml
+++ b/org.eclipse.wb.doc.user.feature_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.doc.user.feature"
       label="%featureName"
-      version="1.15.0.qualifier"
+      version="1.16.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.wb.doc.user">
 

--- a/org.eclipse.wb.layout.group.feature_feature/feature.xml
+++ b/org.eclipse.wb.layout.group.feature_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.layout.group.feature"
       label="%featureName"
-      version="1.15.0.qualifier"
+      version="1.16.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.wb.layout.group">
 

--- a/org.eclipse.wb.os.feature_feature/feature.xml
+++ b/org.eclipse.wb.os.feature_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.os.feature"
       label="%featureName"
-      version="1.15.0.qualifier"
+      version="1.16.0.qualifier"
       provider-name="%providerName">
 
    <description>

--- a/org.eclipse.wb.rcp.SWT_AWT_support_feature/feature.xml
+++ b/org.eclipse.wb.rcp.SWT_AWT_support_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.rcp.SWT_AWT_support"
       label="%featureName"
-      version="1.15.0.qualifier"
+      version="1.16.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.wb.rcp.SWT_AWT">
 

--- a/org.eclipse.wb.rcp.doc.user.feature_feature/feature.xml
+++ b/org.eclipse.wb.rcp.doc.user.feature_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.rcp.doc.user.feature"
       label="%featureName"
-      version="1.15.0.qualifier"
+      version="1.16.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.wb.rcp.doc.user">
 

--- a/org.eclipse.wb.rcp.feature_feature/feature.xml
+++ b/org.eclipse.wb.rcp.feature_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.rcp.feature"
       label="%featureName"
-      version="1.15.0.qualifier"
+      version="1.16.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.wb.rcp">
 

--- a/org.eclipse.wb.swing.doc.user.feature_feature/feature.xml
+++ b/org.eclipse.wb.swing.doc.user.feature_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.swing.doc.user.feature"
       label="%featureName"
-      version="1.15.0.qualifier"
+      version="1.16.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.wb.swing.doc.user">
 

--- a/org.eclipse.wb.swing.feature_feature/feature.xml
+++ b/org.eclipse.wb.swing.feature_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.swing.feature"
       label="%featureName"
-      version="1.15.0.qualifier"
+      version="1.16.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.wb.swing">
 

--- a/org.eclipse.wb.swt.feature_feature/feature.xml
+++ b/org.eclipse.wb.swt.feature_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wb.swt.feature"
       label="%featureName"
-      version="1.15.0.qualifier"
+      version="1.16.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.wb.swt">
 

--- a/target-platform/mvn/wb-mvn.target
+++ b/target-platform/mvn/wb-mvn.target
@@ -7,7 +7,7 @@
 				<dependency>
 					<groupId>com.sun.xml.bind</groupId>
 					<artifactId>jaxb-osgi</artifactId>
-					<version>4.0.4</version>
+					<version>4.0.5</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
@@ -31,13 +31,13 @@
 				<dependency>
 					<groupId>jakarta.activation</groupId>
 					<artifactId>jakarta.activation-api</artifactId>
-					<version>2.1.2</version>
+					<version>2.1.3</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>jakarta.xml.bind</groupId>
 					<artifactId>jakarta.xml.bind-api</artifactId>
-					<version>4.0.1</version>
+					<version>4.0.2</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
@@ -61,7 +61,7 @@
 				<dependency>
 					<groupId>org.mvel</groupId>
 					<artifactId>mvel2</artifactId>
-					<version>2.5.1.Final</version>
+					<version>2.5.2.Final</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>

--- a/target-platform/wb.target
+++ b/target-platform/wb.target
@@ -3,8 +3,7 @@
 <target name="wb">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/releases/2024-03/"/>
-			<repository location="https://download.eclipse.org/eclipse/updates/4.31-I-builds/"/>
+			<repository location="https://download.eclipse.org/releases/2024-06/"/>
 			<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.gef.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
@@ -22,7 +21,7 @@
 		</location>
 		<location type="Target" uri="file:${project_loc:/target-platform}/mvn/wb-mvn.target"/>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2024-03"/>
+			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2024-06"/>
 			<unit id="assertj-core" version="0.0.0"/>
 			<unit id="org.apache.commons.commons-collections4" version="0.0.0"/>
 			<unit id="org.apache.commons.lang3" version="0.0.0"/>


### PR DESCRIPTION
This change updates all features to 1.16.0, updates the target platform to use the 2024-06 repository and handles the changes detected in the XSD plugin.

To handle the timestamp in the generated JAXB files, a PR has already been created. In the meantime, we simply replace it using a small Ant script.