### PR TITLE
Fix: Only disable resizability of frame when taking a screenshot.

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingScreenshotMaker.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingScreenshotMaker.java
@@ -100,13 +100,6 @@ public final class SwingScreenshotMaker {
 			}
 			frame.pack();
 		}
-		// When the size of the frame exceeds the size of the screen, then the frame
-		// will be maximized instead. As a result, the edges of the frame outside the
-		// visible area won't be captured. This behavior can be explicitly disabled by
-		// simply clearing the "resizable" flag.
-		if (m_window instanceof Frame frame) {
-			frame.setResizable(false);
-		}
 		// Just clearing the "resizable" flag doesn't seem to be sufficient on Windows
 		// and the edges are still cut off when they are larger than the screen. I've
 		// traced the problem back to a native call to
@@ -130,6 +123,15 @@ public final class SwingScreenshotMaker {
 		final int componentWidth = Math.max(1, m_component.getWidth());
 		final int componentHeight = Math.max(1, m_component.getHeight());
 		m_oldComponentLocation = m_component.getLocation();
+		boolean isResizable = false;
+		// When the size of the frame exceeds the size of the screen, then the frame
+		// will be maximized instead. As a result, the edges of the frame outside the
+		// visible area won't be captured. This behavior can be explicitly disabled by
+		// simply clearing the "resizable" flag.
+		if (m_window instanceof Frame frame) {
+			isResizable = frame.isResizable();
+			frame.setResizable(false);
+		}
 		SwingImageUtils.prepareForPrinting(m_window);
 		fixJLabelWithHTML(m_component);
 		// prepare empty image
@@ -196,6 +198,9 @@ public final class SwingScreenshotMaker {
 			if (oldImage != null) {
 				oldImage.dispose();
 			}
+		}
+		if (m_window instanceof Frame frame) {
+			frame.setResizable(isResizable);
 		}
 		// set images
 		m_root.accept(new ObjectInfoVisitor() {


### PR DESCRIPTION
We explicitly cann frame.setResizable(false), in order to allow taking a screenshot for composites that are larger than the screen resolution. This has the unpleasant side effect that it's not possible to maximize the composite when opening the preview mode.

This property is now set before the screenshots are created and unset once everything is finished.

Fixes https://github.com/eclipse-windowbuilder/windowbuilder/issues/751

Amends 8c91b9b544942f659e93d824d9a22aaf3cabb5df