### PR TITLE
Always show scrollbar in property table to avoid obscured buttons

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/table/PropertyTable.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/table/PropertyTable.java
@@ -139,6 +139,7 @@ public class PropertyTable extends ScrollingGraphicalViewer {
 		setEditPartFactory(new PropertyEditPartFactory());
 		setEditDomain(new PropertyEditDomain());
 		getControl().addListener(SWT.Resize, event -> handleResize());
+		getControl().setScrollbarsMode(SWT.NONE);
 		// calculate sizes
 		m_rowHeight = 1 + FigureUtilities.getFontMetrics(getControl().getFont()).getHeight() + 1;
 		m_baseFont = parent.getFont();

--- a/target-platform/wb.target
+++ b/target-platform/wb.target
@@ -4,6 +4,7 @@
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/staging/2024-09/"/>
+			<repository location="https://download.eclipse.org/tools/gef/classic/nightly/latest"/>
 			<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.gef.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>


### PR DESCRIPTION
This effectively disables the scrollbar overlay so avoid weird situations where buttons can't be clicked because they are obscured by the srollbar itself.

Furthermore updates to the latest GEF build in order to fix other issues where the scrollbar bounds are not considered when updating the bounds of the root figure.

Fixes https://github.com/eclipse-windowbuilder/windowbuilder/issues/795