### PR TITLE
Fix NPE when MigLayout bundle has been added as external jar

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/model/entry/BundleLibraryInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/model/entry/BundleLibraryInfo.java
@@ -72,6 +72,11 @@ public final class BundleLibraryInfo implements LibraryInfo {
 
 		if (type != null) {
 			IResource bundleFile = type.getResource();
+			if (bundleFile == null) {
+				// Added as external library to the classpath
+				return;
+			}
+
 			Version bundleVersion = getBundleVersion(bundleFile);
 
 			if (bundleVersion == null || bundleVersion.compareTo(bundle.getVersion()) < 0) {


### PR DESCRIPTION
When a bundle is not in the workspace, the call to getResource() returns null, leading to an exception when trying to extract the bundle version.

We mustn't modify files outside the workspace, so we simply return early.

Fixes https://github.com/eclipse-windowbuilder/windowbuilder/issues/819