### PR TITLE
Update GitHub workflow actions and use commit ids instead of tags

### DIFF
--- a/.github/workflows/license-review.yml
+++ b/.github/workflows/license-review.yml
@@ -8,7 +8,7 @@ jobs:
   call-license-check:
     permissions:
       pull-requests: write
-    uses: eclipse/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
+    uses: eclipse/dash-licenses/.github/workflows/mavenLicenseCheck.yml@90ebdf14dff066293b65b9d3ca99c8fb90d5222b
     with:
       projectId: tools.windowbuilder
     secrets:

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -9,7 +9,7 @@ on:
       - master
 jobs:
   check-dash-licenses:
-    uses: eclipse/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
+    uses: eclipse/dash-licenses/.github/workflows/mavenLicenseCheck.yml@90ebdf14dff066293b65b9d3ca99c8fb90d5222b
     with:
       projectId: tools.windowbuilder
   build:
@@ -22,26 +22,26 @@ jobs:
     name: OS ${{ matrix.os }} Java ${{ matrix.java }} compile
     timeout-minutes: 90
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
       with:
        fetch-depth: 0
     - name: Set up JDK 17/21
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9
       with:
         distribution: 'temurin' # See 'Supported distributions' for available options
         java-version: ${{ matrix.java }}
         cache: 'maven'
     - name: Set up Maven
-      uses: stCarolas/setup-maven@v4.5
+      uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1
       with:
         maven-version: 3.9.2
     - name: Build with Maven
-      uses: coactions/setup-xvfb@v1
+      uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3
       with:
        run: >- 
         mvn -V -B -fae -ntp clean verify
     - name: Upload Test Results for Java-${{ matrix.java }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
       if: always()
       with:
         name: test-results-${{ matrix.os }}-java${{ matrix.java }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,7 +29,7 @@ jobs:
            done
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@30eadd5010312f995f0d3b3cff7fe2984f69409e
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           files: "artifacts/**/*.xml"


### PR DESCRIPTION
Tags are supposedly unsafe as they are not immutable. A malicious third party can potentially retag a release containing harmful changes, which would then be executed as part of the build.

Using the commit id makes this much more difficult, as this is not easily reproducible.