### PR TITLE
Remove unnecessary "throws" statement in model methods

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/creation/ConstructorCreationSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/creation/ConstructorCreationSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -353,7 +353,7 @@ ILiveCreationSupport {
 
 	@Override
 	public void addAccessors(GenericPropertyDescription propertyDescription,
-			List<ExpressionAccessor> accessors) throws Exception {
+			List<ExpressionAccessor> accessors) {
 		// add accessors for parameters bound to given property
 		List<ParameterDescription> parameters = m_description.getParameters();
 		for (ParameterDescription parameter : parameters) {

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/creation/CreationSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/creation/CreationSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -110,7 +110,7 @@ public abstract class CreationSupport {
 	 * Adds {@link ExpressionAccessor} for given {@link GenericPropertyDescription}.
 	 */
 	public void addAccessors(GenericPropertyDescription propertyDescription,
-			List<ExpressionAccessor> accessors) throws Exception {
+			List<ExpressionAccessor> accessors) {
 		// don't add any new accessors by default
 	}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/creation/ThisCreationSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/creation/ThisCreationSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -759,7 +759,7 @@ public final class ThisCreationSupport extends CreationSupport {
 
 	@Override
 	public void addAccessors(GenericPropertyDescription propertyDescription,
-			List<ExpressionAccessor> accessors) throws Exception {
+			List<ExpressionAccessor> accessors) {
 		// add accessors for parameters bound to given property
 		if (m_invocation != null) {
 			for (ParameterDescription parameter : m_description.getParameters()) {

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/creation/factory/AbstractFactoryCreationSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/creation/factory/AbstractFactoryCreationSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -137,7 +137,7 @@ public abstract class AbstractFactoryCreationSupport extends CreationSupport {
 
 	@Override
 	public final void addAccessors(GenericPropertyDescription propertyDescription,
-			List<ExpressionAccessor> accessors) throws Exception {
+			List<ExpressionAccessor> accessors) {
 		for (ParameterDescription parameter : m_description.getParameters()) {
 			if (propertyDescription.getId().equals(parameter.getProperty())) {
 				int index = parameter.getIndex();

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/ComponentDescriptionHelper.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/ComponentDescriptionHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -249,9 +249,9 @@ public final class ComponentDescriptionHelper {
 	 *
 	 * @return the {@link ComponentDescription} of component with given
 	 *         {@link Class}.
-	 * @throws Exception if no {@link ComponentDescription} can be found.
+	 * @throws DesignerException if no {@link ComponentDescription} can be found.
 	 */
-	public static ComponentDescription getDescription(AstEditor editor, Class<?> componentClass) throws Exception {
+	public static ComponentDescription getDescription(AstEditor editor, Class<?> componentClass) {
 		ComponentDescription description = m_getDescription_Class.get(componentClass);
 		if (description == null) {
 			description = getDescription0(editor, componentClass);
@@ -263,7 +263,7 @@ public final class ComponentDescriptionHelper {
 	/**
 	 * Implementation for {@link #getDescription(AstEditor, Class)}.
 	 */
-	private static ComponentDescription getDescription0(AstEditor editor, Class<?> componentClass) throws Exception {
+	private static ComponentDescription getDescription0(AstEditor editor, Class<?> componentClass) {
 		// we should use component class that can be loaded, for example ignore
 		// anonymous classes
 		for (;; componentClass = componentClass.getSuperclass()) {
@@ -339,10 +339,10 @@ public final class ComponentDescriptionHelper {
 	 *
 	 * @return the {@link ComponentDescription} of component with given
 	 *         {@link Class}.
-	 * @throws Exception if no {@link ComponentDescription} can be found.
+	 * @throws DesignerException if no {@link ComponentDescription} can be found.
 	 */
 	private static ComponentDescription getDescription0(AstEditor editor, ComponentDescriptionKey key,
-			List<ClassResourceInfo> additionalDescriptionInfos) throws Exception {
+			List<ClassResourceInfo> additionalDescriptionInfos) {
 		EditorState state = EditorState.get(editor);
 		ILoadingContext context = EditorStateLoadingContext.get(state);
 		Class<?> componentClass = key.getComponentClass();

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/GenericProperty.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/GenericProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -52,7 +52,7 @@ public abstract class GenericProperty extends JavaProperty implements ITypedProp
 	 * @return the default value of this {@link GenericProperty}. This value is got from component
 	 *         directly after its creation, or set externally in component description.
 	 */
-	public abstract Object getDefaultValue() throws Exception;
+	public abstract Object getDefaultValue();
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -63,7 +63,7 @@ public abstract class GenericProperty extends JavaProperty implements ITypedProp
 	 * @return the {@link Expression} that was used for calculating value of this
 	 *         {@link GenericProperty}.
 	 */
-	public abstract Expression getExpression() throws Exception;
+	public abstract Expression getExpression();
 
 	/**
 	 * Changes value using Java source and (optional) value.

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/GenericPropertyComposite.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/GenericPropertyComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -117,7 +117,7 @@ public final class GenericPropertyComposite extends GenericProperty {
 	}
 
 	@Override
-	public Object getDefaultValue() throws Exception {
+	public Object getDefaultValue() {
 		Object value = NO_VALUE;
 		for (GenericProperty property : m_properties) {
 			Object propertyValue = property.getDefaultValue();
@@ -172,7 +172,7 @@ public final class GenericPropertyComposite extends GenericProperty {
 	 * @return {@link Expression} if all properties have {@link Expression}'s with same source.
 	 */
 	@Override
-	public Expression getExpression() throws Exception {
+	public Expression getExpression() {
 		Expression commonExpression = null;
 		String commonSource = null;
 		for (GenericProperty property : m_properties) {

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/GenericPropertyImpl.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/GenericPropertyImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -105,7 +105,7 @@ public final class GenericPropertyImpl extends GenericProperty {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public boolean isModified() throws Exception {
+	public boolean isModified() {
 		return getExpressionInfo() != null;
 	}
 
@@ -184,7 +184,7 @@ public final class GenericPropertyImpl extends GenericProperty {
 	}
 
 	@Override
-	public Object getDefaultValue() throws Exception {
+	public Object getDefaultValue() {
 		// if has forced default value from property, use it
 		if (m_defaultValue != UNKNOWN_VALUE) {
 			return m_defaultValue;
@@ -265,7 +265,7 @@ public final class GenericPropertyImpl extends GenericProperty {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Expression getExpression() throws Exception {
+	public Expression getExpression() {
 		ExpressionInfo expressionInfo = getExpressionInfo();
 		return expressionInfo != null ? expressionInfo.m_expression : null;
 	}
@@ -391,7 +391,7 @@ public final class GenericPropertyImpl extends GenericProperty {
 	 *
 	 * @return the current {@link ExpressionAccessor}'s.
 	 */
-	public List<ExpressionAccessor> getAccessors() throws Exception {
+	public List<ExpressionAccessor> getAccessors() {
 		List<ExpressionAccessor> accessors = new ArrayList<>();
 		// add "static" accessors
 		Collections.addAll(accessors, m_accessors);
@@ -416,7 +416,7 @@ public final class GenericPropertyImpl extends GenericProperty {
 	 * @return the {@link ExpressionInfo} for existing property {@link Expression} or
 	 *         <code>null</code> if not {@link Expression} was found.
 	 */
-	private ExpressionInfo getExpressionInfo() throws Exception {
+	private ExpressionInfo getExpressionInfo() {
 		for (ExpressionAccessor accessor : getAccessors()) {
 			Expression expression = accessor.getExpression(m_javaInfo);
 			if (expression != null) {

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/ConstructorAccessor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/ConstructorAccessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -46,7 +46,7 @@ public final class ConstructorAccessor extends ExpressionAccessor {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Expression getExpression(JavaInfo javaInfo) throws Exception {
+	public Expression getExpression(JavaInfo javaInfo) {
 		ClassInstanceCreation creation =
 				((ConstructorCreationSupport) javaInfo.getCreationSupport()).getCreation();
 		return DomGenerics.arguments(creation).get(m_index);

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/ExpressionAccessor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/ExpressionAccessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -49,7 +49,7 @@ public abstract class ExpressionAccessor extends AbstractDescription {
 	/**
 	 * @return the {@link Expression} for given {@link JavaInfo}.
 	 */
-	public abstract Expression getExpression(JavaInfo javaInfo) throws Exception;
+	public abstract Expression getExpression(JavaInfo javaInfo);
 
 	/**
 	 * Sets new expression with given source to the given {@link JavaInfo}.
@@ -87,7 +87,7 @@ public abstract class ExpressionAccessor extends AbstractDescription {
 	 * @return optional default value for this property or {@link Property#UNKNOWN_VALUE} if default
 	 *         value is unknown.
 	 */
-	public Object getDefaultValue(JavaInfo javaInfo) throws Exception {
+	public Object getDefaultValue(JavaInfo javaInfo) {
 		return Property.UNKNOWN_VALUE;
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/FactoryAccessor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/FactoryAccessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -47,7 +47,7 @@ public final class FactoryAccessor extends ExpressionAccessor {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Expression getExpression(JavaInfo javaInfo) throws Exception {
+	public Expression getExpression(JavaInfo javaInfo) {
 		MethodInvocation invocation = (MethodInvocation) javaInfo.getCreationSupport().getNode();
 		return DomGenerics.arguments(invocation).get(m_index);
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/FieldAccessor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/FieldAccessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -99,7 +99,7 @@ public final class FieldAccessor extends ExpressionAccessor {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Expression getExpression(JavaInfo javaInfo) throws Exception {
+	public Expression getExpression(JavaInfo javaInfo) {
 		Assignment assignment = getFieldAssignment(javaInfo);
 		return getExpression(assignment);
 	}
@@ -140,7 +140,7 @@ public final class FieldAccessor extends ExpressionAccessor {
 	}
 
 	@Override
-	public Object getDefaultValue(JavaInfo javaInfo) throws Exception {
+	public Object getDefaultValue(JavaInfo javaInfo) {
 		return javaInfo.getArbitraryValue(this);
 	}
 
@@ -196,7 +196,7 @@ public final class FieldAccessor extends ExpressionAccessor {
 	/**
 	 * @return the {@link Assignment} of this field accessor for given {@link JavaInfo}.
 	 */
-	private Assignment getFieldAssignment(JavaInfo javaInfo) throws Exception {
+	private Assignment getFieldAssignment(JavaInfo javaInfo) {
 		return javaInfo.getFieldAssignment(m_fieldName);
 	}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/InvocationChildAssociationAccessor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/InvocationChildAssociationAccessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -48,7 +48,7 @@ public final class InvocationChildAssociationAccessor extends ExpressionAccessor
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Expression getExpression(JavaInfo javaInfo) throws Exception {
+	public Expression getExpression(JavaInfo javaInfo) {
 		MethodInvocation invocation =
 				((InvocationAssociation) javaInfo.getAssociation()).getInvocation();
 		return DomGenerics.arguments(invocation).get(m_index);

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/MethodInvocationAccessor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/MethodInvocationAccessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -56,7 +56,7 @@ public final class MethodInvocationAccessor extends ExpressionAccessor {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Expression getExpression(JavaInfo javaInfo) throws Exception {
+	public Expression getExpression(JavaInfo javaInfo) {
 		return getMethodInvocation(javaInfo);
 	}
 
@@ -120,7 +120,7 @@ public final class MethodInvocationAccessor extends ExpressionAccessor {
 	/**
 	 * @return the {@link MethodInvocation} of this setter for given {@link JavaInfo}.
 	 */
-	private MethodInvocation getMethodInvocation(JavaInfo javaInfo) throws Exception {
+	private MethodInvocation getMethodInvocation(JavaInfo javaInfo) {
 		return javaInfo.getMethodInvocation(m_methodSignature);
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/MethodInvocationArgumentAccessor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/MethodInvocationArgumentAccessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -62,7 +62,7 @@ public final class MethodInvocationArgumentAccessor extends ExpressionAccessor {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Expression getExpression(JavaInfo javaInfo) throws Exception {
+	public Expression getExpression(JavaInfo javaInfo) {
 		MethodInvocation invocation = getMethodInvocation(javaInfo);
 		return getArgumentExpression(invocation);
 	}
@@ -114,7 +114,7 @@ public final class MethodInvocationArgumentAccessor extends ExpressionAccessor {
 	/**
 	 * @return the {@link MethodInvocation} of this setter for given {@link JavaInfo}.
 	 */
-	private MethodInvocation getMethodInvocation(JavaInfo javaInfo) throws Exception {
+	private MethodInvocation getMethodInvocation(JavaInfo javaInfo) {
 		return javaInfo.getMethodInvocation(m_methodSignature);
 	}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/SetterAccessor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/SetterAccessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -115,7 +115,7 @@ public final class SetterAccessor extends ExpressionAccessor {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Expression getExpression(JavaInfo javaInfo) throws Exception {
+	public Expression getExpression(JavaInfo javaInfo) {
 		MethodInvocation invocation = getMethodInvocation(javaInfo);
 		return getExpression(invocation);
 	}
@@ -157,7 +157,7 @@ public final class SetterAccessor extends ExpressionAccessor {
 	}
 
 	@Override
-	public Object getDefaultValue(JavaInfo javaInfo) throws Exception {
+	public Object getDefaultValue(JavaInfo javaInfo) {
 		return javaInfo.getArbitraryValue(this);
 	}
 
@@ -213,7 +213,7 @@ public final class SetterAccessor extends ExpressionAccessor {
 	/**
 	 * @return the {@link MethodInvocation} of this setter for given {@link JavaInfo}.
 	 */
-	private MethodInvocation getMethodInvocation(JavaInfo javaInfo) throws Exception {
+	private MethodInvocation getMethodInvocation(JavaInfo javaInfo) {
 		return javaInfo.getMethodInvocation(m_setterSignature);
 	}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/SuperConstructorAccessor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/SuperConstructorAccessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -50,7 +50,7 @@ public final class SuperConstructorAccessor extends ExpressionAccessor {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Expression getExpression(JavaInfo javaInfo) throws Exception {
+	public Expression getExpression(JavaInfo javaInfo) {
 		return DomGenerics.arguments(m_invocation).get(m_index);
 	}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/BooleanArrayConverter.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/BooleanArrayConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ public final class BooleanArrayConverter extends ExpressionConverter {
 	// Instance
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public static final ExpressionConverter INSTANCE = new BooleanArrayConverter();
+	public static final BooleanArrayConverter INSTANCE = new BooleanArrayConverter();
 
 	private BooleanArrayConverter() {
 	}
@@ -35,7 +35,7 @@ public final class BooleanArrayConverter extends ExpressionConverter {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public String toJavaSource(JavaInfo javaInfo, Object value) throws Exception {
+	public String toJavaSource(JavaInfo javaInfo, Object value) {
 		if (value == null) {
 			return "(boolean[]) null";
 		} else {

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/BooleanConverter.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/BooleanConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ public final class BooleanConverter extends ExpressionConverter {
 	// Instance
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public static final ExpressionConverter INSTANCE = new BooleanConverter();
+	public static final BooleanConverter INSTANCE = new BooleanConverter();
 
 	private BooleanConverter() {
 	}
@@ -35,7 +35,7 @@ public final class BooleanConverter extends ExpressionConverter {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public String toJavaSource(JavaInfo javaInfo, Object value) throws Exception {
+	public String toJavaSource(JavaInfo javaInfo, Object value) {
 		return ((Boolean) value).toString();
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/BooleanObjectConverter.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/BooleanObjectConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,7 +27,7 @@ public final class BooleanObjectConverter extends ExpressionConverter {
 	// Instance
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public static final ExpressionConverter INSTANCE = new BooleanObjectConverter();
+	public static final BooleanObjectConverter INSTANCE = new BooleanObjectConverter();
 
 	private BooleanObjectConverter() {
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/ByteConverter.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/ByteConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ public final class ByteConverter extends ExpressionConverter {
 	// Instance
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public static final ExpressionConverter INSTANCE = new ByteConverter();
+	public static final ByteConverter INSTANCE = new ByteConverter();
 
 	private ByteConverter() {
 	}
@@ -35,7 +35,7 @@ public final class ByteConverter extends ExpressionConverter {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public String toJavaSource(JavaInfo javaInfo, Object value) throws Exception {
+	public String toJavaSource(JavaInfo javaInfo, Object value) {
 		return "(byte) " + ((Byte) value).toString();
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/ByteObjectConverter.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/ByteObjectConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ public final class ByteObjectConverter extends AbstractNumberConverter {
 	// Instance
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public static final ExpressionConverter INSTANCE = new ByteObjectConverter();
+	public static final ByteObjectConverter INSTANCE = new ByteObjectConverter();
 
 	private ByteObjectConverter() {
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/CharacterConverter.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/CharacterConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ public final class CharacterConverter extends ExpressionConverter {
 	// Instance
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public static final ExpressionConverter INSTANCE = new CharacterConverter();
+	public static final CharacterConverter INSTANCE = new CharacterConverter();
 
 	private CharacterConverter() {
 	}
@@ -35,7 +35,7 @@ public final class CharacterConverter extends ExpressionConverter {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public String toJavaSource(JavaInfo javaInfo, Object value) throws Exception {
+	public String toJavaSource(JavaInfo javaInfo, Object value) {
 		return "'" + ((Character) value).charValue() + "'";
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/DoubleConverter.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/DoubleConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ public final class DoubleConverter extends ExpressionConverter {
 	// Instance
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public static final ExpressionConverter INSTANCE = new DoubleConverter();
+	public static final DoubleConverter INSTANCE = new DoubleConverter();
 
 	private DoubleConverter() {
 	}
@@ -35,7 +35,7 @@ public final class DoubleConverter extends ExpressionConverter {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public String toJavaSource(JavaInfo javaInfo, Object value) throws Exception {
+	public String toJavaSource(JavaInfo javaInfo, Object value) {
 		double doubleValue = ((Number) value).doubleValue();
 		return Double.toString(doubleValue);
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/DoubleObjectConverter.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/DoubleObjectConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ public final class DoubleObjectConverter extends AbstractNumberConverter {
 	// Instance
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public static final ExpressionConverter INSTANCE = new DoubleObjectConverter();
+	public static final DoubleObjectConverter INSTANCE = new DoubleObjectConverter();
 
 	private DoubleObjectConverter() {
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/FloatConverter.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/FloatConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ public final class FloatConverter extends ExpressionConverter {
 	// Instance
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public static final ExpressionConverter INSTANCE = new FloatConverter();
+	public static final FloatConverter INSTANCE = new FloatConverter();
 
 	private FloatConverter() {
 	}
@@ -35,7 +35,7 @@ public final class FloatConverter extends ExpressionConverter {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public String toJavaSource(JavaInfo javaInfo, Object value) throws Exception {
+	public String toJavaSource(JavaInfo javaInfo, Object value) {
 		return ((Float) value).toString() + "f";
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/IntegerArrayConverter.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/IntegerArrayConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ public final class IntegerArrayConverter extends ExpressionConverter {
 	// Instance
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public static final ExpressionConverter INSTANCE = new IntegerArrayConverter();
+	public static final IntegerArrayConverter INSTANCE = new IntegerArrayConverter();
 
 	private IntegerArrayConverter() {
 	}
@@ -35,7 +35,7 @@ public final class IntegerArrayConverter extends ExpressionConverter {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public String toJavaSource(JavaInfo javaInfo, Object value) throws Exception {
+	public String toJavaSource(JavaInfo javaInfo, Object value) {
 		if (value == null) {
 			return "(int[]) null";
 		} else {

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/IntegerConverter.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/IntegerConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ public final class IntegerConverter extends ExpressionConverter {
 	// Instance
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public static final ExpressionConverter INSTANCE = new IntegerConverter();
+	public static final IntegerConverter INSTANCE = new IntegerConverter();
 
 	private IntegerConverter() {
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/IntegerObjectConverter.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/IntegerObjectConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ public final class IntegerObjectConverter extends AbstractNumberConverter {
 	// Instance
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public static final ExpressionConverter INSTANCE = new IntegerObjectConverter();
+	public static final IntegerObjectConverter INSTANCE = new IntegerObjectConverter();
 
 	private IntegerObjectConverter() {
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/LocaleConverter.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/LocaleConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,7 +28,7 @@ public final class LocaleConverter extends ExpressionConverter {
 	// Instance
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public static final ExpressionConverter INSTANCE = new LocaleConverter();
+	public static final LocaleConverter INSTANCE = new LocaleConverter();
 
 	private LocaleConverter() {
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/LongConverter.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/LongConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ public final class LongConverter extends ExpressionConverter {
 	// Instance
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public static final ExpressionConverter INSTANCE = new LongConverter();
+	public static final LongConverter INSTANCE = new LongConverter();
 
 	private LongConverter() {
 	}
@@ -35,7 +35,7 @@ public final class LongConverter extends ExpressionConverter {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public String toJavaSource(JavaInfo javaInfo, Object value) throws Exception {
+	public String toJavaSource(JavaInfo javaInfo, Object value) {
 		return ((Long) value).toString() + "L";
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/LongObjectConverter.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/LongObjectConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ public final class LongObjectConverter extends AbstractNumberConverter {
 	// Instance
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public static final ExpressionConverter INSTANCE = new LongObjectConverter();
+	public static final LongObjectConverter INSTANCE = new LongObjectConverter();
 
 	private LongObjectConverter() {
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/ShortConverter.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/ShortConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ public final class ShortConverter extends ExpressionConverter {
 	// Instance
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public static final ExpressionConverter INSTANCE = new ShortConverter();
+	public static final ShortConverter INSTANCE = new ShortConverter();
 
 	private ShortConverter() {
 	}
@@ -35,7 +35,7 @@ public final class ShortConverter extends ExpressionConverter {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public String toJavaSource(JavaInfo javaInfo, Object value) throws Exception {
+	public String toJavaSource(JavaInfo javaInfo, Object value) {
 		return "(short) " + ((Short) value).toString();
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/ShortObjectConverter.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/ShortObjectConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ public final class ShortObjectConverter extends AbstractNumberConverter {
 	// Instance
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public static final ExpressionConverter INSTANCE = new ShortObjectConverter();
+	public static final ShortObjectConverter INSTANCE = new ShortObjectConverter();
 
 	private ShortObjectConverter() {
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/StringArrayConverter.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/StringArrayConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ public final class StringArrayConverter extends ExpressionConverter {
 	// Instance
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public static final ExpressionConverter INSTANCE = new StringArrayConverter();
+	public static final StringArrayConverter INSTANCE = new StringArrayConverter();
 
 	private StringArrayConverter() {
 	}
@@ -35,7 +35,7 @@ public final class StringArrayConverter extends ExpressionConverter {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public String toJavaSource(JavaInfo javaInfo, Object value) throws Exception {
+	public String toJavaSource(JavaInfo javaInfo, Object value) {
 		if (value == null) {
 			return "(String[]) null";
 		} else {

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/StringConverter.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/StringConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,7 +29,7 @@ public final class StringConverter extends ExpressionConverter {
 	// Instance
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public static final ExpressionConverter INSTANCE = new StringConverter();
+	public static final StringConverter INSTANCE = new StringConverter();
 
 	private StringConverter() {
 	}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/WorkbenchWindowAdvisorPropertiesProvider.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/WorkbenchWindowAdvisorPropertiesProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -247,7 +247,7 @@ final class WorkbenchWindowAdvisorPropertiesProvider {
 		//
 		////////////////////////////////////////////////////////////////////////////
 		@Override
-		public Expression getExpression(JavaInfo javaInfo) throws Exception {
+		public Expression getExpression(JavaInfo javaInfo) {
 			MethodInvocation invocation = getInvocation();
 			if (invocation != null) {
 				return DomGenerics.arguments(invocation).get(0);

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/parser/DefaultComponentFactoryCreationSupport.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/parser/DefaultComponentFactoryCreationSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -65,7 +65,7 @@ ILiveCreationSupport {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public void addAccessors(GenericPropertyDescription propertyDescription,
-			List<ExpressionAccessor> accessors) throws Exception {
+			List<ExpressionAccessor> accessors) {
 		if (propertyDescription.getId().equals("setText(java.lang.String)")) {
 			String signature = getSignature();
 			if (signature.equals("createLabel(java.lang.String)")

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/bean/AbstractActionInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/bean/AbstractActionInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -193,7 +193,7 @@ public class AbstractActionInfo extends ActionInfo {
 					final int index = parameter.getIndex();
 					return new ExpressionAccessor() {
 						@Override
-						public Expression getExpression(JavaInfo javaInfo) throws Exception {
+						public Expression getExpression(JavaInfo javaInfo) {
 							ASTNode creationNode = creationInfo.getCreation();
 							return DomGenerics.arguments(creationNode).get(index);
 						}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/bean/ActionExpressionAccessor.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/bean/ActionExpressionAccessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -67,7 +67,7 @@ public final class ActionExpressionAccessor extends ExpressionAccessor {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Expression getExpression(JavaInfo javaInfo) throws Exception {
+	public Expression getExpression(JavaInfo javaInfo) {
 		for (Block block : m_actionInfo.getInitializationBlocks()) {
 			for (Statement statement : DomGenerics.statements(block)) {
 				Expression expression = null;
@@ -87,8 +87,7 @@ public final class ActionExpressionAccessor extends ExpressionAccessor {
 		return null;
 	}
 
-	private Expression getExpression_SuperConstructorInvocation(SuperConstructorInvocation invocation)
-			throws Exception {
+	private Expression getExpression_SuperConstructorInvocation(SuperConstructorInvocation invocation) {
 		// prepare description
 		ConstructorDescription constructor = m_actionInfo.getConstructorDescription();
 		// analyze arguments

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/bean/IActionSupport.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/bean/IActionSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -34,10 +34,10 @@ public interface IActionSupport {
 	/**
 	 * @return list {@link Block} containing initialization source code.
 	 */
-	List<Block> getInitializationBlocks() throws Exception;
+	List<Block> getInitializationBlocks();
 
 	/**
 	 * @return {@link ConstructorDescription} for action instance creation.
 	 */
-	ConstructorDescription getConstructorDescription() throws Exception;
+	ConstructorDescription getConstructorDescription();
 }

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/JTabbedPaneAtAccessor.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/JTabbedPaneAtAccessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -63,7 +63,7 @@ public final class JTabbedPaneAtAccessor extends ExpressionAccessor {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Expression getExpression(JavaInfo javaInfo) throws Exception {
+	public Expression getExpression(JavaInfo javaInfo) {
 		MethodInvocation invocation = getMethodInvocation();
 		// check if valid creation found
 		if (invocation != null) {
@@ -129,7 +129,7 @@ public final class JTabbedPaneAtAccessor extends ExpressionAccessor {
 	 * @return the {@link MethodInvocation} for this {@link JTabbedPaneInfo} and {@link ComponentInfo}
 	 *         .
 	 */
-	private MethodInvocation getMethodInvocation() throws Exception {
+	private MethodInvocation getMethodInvocation() {
 		int componentIndex = getComponentIndex();
 		Assert.isTrue(componentIndex >= 0);
 		//

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/BorderPropertyEditor.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/BorderPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -183,12 +183,12 @@ IClipboardSourceProvider {
 						}
 
 						@Override
-						public Expression getExpression() throws Exception {
+						public Expression getExpression() {
 							return argument;
 						}
 
 						@Override
-						public Object getDefaultValue() throws Exception {
+						public Object getDefaultValue() {
 							return UNKNOWN_VALUE;
 						}
 					});

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/property/editor/image/ImageEvaluator.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/property/editor/image/ImageEvaluator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -140,7 +140,7 @@ public class ImageEvaluator implements IExpressionEvaluator {
 	 *         {@link AbstractUIPlugin#imageDescriptorFromPlugin(String,String)} or
 	 *         {@code null} otherwise.
 	 */
-	public static String[] getPluginImageValue(Property property) throws Exception {
+	public static String[] getPluginImageValue(Property property) {
 		Expression expression = ((GenericProperty) property).getExpression();
 		if (isAbstractUiPlugin(expression) || isNewResourceManager(expression)) {
 			MethodInvocation invocation = (MethodInvocation) expression;
@@ -171,7 +171,7 @@ public class ImageEvaluator implements IExpressionEvaluator {
 	// Workspace utils
 	//
 	////////////////////////////////////////////////////////////////////////////
-	private static IProject getProjectOverActivator(Expression activatorAccessNode) throws Exception {
+	private static IProject getProjectOverActivator(Expression activatorAccessNode) {
 		if (activatorAccessNode instanceof MethodInvocation pluginAccessInvocation) {
 			String activatorClass =
 					AstNodeUtils.getFullyQualifiedName(pluginAccessInvocation.getExpression(), false);

--- a/org.eclipse.wb.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: WindowBuilder Tests
 Bundle-SymbolicName: org.eclipse.wb.tests;singleton:=true
-Bundle-Version: 1.4.0.qualifier
+Bundle-Version: 1.4.100.qualifier
 Bundle-Activator: org.eclipse.wb.tests.designer.tests.Activator
 Bundle-Vendor: Google
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.wb.tests/pom.xml
+++ b/org.eclipse.wb.tests/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.wb</groupId>
   <artifactId>org.eclipse.wb.tests</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
  

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/PropertyTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/PropertyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -248,7 +248,7 @@ public class PropertyTest extends SwingModelTest {
 	private static GenericPropertyNoValue create_GenericProperty_defaultValue(final String defaultValue) {
 		return new GenericPropertyNoValue(null, "title", StringPropertyEditor.INSTANCE) {
 			@Override
-			public Object getDefaultValue() throws Exception {
+			public Object getDefaultValue() {
 				return defaultValue;
 			}
 		};

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/bean/ActionTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/bean/ActionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -1158,7 +1158,7 @@ public class ActionTest extends SwingModelTest {
 				ActionExpressionAccessor accessor =
 						new ActionExpressionAccessor(new LazyActionSupport(constructor) {
 							@Override
-							public ConstructorDescription getConstructorDescription() throws Exception {
+							public ConstructorDescription getConstructorDescription() {
 								ComponentDescription description =
 										ComponentDescriptionHelper.getDescription(
 												panel.getEditor(),
@@ -1176,7 +1176,7 @@ public class ActionTest extends SwingModelTest {
 				ActionExpressionAccessor accessor =
 						new ActionExpressionAccessor(new LazyActionSupport(constructor) {
 							@Override
-							public ConstructorDescription getConstructorDescription() throws Exception {
+							public ConstructorDescription getConstructorDescription() {
 								ComponentDescription description =
 										ComponentDescriptionHelper.getDescription(
 												panel.getEditor(),
@@ -1887,7 +1887,7 @@ public class ActionTest extends SwingModelTest {
 		}
 
 		@Override
-		public ConstructorDescription getConstructorDescription() throws Exception {
+		public ConstructorDescription getConstructorDescription() {
 			return null;
 		}
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/tests/common/GenericPropertyNoValue.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/tests/common/GenericPropertyNoValue.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -47,7 +47,7 @@ public class GenericPropertyNoValue extends GenericProperty {
 	}
 
 	@Override
-	public Object getDefaultValue() throws Exception {
+	public Object getDefaultValue() {
 		return UNKNOWN_VALUE;
 	}
 
@@ -66,7 +66,7 @@ public class GenericPropertyNoValue extends GenericProperty {
 	}
 
 	@Override
-	public Expression getExpression() throws Exception {
+	public Expression getExpression() {
 		return null;
 	}
 


### PR DESCRIPTION
This removes the "throws Exception" section from several methods of our data model where no exception is thrown. Doings so avoids having to explicitly wrap those method calls in a try-catch block, even though an exception can't occur.