### PR TITLE
Raise lower bound of SWT bundle to 3.126

### DIFF
--- a/org.eclipse.wb.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core/META-INF/MANIFEST.MF
@@ -143,7 +143,7 @@ Import-Package: org.apache.commons.collections4;version="[4.4.0,5.0.0)",
  org.apache.commons.text;version="[1.11.0,2.0.0)",
  org.burningwave.core.assembler,
  org.burningwave.core.classes
-Require-Bundle: org.eclipse.ui;visibility:=reexport,
+Require-Bundle: org.eclipse.ui;bundle-version="3.206.0";visibility:=reexport,
  org.eclipse.ui.editors,
  org.eclipse.ui.ide;visibility:=reexport,
  org.eclipse.core.runtime,


### PR DESCRIPTION
The PropertyTable class calls the method FigureCanvas.setScrollbarsMode which has been introduced with the given version. Trying to use the editor with an older version otherwise leads to a NoSuchMethodError.

The bound is set implicitly via org.eclipse.ui, which re-exports the SWT bundle.

Amends e6c43ce3c25e2a893acf2e90e04dd0ba68402c7b