### PR TITLE
[Draw2D] Paint whole property table using Draw2D graphics object

### DIFF
--- a/org.eclipse.wb.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.core;singleton:=true
-Bundle-Version: 1.15.0.qualifier
+Bundle-Version: 1.16.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.core.DesignerPlugin


### PR DESCRIPTION
In preparation for converting the property table in a GEF viewer, this change makes it so that the individual properties are drawn using the Draw2D Graphics object, rather than GC.

In the future, this painting is then done within a figure, where the Graphics object is automatically created by GEF and passed as a method argument.