### PR TITLE
Fix incompatibilities introduced with 2024-06 M2

### DIFF
--- a/org.eclipse.wb.os.linux/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.os.linux/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.os.linux;singleton:=true
-Bundle-Version: 1.9.600.qualifier
+Bundle-Version: 1.9.700.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-PlatformFilter: (& (osgi.ws=gtk) (osgi.os=linux))

--- a/org.eclipse.wb.os.linux/pom.xml
+++ b/org.eclipse.wb.os.linux/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.eclipse.wb</groupId>
     <artifactId>org.eclipse.wb.os.linux</artifactId>
-    <version>1.9.600-SNAPSHOT</version>
+    <version>1.9.700-SNAPSHOT</version>
     <packaging>eclipse-plugin</packaging>
 
     <build>

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/tests/DesignerTestCase.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/tests/DesignerTestCase.java
@@ -25,7 +25,6 @@ import org.eclipse.wb.tests.gef.UiContext;
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.ILogListener;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.e4.ui.css.core.utils.ClassUtils;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.ActionContributionItem;
 import org.eclipse.jface.action.IAction;
@@ -112,8 +111,6 @@ public abstract class DesignerTestCase extends Assert {
 		// ObjectInfoUtils
 		((Map<?, ?>) ReflectionUtils.getFieldObject(ObjectInfoUtils.class, "m_idToObjectInfo")).clear();
 		((Map<?, ?>) ReflectionUtils.getFieldObject(ObjectInfoUtils.class, "m_objectInfoToId")).clear();
-		// ClassUtils
-		((Map<?, ?>) ReflectionUtils.getFieldObject(ClassUtils.class, "simpleNames")).clear();
 	}
 
 	private void configureFirstTime() {


### PR DESCRIPTION
The method Shell.adjustTrim() has been replaced by a new method (with same name), which now expects two integers as as arguments. For the sake of backwards compatibility, we check the version of SWT and then call either one or the other method.

Furthermore, the memory leak in ClassUtils has been fixed, so we no longer need to handle this case in our test suite.