### PR TITLE
[GEF] Remove duplicate activate/deactivate methods in edit part

### DIFF
--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/EditPart.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/EditPart.java
@@ -12,10 +12,8 @@ package org.eclipse.wb.gef.core;
 
 import org.eclipse.wb.internal.gef.core.EditPartVisitor;
 
-import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.Request;
-import org.eclipse.gef.RootEditPart;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.commands.CompoundCommand;
 
@@ -36,92 +34,6 @@ import java.util.Map;
  * @coverage gef.core
  */
 public abstract class EditPart extends org.eclipse.gef.editparts.AbstractEditPart {
-	////////////////////////////////////////////////////////////////////////////
-	//
-	// Activate/Deactivate
-	//
-	////////////////////////////////////////////////////////////////////////////
-	/**
-	 * Activates the {@link EditPart}. EditParts that observe a dynamic model or support editing must
-	 * be <i>active</i>. Called by the managing {@link EditPart}, or the Viewer in the case of the
-	 * {@link RootEditPart}. This method may be called again once {@link #deactivate()} has been
-	 * called.
-	 * <P>
-	 * During activation the receiver should:
-	 * <UL>
-	 * <LI>begin to observe its model if appropriate, and should continue the observation until
-	 * {@link #deactivate()} is called.
-	 * <LI>activate all of its EditPolicies. EditPolicies may also observe the model, although this is
-	 * rare. But it is common for EditPolicies to contribute additional visuals, such as selection
-	 * handles or feedback during interactions. Therefore it is necessary to tell the EditPolicies
-	 * when to start doing this, and when to stop.
-	 * <LI>call activate() on the EditParts it manages. This includes its children.
-	 * </UL>
-	 */
-	@Override
-	public void activate() {
-		setFlag(FLAG_ACTIVE, true);
-		activateEditPolicies();
-		for (EditPart childPart : getChildren()) {
-			childPart.activate();
-		}
-	}
-
-	/**
-	 * Deactivates the {@link EditPart}. EditParts that observe a dynamic model or support editing
-	 * must be <i>active</i>. <code>deactivate()</code> is guaranteed to be called when an EditPart
-	 * will no longer be used. Called by the managing EditPart, or the Viewer in the case of the
-	 * {@link RootEditPart}. This method may be called multiple times.
-	 * <P>
-	 * During deactivation the receiver should:
-	 * <UL>
-	 * <LI>remove all listeners that were added in {@link #activate}
-	 * <LI>deactivate all of its EditPolicies. EditPolicies may be contributing additional visuals,
-	 * such as selection handles or feedback during interactions. Therefore it is necessary to tell
-	 * the EditPolicies when to start doing this, and when to stop.
-	 * <LI>call deactivate() on the EditParts it manages. This includes its children.
-	 * </UL>
-	 */
-	@Override
-	public void deactivate() {
-		for (EditPart childPart : getChildren()) {
-			childPart.deactivate();
-		}
-		deactivateEditPolicies();
-		setFlag(FLAG_ACTIVE, false);
-	}
-
-	/**
-	 * Called <em>after</em> the {@link EditPart} has been added to its parent. This is used to
-	 * indicate to the {@link EditPart} that it should refresh itself for the first time.
-	 */
-	@Override
-	public void addNotify() {
-		getViewer().registerEditPart(this);
-		createEditPolicies();
-		for (EditPart childPart : getChildren()) {
-			childPart.addNotify();
-		}
-		refresh();
-	}
-
-	/**
-	 * Called when the {@link EditPart} is being permanently removed from its {@link EditPartViewer}.
-	 * This indicates that the {@link EditPart} will no longer be in the Viewer, and therefore should
-	 * remove itself from the Viewer. This method is <EM>not</EM> called when a Viewer is disposed. It
-	 * is only called when the EditPart is removed from its parent. This method is the inverse of
-	 * {@link #addNotify()}
-	 */
-	@Override
-	public void removeNotify() {
-		if (getSelected() != SELECTED_NONE) {
-			getViewer().deselect(this);
-		}
-		for (EditPart childPart : getChildren()) {
-			childPart.removeNotify();
-		}
-		getViewer().unregisterEditPart(this);
-	}
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -246,9 +158,9 @@ public abstract class EditPart extends org.eclipse.gef.editparts.AbstractEditPar
 				}
 			} else {
 				if (model != childPart.getModel()) {
-					getViewer().unregisterEditPart(childPart);
+					childPart.unregister();
 					childPart.setModel(model);
-					getViewer().registerEditPart(childPart);
+					childPart.register();
 					childPart.updateModel();
 				}
 				// reorder child EditPart

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/IEditPartViewer.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/IEditPartViewer.java
@@ -121,16 +121,6 @@ public interface IEditPartViewer extends ISelectionProvider, org.eclipse.gef.Edi
 	Layer getLayer(String name);
 
 	/**
-	 * Register given {@link EditPart} into this viewer.
-	 */
-	void registerEditPart(EditPart editPart);
-
-	/**
-	 * Unregister given {@link EditPart} into this viewer.
-	 */
-	void unregisterEditPart(EditPart editPart);
-
-	/**
 	 * Returns the {@link EditDomain EditDomain} to which this viewer belongs.
 	 */
 	EditDomain getEditDomain();

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/core/AbstractEditPartViewer.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/core/AbstractEditPartViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -70,30 +70,6 @@ public abstract class AbstractEditPartViewer extends org.eclipse.gef.ui.parts.Ab
 	 */
 	public void setEditPartFactory(IEditPartFactory factory) {
 		m_factory = factory;
-	}
-
-	/**
-	 * Register given {@link EditPart} into this viewer.
-	 */
-	@Override
-	public void registerEditPart(EditPart editPart) {
-		getEditPartRegistry().put(editPart.getModel(), editPart);
-	}
-
-	/**
-	 * Unregister given {@link EditPart} into this viewer.
-	 */
-	@Override
-	public void unregisterEditPart(EditPart editPart) {
-		Object model = editPart.getModel();
-		Object registerPart = getEditPartRegistry().get(model);
-		/*
-		 * check editPart because during refreshChildren firstly add new child,
-		 * example (old model, new EditPart) after remove old child (old model, old EditPart)
-		 */
-		if (registerPart == editPart) {
-			getEditPartRegistry().remove(model);
-		}
 	}
 
 	/**

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/EmptyEditPartViewer.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/EmptyEditPartViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -116,10 +116,6 @@ public class EmptyEditPartViewer extends AbstractEditPartViewer implements IEdit
 	}
 
 	@Override
-	public void registerEditPart(EditPart editPart) {
-	}
-
-	@Override
 	public void select(EditPart part) {
 	}
 
@@ -138,10 +134,6 @@ public class EmptyEditPartViewer extends AbstractEditPartViewer implements IEdit
 
 	@Override
 	public void setSelection(List<EditPart> editParts) {
-	}
-
-	@Override
-	public void unregisterEditPart(EditPart editPart) {
 	}
 
 	@Override


### PR DESCRIPTION
With the exception of calling the fireActivated() and fireDeactivated() methods, the active() and deactivate() method of the GEF and WindowBuilder edit part are functionally identical. Given that we don't register any of those listeners to the edit parts, they become interchangeable.

The registerEditPart() and unregisterEditPart() methods of the viewer are replaced with the register() and unregister() methods within the edit part itself. In addition to registering the model, this method now also registers visuals and the accessibility edit part. Neither of which we currently use.