### PR TITLE
Fix: NLS missing message: ColorPreferenceChooser_Include

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/ModelMessages.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/ModelMessages.java
@@ -45,7 +45,6 @@ public class ModelMessages extends NLS {
 	public static String CardLayoutAssistantPage_verticalGap;
 	public static String ColorField_reset;
 	public static String ColorField_select;
-	public static String ColorPreferenceChooser_Include;
 	public static String ColumnEditDialog_aCenter;
 	public static String ColumnEditDialog_aFill;
 	public static String ColumnEditDialog_aLeft;


### PR DESCRIPTION
The value is never used, so we can simply remove it.