### PR TITLE
Clean the src-gen directory of the XSD bundle as part of the Maven build

### DIFF
--- a/org.eclipse.wb.core.databinding.xsd/pom.xml
+++ b/org.eclipse.wb.core.databinding.xsd/pom.xml
@@ -28,6 +28,17 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-clean-plugin</artifactId>
+					<configuration>
+						<filesets>
+							<fileset>
+								<directory>${basedir}/src-gen</directory>
+							</fileset>
+						</filesets>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>jaxb2-maven-plugin</artifactId>
 				<version>3.1.0</version>


### PR DESCRIPTION
The XSD model generator doesn't overwrite an existing xjb file and is put next to it, instead. As a result, the ant-script no longer works as it can't find the correct file anymore.