### PR TITLE
Update organisation hosting the dash-license yaml file.

### DIFF
--- a/.github/workflows/license-review.yml
+++ b/.github/workflows/license-review.yml
@@ -8,7 +8,7 @@ jobs:
   call-license-check:
     permissions:
       pull-requests: write
-    uses: eclipse/dash-licenses/.github/workflows/mavenLicenseCheck.yml@90ebdf14dff066293b65b9d3ca99c8fb90d5222b
+    uses: eclipse-dash/dash-licenses/.github/workflows/mavenLicenseCheck.yml@90ebdf14dff066293b65b9d3ca99c8fb90d5222b # 1.1.0
     with:
       projectId: tools.windowbuilder
     secrets:

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -9,7 +9,7 @@ on:
       - master
 jobs:
   check-dash-licenses:
-    uses: eclipse/dash-licenses/.github/workflows/mavenLicenseCheck.yml@90ebdf14dff066293b65b9d3ca99c8fb90d5222b
+    uses: eclipse-dash/dash-licenses/.github/workflows/mavenLicenseCheck.yml@90ebdf14dff066293b65b9d3ca99c8fb90d5222b # 1.1.0
     with:
       projectId: tools.windowbuilder
   build:


### PR DESCRIPTION
The organisation has changed from eclipse to eclipse-dash. No clue why the URL forwarding doesn't work...