### PR TITLE
Update JavaDoc to remove references to old Observable API

### DIFF
--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/ObservableCodeSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/ObservableCodeSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,7 @@ import java.util.List;
 
 /**
  * Source code generator for owner {@link ObservableInfo}. {@link ObservableInfo} can have multiple
- * code generators (f.e. BeansObservables or BeanProperties).
+ * code generators (f.e. BeanProperties).
  *
  * @author lobas_av
  * @coverage bindings.rcp.model

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/BeanObservableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/BeanObservableInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,7 @@ import org.eclipse.wb.internal.rcp.databinding.model.ObservableInfo;
 import org.eclipse.wb.internal.rcp.databinding.model.beans.IMasterDetailProvider;
 
 /**
- * Abstract model for observable objects <code>BeansObservables.observeXXX(...)</code>.
+ * Abstract model for observable objects {@code BeanProperties.XXX(...).observe(...)}.
  *
  * @author lobas_av
  * @coverage bindings.rcp.model.beans

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/DetailListBeanObservableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/DetailListBeanObservableInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,7 @@ package org.eclipse.wb.internal.rcp.databinding.model.beans.observables;
 import org.eclipse.wb.internal.rcp.databinding.model.ObservableInfo;
 
 /**
- * Model for observable object <code>BeansObservables.observeDetailList(...)</code>.
+ * Model for observable object {@code BeanProperties.list(...).observeDetail(...)}.
  *
  * @author lobas_av
  * @coverage bindings.rcp.model.beans

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/DetailSetBeanObservableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/DetailSetBeanObservableInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,7 @@ package org.eclipse.wb.internal.rcp.databinding.model.beans.observables;
 import org.eclipse.wb.internal.rcp.databinding.model.ObservableInfo;
 
 /**
- * Model for observable object <code>BeansObservables.observeDetailSet(...)</code>.
+ * Model for observable object {@code BeanProperties.set(...).observeDetail(...)}.
  *
  * @author lobas_av
  * @coverage bindings.rcp.model.beans

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/DetailValueBeanObservableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/DetailValueBeanObservableInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,7 @@ package org.eclipse.wb.internal.rcp.databinding.model.beans.observables;
 import org.eclipse.wb.internal.rcp.databinding.model.ObservableInfo;
 
 /**
- * Model for observable object <code>BeansObservables.observeDetailValue(...)</code>.
+ * Model for observable object {@code BeanProperties.value(...).observeDetail(...)}.
  *
  * @author lobas_av
  * @coverage bindings.rcp.model.beans

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/ListBeanObservableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/ListBeanObservableInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,7 @@ import org.eclipse.wb.internal.rcp.databinding.model.beans.bindables.BeanBindabl
 import org.eclipse.wb.internal.rcp.databinding.model.beans.bindables.BeanPropertyBindableInfo;
 
 /**
- * Model for observable object <code>BeansObservables.observeList(...)</code>.
+ * Model for observable object {@code BeanProperties.list(...).observe(...)}.
  *
  * @author lobas_av
  * @coverage bindings.rcp.model.beans

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/SetBeanObservableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/SetBeanObservableInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,7 @@ import org.eclipse.wb.internal.rcp.databinding.model.beans.bindables.BeanBindabl
 import org.eclipse.wb.internal.rcp.databinding.model.beans.bindables.BeanPropertyBindableInfo;
 
 /**
- * Model for observable object <code>BeansObservables.observeSet(...)</code>.
+ * Model for observable object {@code BeanProperties.set(...).observe(...)}.
  *
  * @author lobas_av
  * @coverage bindings.rcp.model.beans

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/ValueBeanObservableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/ValueBeanObservableInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,7 @@ import org.eclipse.wb.internal.rcp.databinding.model.beans.bindables.BeanBindabl
 import org.eclipse.wb.internal.rcp.databinding.model.beans.bindables.BeanPropertyBindableInfo;
 
 /**
- * Model for observable object <code>BeansObservables.observeValue(...)</code>.
+ * Model for observable object {@code BeanProperties.value(...).observe(...)}.
  *
  * @author lobas_av
  * @coverage bindings.rcp.model.beans

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/standard/BeanObservableDetailListCodeSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/standard/BeanObservableDetailListCodeSupport.java
@@ -19,7 +19,7 @@ import org.eclipse.wb.internal.rcp.databinding.model.beans.observables.DetailBea
 import java.util.List;
 
 /**
- * Model for observable object {@code BeansObservables.observeDetailList(...)}.
+ * Model for observable object {@code BeanProperties.list(...).observeDetail(...)}.
  *
  * @author lobas_av
  * @coverage bindings.rcp.model.beans

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/standard/BeanObservableDetailSetCodeSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/standard/BeanObservableDetailSetCodeSupport.java
@@ -19,7 +19,7 @@ import org.eclipse.wb.internal.rcp.databinding.model.beans.observables.DetailBea
 import java.util.List;
 
 /**
- * Model for observable object {@code BeansObservables.observeDetailSet(...)}.
+ * Model for observable object {@code BeanProperties.set(...).observeDetail(...)}.
  *
  * @author lobas_av
  * @coverage bindings.rcp.model.beans

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/standard/BeanObservableDetailValueCodeSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/standard/BeanObservableDetailValueCodeSupport.java
@@ -19,7 +19,7 @@ import org.eclipse.wb.internal.rcp.databinding.model.beans.observables.DetailBea
 import java.util.List;
 
 /**
- * Model for observable object {@code BeansObservables.observeDetailValue(...)}.
+ * Model for observable object {@code BeanProperties.value(...).observeDetail(...)}.
  *
  * @author lobas_av
  * @coverage bindings.rcp.model.beans

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/standard/BeanObservableListCodeSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/standard/BeanObservableListCodeSupport.java
@@ -18,7 +18,7 @@ import org.eclipse.wb.internal.rcp.databinding.model.ObservableInfo;
 import java.util.List;
 
 /**
- * Model for observable object {@code BeansObservables.observeList(...)}.
+ * Model for observable object {@code BeanProperties.list(...).observe(...)}.
  *
  * @author lobas_av
  * @coverage bindings.rcp.model.beans

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/standard/BeanObservableSetCodeSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/standard/BeanObservableSetCodeSupport.java
@@ -18,7 +18,7 @@ import org.eclipse.wb.internal.rcp.databinding.model.ObservableInfo;
 import java.util.List;
 
 /**
- * Model for observable object {@code BeansObservables.observeSet(...)}.
+ * Model for observable object {@code BeanProperties.set(...).observe(...)}.
  *
  * @author lobas_av
  * @coverage bindings.rcp.model.beans

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/standard/BeanObservableValueCodeSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/standard/BeanObservableValueCodeSupport.java
@@ -18,7 +18,7 @@ import org.eclipse.wb.internal.rcp.databinding.model.ObservableInfo;
 import java.util.List;
 
 /**
- * Model for observable object {@code BeansObservables.observeValue(...)}.
+ * Model for observable object {@code BeanProperties.value(...).observe(...)}.
  *
  * @author lobas_av
  * @coverage bindings.rcp.model.beans


### PR DESCRIPTION
Amends 43e676f2de7a2da38306bbe813252e77f65eee9f
See https://github.com/eclipse-windowbuilder/windowbuilder/issues/492