### PR TITLE
Integrate presentation buttons of property table into GEF layout.

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/presentation/ButtonPropertyEditorPresentation.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/presentation/ButtonPropertyEditorPresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ import org.eclipse.wb.internal.core.EnvironmentUtils;
 import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
 
+import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Button;
@@ -65,18 +66,23 @@ public abstract class ButtonPropertyEditorPresentation extends PropertyEditorPre
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public final int show(final PropertyTable propertyTable,
+	public final void show(final PropertyTable propertyTable,
 			final Property property,
 			final int x,
 			final int y,
 			final int width,
 			final int height) {
-		return m_impl.show(propertyTable, property, x, y, width, height);
+		m_impl.show(propertyTable, property, x, y, width, height);
 	}
 
 	@Override
 	public final void hide(PropertyTable propertyTable, Property property) {
 		m_impl.hide(propertyTable, property);
+	}
+
+	@Override
+	public Dimension getSize(int wHint, int hHint) {
+		return m_impl.getSize(wHint, hHint);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/presentation/ButtonPropertyEditorPresentationImpl.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/presentation/ButtonPropertyEditorPresentationImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
 import org.eclipse.wb.internal.core.utils.Pair;
 
+import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
@@ -57,7 +58,7 @@ class ButtonPropertyEditorPresentationImpl extends PropertyEditorPresentation {
 	}
 
 	@Override
-	public final int show(PropertyTable propertyTable,
+	public final void show(PropertyTable propertyTable,
 			Property property,
 			int x,
 			int y,
@@ -72,7 +73,11 @@ class ButtonPropertyEditorPresentationImpl extends PropertyEditorPresentation {
 		final int controlWidth = height;
 		final int controlX = x + width - controlWidth;
 		setBounds(control, controlX, y, controlWidth, height);
-		return controlWidth;
+	}
+
+	@Override
+	public Dimension getSize(int wHint, int hHint) {
+		return new Dimension(hHint, hHint);
 	}
 
 	/**

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/presentation/CompoundPropertyEditorPresentation.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/presentation/CompoundPropertyEditorPresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,8 @@ package org.eclipse.wb.internal.core.model.property.editor.presentation;
 
 import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
+
+import org.eclipse.draw2d.geometry.Dimension;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,19 +47,17 @@ public class CompoundPropertyEditorPresentation extends PropertyEditorPresentati
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public int show(PropertyTable propertyTable,
+	public void show(PropertyTable propertyTable,
 			Property property,
 			int x,
 			int y,
 			int width,
 			int height) {
-		int sumWidth = 0;
 		for (PropertyEditorPresentation presentation : m_presentations) {
-			int presentationWidth = presentation.show(propertyTable, property, x, y, width, height);
-			sumWidth += presentationWidth;
-			width -= presentationWidth;
+			presentation.show(propertyTable, property, x, y, width, height);
+			Dimension size = presentation.getSize(width, height);
+			width -= size.width;
 		}
-		return sumWidth;
 	}
 
 	@Override
@@ -65,5 +65,20 @@ public class CompoundPropertyEditorPresentation extends PropertyEditorPresentati
 		for (PropertyEditorPresentation presentation : m_presentations) {
 			presentation.hide(propertyTable, property);
 		}
+	}
+
+	@Override
+	public Dimension getSize(int wHint, int hHint) {
+		Dimension compositeSize = new Dimension(0, 0);
+		for (int i = 0; i < m_presentations.size(); ++i) {
+			PropertyEditorPresentation presentation = m_presentations.get(i);
+			if (i == 0) {
+				compositeSize = presentation.getSize(wHint, hHint);
+			} else {
+				Dimension size = presentation.getSize(wHint, hHint);
+				compositeSize.width += size.width;
+			}
+		}
+		return compositeSize;
 	}
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/presentation/PropertyEditorPresentation.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/presentation/PropertyEditorPresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,8 @@ import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.model.property.editor.PropertyEditor;
 import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
 
+import org.eclipse.draw2d.geometry.Dimension;
+
 /**
  * Implementations of {@link PropertyEditorPresentation} are used to show some presentation for
  * visible, but not activated yet {@link PropertyEditor}.
@@ -27,7 +29,7 @@ public abstract class PropertyEditorPresentation {
 	 *
 	 * @return the width that this presentation occupies on the right of given rectangle.
 	 */
-	public abstract int show(PropertyTable propertyTable,
+	public abstract void show(PropertyTable propertyTable,
 			Property property,
 			int x,
 			int y,
@@ -38,4 +40,11 @@ public abstract class PropertyEditorPresentation {
 	 * Hides presentation.
 	 */
 	public abstract void hide(PropertyTable propertyTable, Property property);
+
+	/**
+	 * @param wHint a width hint
+	 * @param hHint a height hint
+	 * @return The size of this presentation.
+	 */
+	public abstract Dimension getSize(int wHint, int hHint);
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/table/PropertyTable.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/table/PropertyTable.java
@@ -972,14 +972,21 @@ public class PropertyTable extends ScrollingGraphicalViewer {
 							}
 							index2--;
 							// draw line if there are children
-							if (index2 > index
-									&& getEditPartRegistry().get(propertyInfo) instanceof PropertyEditPart editPart) {
-								int y = editPart.getFigure().getBounds().top();
-								int x = getTitleX(propertyInfo) + xOffset;
-								int y1 = y + height - yOffset;
-								int y2 = y + m_rowHeight * (index2 - index) + m_rowHeight / 2;
-								graphics.drawLine(x, y1, x, y2);
-								graphics.drawLine(x, y2, x + m_rowHeight / 3, y2);
+							if (index2 > index) {
+								PropertyInfo nextPropertyInfo = m_properties.get(index2);
+								GraphicalEditPart editPart = (GraphicalEditPart) getEditPartRegistry()
+										.get(propertyInfo);
+								GraphicalEditPart nextEditPart = (GraphicalEditPart) getEditPartRegistry()
+										.get(nextPropertyInfo);
+								if (editPart != null && nextEditPart != null) {
+									Rectangle bounds = editPart.getFigure().getBounds();
+									Rectangle nextBounds = nextEditPart.getFigure().getBounds();
+									int x = getTitleX(propertyInfo) + xOffset;
+									int y1 = bounds.top() + height - yOffset;
+									int y2 = nextBounds.top() + m_rowHeight / 2;
+									graphics.drawLine(x, y1, x, y2);
+									graphics.drawLine(x, y2, x + m_rowHeight / 3, y2);
+								}
 							}
 						}
 						//

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/alignment/AlignmentPropertyEditor.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/alignment/AlignmentPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -87,20 +87,19 @@ abstract class AlignmentPropertyEditor extends FloatPropertyEditor {
 	private final CompoundPropertyEditorPresentation m_presentation =
 			new CompoundPropertyEditorPresentation() {
 		@Override
-		public int show(final PropertyTable propertyTable,
+		public void show(final PropertyTable propertyTable,
 				final Property property,
 				int x,
 				int y,
 				int width,
 				int height) {
-			int presentationWidth = super.show(propertyTable, property, x, y, width, height);
+			super.show(propertyTable, property, x, y, width, height);
 			ExecutionUtils.runLog(new RunnableEx() {
 				@Override
 				public void run() throws Exception {
 					selectButtonByValue(propertyTable, property);
 				}
 			});
-			return presentationWidth;
 		}
 	};
 


### PR DESCRIPTION
Instead of placing the buttons directly on the canvas, they are now
wrapped inside a Draw2D figure.

Via the paint() and erase() method, we control whether the buttons
should be shown or hidden. The bounds of the buttons are described by
the bounds of the figure.

To make this possible, the return value of the show() method has been
moved to a seprate getSize() method. This is necessary to calculate the
size of the figure without creating (and showing) the SWT widget.