### PR TITLE
Fix partial initialization of ImplicitLayoutCreationSupport

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/ContainerInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/ContainerInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -629,13 +629,13 @@ public class ContainerInfo extends ComponentInfo {
 		Class<?> preferenceDefaultLayoutClass = null;
 		IPreferenceStore preferences = getDescription().getToolkit().getPreferences();
 		String layoutId = preferences.getString(IPreferenceConstants.P_LAYOUT_DEFAULT);
-		CreationSupport creationSupport = new ImplicitLayoutCreationSupport(this);
 		if (layoutId != "") {
 			LayoutDescription ldescription = LayoutDescriptionHelper.get(getDescription().getToolkit(), layoutId);
 			if (ldescription != null) {
 				String layoutClassName = ldescription.getLayoutClassName();
 				ClassLoader editorLoader = EditorState.get(getEditor()).getEditorLoader();
 				preferenceDefaultLayoutClass = editorLoader.loadClass(layoutClassName);
+				CreationSupport creationSupport = new ImplicitLayoutCreationSupport(this);
 				layoutInf = (LayoutInfo) JavaInfoUtils.createJavaInfo(getEditor(), preferenceDefaultLayoutClass,
 						creationSupport);
 			}

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/widgets/CompositeInfo.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/widgets/CompositeInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc. and others
+ * Copyright (c) 2011, 2024 Google, Inc. and others
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -734,7 +734,6 @@ IThisMethodParameterEvaluator {
 		Class<?> preferenceDefaultlayoutClass = null;
 		IPreferenceStore preferences = getDescription().getToolkit().getPreferences();
 		String layoutId = preferences.getString(IPreferenceConstants.P_LAYOUT_DEFAULT);
-		CreationSupport creationSupport = new ImplicitLayoutCreationSupport(this);
 		if (layoutId != "") {
 			// handle the case that "Implicit" is specified in the preferences
 			//handle the case that another layout has been specified as default
@@ -748,7 +747,7 @@ IThisMethodParameterEvaluator {
 						.getNode(IEditorPreferenceConstants.P_AVAILABLE_LAYOUTS_NODE).getBoolean(layoutClassName, true)) {
 					return layoutInfo = AbsoluteLayoutInfo.createExplicit(this);
 				}
-
+				CreationSupport creationSupport = new ImplicitLayoutCreationSupport(this);
 				layoutInfo = (LayoutInfo) JavaInfoUtils.createJavaInfo(
 						getEditor(),
 						preferenceDefaultlayoutClass,


### PR DESCRIPTION
When a new instance of ImplicitLayoutCreationSupport is created, one must make sure that setJavaInfo is called. This is normally done when calling JavaInfoUtils.createJavaInfo().

Failing to do so results in a AssertionFailedException, when an object is removed from the container again. To reproduce, simply create a JFrame, add a JPanel and then immediately remove it again.

Amends 280f8aa3282dce10f92e7d2cbe7077071aa11836
Fixes https://github.com/eclipse-windowbuilder/windowbuilder/issues/813