### PR TITLE
Fix:Layout preference page doesn't keep default layout

### DIFF
--- a/org.eclipse.wb.core.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.core.ui;singleton:=true
-Bundle-Version: 1.10.400.qualifier
+Bundle-Version: 1.10.500.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,


### PR DESCRIPTION
The input of the combo viewer needs to be set before the databinding is created. Otherwise the initial selection can't be restored. When unchecking an element in the table, the old selection of the combo viewer needs read before the new input is set, otherwise this information is lost.

Fixes https://github.com/eclipse-windowbuilder/windowbuilder/issues/785