### PR TITLE
Use AbstractUIPlugin instead of ResourceManager to load ImageDescriptor

### DIFF
--- a/org.eclipse.wb.swt/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swt;singleton:=true
-Bundle-Version: 1.9.500.qualifier
+Bundle-Version: 1.9.600.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.swt.Activator
 Bundle-Vendor: %providerName

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/property/editor/image/ImageDescriptorPropertyEditor.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/property/editor/image/ImageDescriptorPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -48,9 +48,7 @@ import org.eclipse.swt.widgets.Composite;
  * @author scheglov_ke
  * @coverage swt.property.editor
  */
-public final class ImageDescriptorPropertyEditor extends TextDialogPropertyEditor
-implements
-IClipboardSourceProvider {
+public final class ImageDescriptorPropertyEditor extends TextDialogPropertyEditor implements IClipboardSourceProvider {
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Instance
@@ -164,11 +162,7 @@ IClipboardSourceProvider {
 					String symbolicName = StringConverter.INSTANCE.toJavaSource(javaInfo, imageValue[0]);
 					String pathSource = StringConverter.INSTANCE.toJavaSource(javaInfo, imageValue[1]);
 					//
-					return "org.eclipse.wb.swt.ResourceManager.getPluginImageDescriptor("
-					+ symbolicName
-					+ ", "
-					+ pathSource
-					+ ")";
+					return ImageEvaluator.getPluginDescriptorInvocationSource(symbolicName, pathSource);
 				}
 			}
 		}
@@ -234,12 +228,7 @@ IClipboardSourceProvider {
 						String symbolicName = StringConverter.INSTANCE.toJavaSource(javaInfo, data[0]);
 						String pathSource = StringConverter.INSTANCE.toJavaSource(javaInfo, data[1]);
 						//
-						source =
-								"org.eclipse.wb.swt.ResourceManager.getPluginImageDescriptor("
-										+ symbolicName
-										+ ", "
-										+ pathSource
-										+ ")";
+						source = ImageEvaluator.getPluginDescriptorInvocationSource(symbolicName, pathSource);
 					}
 				}
 			}

--- a/org.eclipse.wb.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: WindowBuilder Tests
 Bundle-SymbolicName: org.eclipse.wb.tests;singleton:=true
-Bundle-Version: 1.3.0.qualifier
+Bundle-Version: 1.3.100.qualifier
 Bundle-Activator: org.eclipse.wb.tests.designer.tests.Activator
 Bundle-Vendor: Google
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.wb.tests/pom.xml
+++ b/org.eclipse.wb.tests/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.wb</groupId>
   <artifactId>org.eclipse.wb.tests</artifactId>
-  <version>1.3.0-SNAPSHOT</version>
+  <version>1.3.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
  

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ImageDescriptorPropertyEditorTestPlugin.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ImageDescriptorPropertyEditorTestPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -71,6 +71,23 @@ public class ImageDescriptorPropertyEditorTestPlugin extends ImageDescriptorProp
 	// Tests
 	//
 	////////////////////////////////////////////////////////////////////////////
+
+	@Test
+	public void test_ThisPluginImage_Eclipse_workspace() throws Exception {
+		assert_getText_getClipboardSource_forSource(
+				"org.eclipse.ui.plugin.AbstractUIPlugin.imageDescriptorFromPlugin(\"TestProject\", \"icons/1.png\")",
+				"Plugin: TestProject icons/1.png",
+				"org.eclipse.ui.plugin.AbstractUIPlugin.imageDescriptorFromPlugin(\"TestProject\", \"icons/1.png\")");
+	}
+
+	@Test
+	public void test_PluginImage_Eclipse() throws Exception {
+		assert_getText_getClipboardSource_forSource(
+				"org.eclipse.ui.plugin.AbstractUIPlugin.imageDescriptorFromPlugin(\"org.eclipse.jdt.ui\", \"/icons/full/elcl16/ch_cancel.png\")",
+				"Plugin: org.eclipse.jdt.ui /icons/full/elcl16/ch_cancel.png",
+				"org.eclipse.ui.plugin.AbstractUIPlugin.imageDescriptorFromPlugin(\"org.eclipse.jdt.ui\", \"/icons/full/elcl16/ch_cancel.png\")");
+	}
+
 	@Test
 	public void test_ThisPluginImage_OLD() throws Exception {
 		ensureManagers();
@@ -78,7 +95,7 @@ public class ImageDescriptorPropertyEditorTestPlugin extends ImageDescriptorProp
 		assert_getText_getClipboardSource_forSource(
 				"org.eclipse.wb.swt.ResourceManager.getPluginImageDescriptor(testplugin.Activator.getDefault(), \"icons/1.png\")",
 				"Plugin: TestProject icons/1.png",
-				"org.eclipse.wb.swt.ResourceManager.getPluginImageDescriptor(\"TestProject\", \"icons/1.png\")");
+				"org.eclipse.ui.plugin.AbstractUIPlugin.imageDescriptorFromPlugin(\"TestProject\", \"icons/1.png\")");
 	}
 
 	@Test
@@ -88,7 +105,7 @@ public class ImageDescriptorPropertyEditorTestPlugin extends ImageDescriptorProp
 		assert_getText_getClipboardSource_forSource(
 				"org.eclipse.wb.swt.ResourceManager.getPluginImageDescriptor(\"TestProject\", \"icons/1.png\")",
 				"Plugin: TestProject icons/1.png",
-				"org.eclipse.wb.swt.ResourceManager.getPluginImageDescriptor(\"TestProject\", \"icons/1.png\")");
+				"org.eclipse.ui.plugin.AbstractUIPlugin.imageDescriptorFromPlugin(\"TestProject\", \"icons/1.png\")");
 	}
 
 	@Test
@@ -98,14 +115,15 @@ public class ImageDescriptorPropertyEditorTestPlugin extends ImageDescriptorProp
 		assert_getText_getClipboardSource_forSource(
 				"org.eclipse.wb.swt.ResourceManager.getPluginImageDescriptor(\"org.eclipse.jdt.ui\", \"/icons/full/elcl16/ch_cancel.png\")",
 				"Plugin: org.eclipse.jdt.ui /icons/full/elcl16/ch_cancel.png",
-				"org.eclipse.wb.swt.ResourceManager.getPluginImageDescriptor(\"org.eclipse.jdt.ui\", \"/icons/full/elcl16/ch_cancel.png\")");
+				"org.eclipse.ui.plugin.AbstractUIPlugin.imageDescriptorFromPlugin(\"org.eclipse.jdt.ui\", \"/icons/full/elcl16/ch_cancel.png\")");
 	}
 
 	@Test
 	public void test_ThisPlugin_Value() throws Exception {
 		ensureManagers();
 		GenericProperty property =
-				createImageDescriptorPropertyForSource("org.eclipse.wb.swt.ResourceManager.getPluginImageDescriptor(\"TestProject\", \"icons/1.png\")");
+				createImageDescriptorPropertyForSource(
+						"org.eclipse.ui.plugin.AbstractUIPlugin.imageDescriptorFromPlugin(\"TestProject\", \"icons/1.png\")");
 		assertNotNull(property);
 		assertNotNull(property.getValue());
 		//
@@ -121,7 +139,7 @@ public class ImageDescriptorPropertyEditorTestPlugin extends ImageDescriptorProp
 		ensureManagers();
 		GenericProperty property =
 				createImageDescriptorPropertyForSource(
-						"org.eclipse.wb.swt.ResourceManager.getPluginImageDescriptor(\"org.eclipse.jdt.ui\", \"/icons/full/elcl16/ch_cancel.png\")");
+						"org.eclipse.ui.plugin.AbstractUIPlugin.imageDescriptorFromPlugin(\"org.eclipse.jdt.ui\", \"/icons/full/elcl16/ch_cancel.png\")");
 		assertNotNull(property);
 		assertNotNull(property.getValue());
 		//


### PR DESCRIPTION
This removes the internal usage of
ResourceManager.getPluginImageDescriptor() in favor of AbstractUIPlugin.imageDescriptorFromPlugin().

Note that the ResourceManager class is using a special PluginResourceProvider interface for loading bundle images at design time, because the widget class is not parsed within an OSGi environment and therefore Platform.getBundle() always returns null. To replicate this behavior, the method invocation is hijacked and replaced by a call to SwtInvocationEvaluatorInterceptor.getEntry() (the same method that is used by the ResourceManager).

See #486