### PR TITLE
Add ability to contribute OSGi bundles as additional libraries

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/core/editor/palette/model/entry/ComponentEntryInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/core/editor/palette/model/entry/ComponentEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,6 +23,8 @@ import org.eclipse.wb.internal.core.editor.Messages;
 import org.eclipse.wb.internal.core.editor.palette.TypeParametersDialog;
 import org.eclipse.wb.internal.core.editor.palette.model.entry.AttributesProvider;
 import org.eclipse.wb.internal.core.editor.palette.model.entry.AttributesProviders;
+import org.eclipse.wb.internal.core.editor.palette.model.entry.BundleLibraryInfo;
+import org.eclipse.wb.internal.core.editor.palette.model.entry.JarLibraryInfo;
 import org.eclipse.wb.internal.core.editor.palette.model.entry.LibraryInfo;
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
 import org.eclipse.wb.internal.core.model.creation.ConstructorCreationSupport;
@@ -178,7 +180,10 @@ public final class ComponentEntryInfo extends ToolEntryInfo {
 	 */
 	private void addLibraries(IConfigurationElement componentElement) {
 		for (IConfigurationElement libraryElement : componentElement.getChildren("library")) {
-			m_libraries.add(new LibraryInfo(libraryElement));
+			m_libraries.add(new JarLibraryInfo(libraryElement));
+		}
+		for (IConfigurationElement libraryElement : componentElement.getChildren("bundle-library")) {
+			m_libraries.add(new BundleLibraryInfo(libraryElement));
 		}
 	}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/model/entry/BundleLibraryInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/model/entry/BundleLibraryInfo.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Patrick Ziegler and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.internal.core.editor.palette.model.entry;
+
+import org.eclipse.wb.core.editor.palette.model.entry.ComponentEntryInfo;
+import org.eclipse.wb.internal.core.DesignerPlugin;
+import org.eclipse.wb.internal.core.utils.external.ExternalFactoriesHelper;
+import org.eclipse.wb.internal.core.utils.jdt.core.ProjectUtils;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.QualifiedName;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IType;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.Constants;
+import org.osgi.framework.Version;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.function.Predicate;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+
+/**
+ * Library is description of OSGi bundles that should be added when
+ * {@link ComponentEntryInfo} selected from palette.
+ *
+ * @author scheglov_ke
+ * @coverage core.editor.palette
+ */
+public final class BundleLibraryInfo implements LibraryInfo {
+	public static final QualifiedName VERSION = new QualifiedName(DesignerPlugin.PLUGIN_ID, "version");
+	private final String typeName;
+	private final String symbolicName;
+
+	////////////////////////////////////////////////////////////////////////////
+	//
+	// Constructor
+	//
+	////////////////////////////////////////////////////////////////////////////
+	public BundleLibraryInfo(IConfigurationElement element) {
+		typeName = ExternalFactoriesHelper.getRequiredAttribute(element, "type");
+		symbolicName = ExternalFactoriesHelper.getRequiredAttribute(element, "symbolicName");
+	}
+
+	@Override
+	public void ensure(IJavaProject javaProject) throws Exception {
+		IType type = javaProject.findType(typeName);
+		Bundle bundle = ExternalFactoriesHelper.getRequiredBundle(symbolicName);
+
+		if (type != null) {
+			IResource bundleFile = type.getResource();
+			Version bundleVersion = getBundleVersion(bundleFile);
+
+			if (bundleVersion == null || bundleVersion.compareTo(bundle.getVersion()) < 0) {
+				type = null;
+				IPath bundlePath = bundleFile.getFullPath();
+				Predicate<IClasspathEntry> versionComparator = classpath -> bundlePath.equals(classpath.getPath());
+				ProjectUtils.removeClasspathEntries(javaProject, versionComparator);
+				bundleFile.delete(true, null);
+				ProjectUtils.waitForAutoBuild();
+			}
+		}
+
+		if (type == null) {
+			File bundleFile = FileLocator.getBundleFileLocation(bundle).orElse(null);
+			if (bundleFile != null) {
+				// add JAR
+				ProjectUtils.addJar(javaProject, bundleFile.getAbsolutePath(), null);
+				ProjectUtils.waitForAutoBuild();
+			} else {
+				DesignerPlugin.log(Status.warning("Unable to find bundle file " + bundleFile));
+			}
+		}
+	}
+
+	/**
+	 * Extracts and returns the version of {@link #typeName} using the Manifest
+	 * entry of the containing bundle. For performance reason, the Manifest is only
+	 * read once and the version then stored in the file properties.
+	 *
+	 * @param bundleResource The jar file declaring {@link #typeName}.
+	 * @return The bundle version or {@code null}, if none could be found.
+	 */
+	private Version getBundleVersion(IResource bundleResource) {
+		if (bundleResource instanceof IFile bundleFile) {
+			// Check file properties first to increase performance of successive reads
+			try {
+				String versionString = bundleResource.getPersistentProperty(VERSION);
+				if (versionString != null) {
+					return Version.parseVersion(versionString);
+				}
+			} catch (CoreException e) {
+				DesignerPlugin.log(e);
+			}
+			// Read Bundle-Version header from manifest instead
+			File javaFile = bundleFile.getLocation().toFile();
+			try (JarFile jarFile = new JarFile(javaFile)) {
+				Manifest manifest = jarFile.getManifest();
+				Attributes attributes = manifest.getMainAttributes();
+				String versionString = attributes.getValue(Constants.BUNDLE_VERSION);
+				bundleResource.setPersistentProperty(VERSION, versionString);
+				return Version.parseVersion(versionString);
+			} catch (CoreException | IOException e) {
+				DesignerPlugin.log(e);
+			}
+		}
+		return null;
+	}
+}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/model/entry/JarLibraryInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/model/entry/JarLibraryInfo.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2024 Google, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Google, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.internal.core.editor.palette.model.entry;
+
+import org.eclipse.wb.core.editor.palette.model.entry.ComponentEntryInfo;
+import org.eclipse.wb.internal.core.utils.external.ExternalFactoriesHelper;
+import org.eclipse.wb.internal.core.utils.jdt.core.ProjectUtils;
+
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.jdt.core.IJavaProject;
+
+import org.osgi.framework.Bundle;
+
+/**
+ * Library is description of JAR and optional source ZIP that should be added when
+ * {@link ComponentEntryInfo} selected from palette.
+ *
+ * @author scheglov_ke
+ * @coverage core.editor.palette
+ */
+public final class JarLibraryInfo implements LibraryInfo {
+	private final String m_typeName;
+	private final String m_bundleId;
+	private final String m_jarPath;
+	private final String m_srcPath;
+
+	////////////////////////////////////////////////////////////////////////////
+	//
+	// Constructor
+	//
+	////////////////////////////////////////////////////////////////////////////
+	public JarLibraryInfo(IConfigurationElement element) {
+		m_typeName = ExternalFactoriesHelper.getRequiredAttribute(element, "type");
+		m_bundleId = ExternalFactoriesHelper.getRequiredAttribute(element, "bundle");
+		m_jarPath = ExternalFactoriesHelper.getRequiredAttribute(element, "jar");
+		m_srcPath = element.getAttribute("src");
+	}
+
+	////////////////////////////////////////////////////////////////////////////
+	//
+	// Access
+	//
+	////////////////////////////////////////////////////////////////////////////
+
+	@Override
+	public void ensure(IJavaProject javaProject) throws Exception {
+		if (javaProject.findType(m_typeName) == null) {
+			Bundle bundle = ExternalFactoriesHelper.getRequiredBundle(m_bundleId);
+			// add JAR
+			ProjectUtils.addJar(javaProject, bundle, m_jarPath, m_srcPath);
+			ProjectUtils.waitForAutoBuild();
+		}
+	}
+}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/model/entry/LibraryInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/model/entry/LibraryInfo.java
@@ -1,63 +1,26 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2024 Patrick Ziegler and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *    Google, Inc. - initial API and implementation
+ *    Patrick Ziegler - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.internal.core.editor.palette.model.entry;
 
-import org.eclipse.wb.core.editor.palette.model.entry.ComponentEntryInfo;
-import org.eclipse.wb.internal.core.utils.external.ExternalFactoriesHelper;
-import org.eclipse.wb.internal.core.utils.jdt.core.ProjectUtils;
-
-import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.jdt.core.IJavaProject;
 
-import org.osgi.framework.Bundle;
-
 /**
- * Library is description of JAR and optional source ZIP that should be added when
- * {@link ComponentEntryInfo} selected from palette.
- *
- * @author scheglov_ke
- * @coverage core.editor.palette
+ * Base interface for additional libraries that need to be added to the
+ * workspace in order to handle custom widgets. Supported are either OSGi
+ * bundles or plain jars.
  */
-public final class LibraryInfo {
-	private final String m_typeName;
-	private final String m_bundleId;
-	private final String m_jarPath;
-	private final String m_srcPath;
-
-	////////////////////////////////////////////////////////////////////////////
-	//
-	// Constructor
-	//
-	////////////////////////////////////////////////////////////////////////////
-	public LibraryInfo(IConfigurationElement element) {
-		m_typeName = ExternalFactoriesHelper.getRequiredAttribute(element, "type");
-		m_bundleId = ExternalFactoriesHelper.getRequiredAttribute(element, "bundle");
-		m_jarPath = ExternalFactoriesHelper.getRequiredAttribute(element, "jar");
-		m_srcPath = element.getAttribute("src");
-	}
-
-	////////////////////////////////////////////////////////////////////////////
-	//
-	// Access
-	//
-	////////////////////////////////////////////////////////////////////////////
+public sealed interface LibraryInfo permits BundleLibraryInfo, JarLibraryInfo {
 	/**
-	 * Ensures that required type exists in {@link IJavaProject}, if needed adds JAR/ZIP to classpath.
+	 * Ensures that required type exists in {@link IJavaProject}, if needed adds
+	 * JAR/ZIP to classpath.
 	 */
-	public void ensure(IJavaProject javaProject) throws Exception {
-		if (javaProject.findType(m_typeName) == null) {
-			Bundle bundle = ExternalFactoriesHelper.getRequiredBundle(m_bundleId);
-			// add JAR
-			ProjectUtils.addJar(javaProject, bundle, m_jarPath, m_srcPath);
-			ProjectUtils.waitForAutoBuild();
-		}
-	}
+	void ensure(IJavaProject javaProject) throws Exception;
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/LayoutDescription.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/LayoutDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,8 @@ import org.eclipse.wb.core.databinding.xsd.component.Component;
 import org.eclipse.wb.core.databinding.xsd.component.ContextFactory;
 import org.eclipse.wb.core.databinding.xsd.component.Creation;
 import org.eclipse.wb.internal.core.DesignerPlugin;
+import org.eclipse.wb.internal.core.editor.palette.model.entry.BundleLibraryInfo;
+import org.eclipse.wb.internal.core.editor.palette.model.entry.JarLibraryInfo;
 import org.eclipse.wb.internal.core.editor.palette.model.entry.LibraryInfo;
 import org.eclipse.wb.internal.core.model.description.helpers.DescriptionHelper;
 import org.eclipse.wb.internal.core.model.description.resource.ResourceInfo;
@@ -139,7 +141,10 @@ public final class LayoutDescription {
 	 */
 	private void addLibraries(IConfigurationElement componentElement) {
 		for (IConfigurationElement libraryElement : componentElement.getChildren("library")) {
-			m_libraries.add(new LibraryInfo(libraryElement));
+			m_libraries.add(new JarLibraryInfo(libraryElement));
+		}
+		for (IConfigurationElement libraryElement : componentElement.getChildren("bundle-library")) {
+			m_libraries.add(new BundleLibraryInfo(libraryElement));
 		}
 	}
 

--- a/org.eclipse.wb.core/schema/layoutManagers.exsd
+++ b/org.eclipse.wb.core/schema/layoutManagers.exsd
@@ -39,6 +39,7 @@ We use them later:
       <complexType>
          <sequence minOccurs="0" maxOccurs="unbounded">
             <element ref="library"/>
+            <element ref="bundle-library"/>
          </sequence>
          <attribute name="toolkit" type="string" use="required">
             <annotation>
@@ -121,6 +122,25 @@ Don&apos;t know yet what to do with absolute/null layout manager.
             <annotation>
                <documentation>
                   Path to optional source ZIP.
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="bundle-library">
+      <complexType>
+         <attribute name="symbolicName" type="string" use="required">
+            <annotation>
+               <documentation>
+                  Fully qualified name of the bundle.
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="type" type="string" use="required">
+            <annotation>
+               <documentation>
+                  Name of type to check, if bundle is already in classpath.
                </documentation>
             </annotation>
          </attribute>

--- a/org.eclipse.wb.core/schema/toolkits.exsd
+++ b/org.eclipse.wb.core/schema/toolkits.exsd
@@ -266,6 +266,7 @@ In Designer itself entries usually defined directly in &quot;category&quot;, so 
       <complexType>
          <choice minOccurs="0" maxOccurs="1">
             <element ref="library" minOccurs="0" maxOccurs="unbounded"/>
+            <element ref="bundle-library" minOccurs="0" maxOccurs="unbounded"/>
          </choice>
          <attribute name="id" type="string">
             <annotation>
@@ -556,6 +557,25 @@ By default &quot;id&quot; of is name of factory class signature of method.
          <sequence>
             <element ref="resourcePrefix" minOccurs="1" maxOccurs="unbounded"/>
          </sequence>
+      </complexType>
+   </element>
+
+   <element name="bundle-library">
+      <complexType>
+         <attribute name="symbolicName" type="string" use="required">
+            <annotation>
+               <documentation>
+                  Fully qualified name of the bundle.
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="type" type="string" use="required">
+            <annotation>
+               <documentation>
+                  Name of type to check, if bundle is already in classpath.
+               </documentation>
+            </annotation>
+         </attribute>
       </complexType>
    </element>
 


### PR DESCRIPTION
The layoutManagers and toolkits extension points have been adapted to not only support plain Java jars, but also proper OSGi bundles. To properly handle both types, the LibraryInfo class has been split into a JarLibraryInfo and a BundleLibraryInfo variant.

For bundles, we also compare the version specified in the bundle manifest with the bundle in the local classpath. If the version in the workspace is older than what's used by WindowBuilder, the jar is replaced.