### PR TITLE
[Draw2D] Painting on FigureCanvas should be done in UpdateManager

### DIFF
--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/FigureCanvas.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/FigureCanvas.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,20 +11,18 @@
 package org.eclipse.wb.internal.draw2d;
 
 import org.eclipse.wb.draw2d.Figure;
-import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
+import org.eclipse.draw2d.DeferredUpdateManager;
 import org.eclipse.draw2d.Graphics;
-import org.eclipse.draw2d.LightweightSystem;
 import org.eclipse.draw2d.SWTGraphics;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.ControlListener;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Event;
-import org.eclipse.swt.widgets.Listener;
 
 /**
  * A Canvas that contains {@link Figure Figures}.
@@ -35,11 +33,7 @@ import org.eclipse.swt.widgets.Listener;
 public class FigureCanvas extends org.eclipse.draw2d.FigureCanvas {
 	private RootFigure m_rootFigure;
 	private final Dimension m_rootPreferredSize = new Dimension();
-	// TODO ptziegler: Painting the figures on the canvas is the responsibility of
-	// the UpdateManager, not the FigureCanvas.
-	@Deprecated
-	private Image m_bufferedImage;
-	private boolean m_drawCached;
+	private CachedUpdateManager m_updateManager;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -47,9 +41,7 @@ public class FigureCanvas extends org.eclipse.draw2d.FigureCanvas {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	public FigureCanvas(Composite parent, int style) {
-		super(parent, style | SWT.NO_BACKGROUND | SWT.NO_REDRAW_RESIZE, createLightweightSystem());
-		// add all listeners
-		hookControlEvents();
+		super(parent, style | SWT.NO_BACKGROUND | SWT.NO_REDRAW_RESIZE);
 		// create root figure
 		createRootFigure();
 	}
@@ -66,38 +58,17 @@ public class FigureCanvas extends org.eclipse.draw2d.FigureCanvas {
 		m_rootFigure.setForegroundColor(getForeground());
 		m_rootFigure.setFont(getFont());
 		setDefaultEventManager();
+		setDefaultUpdateManager();
 		setContents(m_rootFigure);
-	}
-
-	private static LightweightSystem createLightweightSystem() {
-		return new LightweightSystem() {
-			private FigureCanvas getFigureCanvas() {
-				return (FigureCanvas) ReflectionUtils.getFieldObject(this, "canvas");
-			}
-
-			@Override
-			protected void controlResized() {
-				getFigureCanvas().disposeBufferedImage();
-				super.controlResized();
-			}
-
-			@Override
-			public void paint(GC gc) {
-				org.eclipse.swt.graphics.Rectangle bounds = gc.getClipping();
-				getFigureCanvas().handlePaint(gc, bounds.x, bounds.y, bounds.width, bounds.height);
-			}
-		};
 	}
 
 	protected void setDefaultEventManager() {
 		m_rootFigure.getFigureCanvas().getLightweightSystem().setEventDispatcher(new EventManager(this));
 	}
 
-	private void disposeBufferedImage() {
-		if (m_bufferedImage != null) {
-			m_bufferedImage.dispose();
-			m_bufferedImage = null;
-		}
+	protected void setDefaultUpdateManager() {
+		m_updateManager = new CachedUpdateManager(this);
+		m_rootFigure.getFigureCanvas().getLightweightSystem().setUpdateManager(m_updateManager);
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -117,7 +88,7 @@ public class FigureCanvas extends org.eclipse.draw2d.FigureCanvas {
 	 * Sets draw cached mode.
 	 */
 	public void setDrawCached(boolean value) {
-		m_drawCached = value;
+		m_updateManager.m_drawCached = value;
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -136,52 +107,6 @@ public class FigureCanvas extends org.eclipse.draw2d.FigureCanvas {
 	// Handle events
 	//
 	////////////////////////////////////////////////////////////////////////////
-	private void hookControlEvents() {
-		addListener(SWT.Dispose, new Listener() {
-			@Override
-			public void handleEvent(Event event) {
-				disposeBufferedImage();
-			}
-		});
-	}
-
-	private void handlePaint(GC paintGC, int x, int y, int width, int height) {
-		// check draw cached mode
-		if (m_drawCached) {
-			if (m_bufferedImage == null) {
-				paintGC.fillRectangle(x, y, width, height);
-			} else {
-				paintGC.drawImage(m_bufferedImage, 0, 0);
-			}
-			return;
-		}
-		// check double buffered image
-		if (m_bufferedImage == null) {
-			Point size = getSize();
-			m_bufferedImage = new Image(null, size.x, size.y);
-		}
-		// prepare double buffered Graphics
-		GC bufferedGC = new GC(m_bufferedImage);
-		try {
-			bufferedGC.setClipping(x, y, width, height);
-			bufferedGC.setBackground(paintGC.getBackground());
-			bufferedGC.setForeground(paintGC.getForeground());
-			bufferedGC.setFont(paintGC.getFont());
-			bufferedGC.setLineStyle(paintGC.getLineStyle());
-			bufferedGC.setLineWidth(paintGC.getLineWidth());
-			bufferedGC.setXORMode(paintGC.getXORMode());
-			// draw content
-			Graphics graphics = new SWTGraphics(bufferedGC);
-			int dx = -getViewport().getHorizontalRangeModel().getValue();
-			int dy = -getViewport().getVerticalRangeModel().getValue();
-			graphics.translate(dx, dy);
-			m_rootFigure.paint(graphics);
-		} finally {
-			bufferedGC.dispose();
-		}
-		// flush painting
-		paintGC.drawImage(m_bufferedImage, 0, 0);
-	}
 
 	/**
 	 * Check bounds and reconfigure scroll bar's if needed and repaint client area.
@@ -202,6 +127,74 @@ public class FigureCanvas extends org.eclipse.draw2d.FigureCanvas {
 			getViewport().revalidate();
 			// set repaint
 			redraw();
+		}
+	}
+
+	/**
+	 * Update manager using double-buffering and allowing the temporary suspension
+	 * of any actual paint operations. This mechanism is needed during the creation
+	 * of the live images, where the design page is in an inconsistent page.
+	 */
+	private static class CachedUpdateManager extends DeferredUpdateManager {
+		private FigureCanvas m_canvas;
+		private Image m_bufferedImage;
+		private boolean m_drawCached;
+
+		public CachedUpdateManager(FigureCanvas canvas) {
+			m_canvas = canvas;
+			m_canvas.addControlListener(ControlListener.controlResizedAdapter(event -> disposeImage()));
+		}
+
+		@Override
+		protected void paint(GC paintGC) {
+			org.eclipse.swt.graphics.Rectangle bounds = paintGC.getClipping();
+			// check draw cached mode
+			if (m_drawCached) {
+				if (m_bufferedImage == null) {
+					paintGC.fillRectangle(bounds);
+				} else {
+					paintGC.drawImage(m_bufferedImage, 0, 0);
+				}
+				return;
+			}
+			// check double buffered image
+			if (m_bufferedImage == null) {
+				Point size = m_canvas.getSize();
+				m_bufferedImage = new Image(null, size.x, size.y);
+			}
+			// prepare double buffered Graphics
+			GC bufferedGC = new GC(m_bufferedImage);
+			try {
+				bufferedGC.setClipping(bounds);
+				bufferedGC.setBackground(paintGC.getBackground());
+				bufferedGC.setForeground(paintGC.getForeground());
+				bufferedGC.setFont(paintGC.getFont());
+				bufferedGC.setLineStyle(paintGC.getLineStyle());
+				bufferedGC.setLineWidth(paintGC.getLineWidth());
+				bufferedGC.setXORMode(paintGC.getXORMode());
+				// draw content
+				Graphics graphics = new SWTGraphics(bufferedGC);
+				int dx = -m_canvas.getViewport().getHorizontalRangeModel().getValue();
+				int dy = -m_canvas.getViewport().getVerticalRangeModel().getValue();
+				graphics.translate(dx, dy);
+				m_canvas.getRootFigure().paint(graphics);
+			} finally {
+				bufferedGC.dispose();
+			}
+			// flush painting
+			paintGC.drawImage(m_bufferedImage, 0, 0);
+		}
+
+		@Override
+		public void dispose() {
+			disposeImage();
+		}
+
+		private void disposeImage() {
+			if (m_bufferedImage != null) {
+				m_bufferedImage.dispose();
+				m_bufferedImage = null;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Handles the deprecated usage of a buffered image inside the FigureCanvas class. In GEF, painting is done exclusively inside the UpdateManager. By doing so, we break convention which has unpleasant side effects where e.g. a paint event is processed, even though the "draw cached" flag is set.