### PR TITLE
Add missing about.html/plugin.properties to XSD bundle

### DIFF
--- a/org.eclipse.wb.core.databinding.xsd/about.html
+++ b/org.eclipse.wb.core.databinding.xsd/about.html
@@ -1,0 +1,31 @@
+<html>
+
+<head>
+<title>About WindowBuilder</title>
+</head>
+
+<body>
+
+<span class="Apple-style-span" style="border-collapse: separate; color: rgb(0, 0, 0); font-family: 'Times New Roman'; font-style: normal; font-variant: normal; font-weight: normal; letter-spacing: normal; line-height: normal; orphans: 2; text-align: -webkit-auto; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-border-horizontal-spacing: 0px; -webkit-border-vertical-spacing: 0px; -webkit-text-decorations-in-effect: none; -webkit-text-size-adjust: auto; -webkit-text-stroke-width: 0px; font-size: medium; ">
+<h2>About This Content</h2>
+<p>June 22, 2011</p>
+<h3>License</h3>
+<p>The Eclipse Foundation makes available all content in this plug-in 
+(&quot;Content&quot;). Unless otherwise indicated below, the Content is provided to you 
+under the terms and conditions of the Eclipse Public License Version 1.0 
+(&quot;EPL&quot;). A copy of the EPL is available at
+<a href="http://www.eclipse.org/legal/epl-v10.html">
+http://www.eclipse.org/legal/epl-v10.html</a>. For purposes of the EPL, 
+&quot;Program&quot; will mean the Content.</p>
+<p>If you did not receive this Content directly from the Eclipse Foundation, the 
+Content is being redistributed by another party (&quot;Redistributor&quot;) and different 
+terms and conditions may apply to your use of any object code in the Content. 
+Check the Redistributor's license that was provided with the Content. If no such 
+license exists, contact the Redistributor. Unless otherwise indicated below, the 
+terms and conditions of the EPL still apply to any source code in the Content 
+and such source code may be obtained at<span class="Apple-converted-space">&nbsp;</span><a href="http://www.eclipse.org">http://www.eclipse.org</a>.</p>
+</span>
+<p align="center"><strong>Copyright © 2003, 2014 Google, Inc. All rights reserved.</strong></p>
+
+</body>
+</html>

--- a/org.eclipse.wb.core.databinding.xsd/build.properties
+++ b/org.eclipse.wb.core.databinding.xsd/build.properties
@@ -2,4 +2,6 @@ source.. = src-gen/,\
            src/
 bin.includes = META-INF/,\
                schema/,\
-               .
+               .,\
+               plugin.properties,\
+               about.html


### PR DESCRIPTION
Fixes https://github.com/eclipse-windowbuilder/windowbuilder/issues/777