### PR TITLE
[GEF] Make IEntry compatible with PaletteEntry

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPalette.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPalette.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc. and Others.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.editor.palette;
 
+import org.eclipse.wb.core.controls.palette.DesignerEntry;
 import org.eclipse.wb.core.controls.palette.ICategory;
 import org.eclipse.wb.core.controls.palette.IEntry;
 import org.eclipse.wb.core.controls.palette.IPalette;
@@ -240,8 +241,8 @@ public class DesignerPalette {
 	private final Map<String, Boolean> m_openCategories = new HashMap<>();
 	private final Set<EntryInfo> m_knownEntryInfos = new HashSet<>();
 	private final Set<EntryInfo> m_goodEntryInfos = new HashSet<>();
-	private final Map<EntryInfo, IEntry> m_entryInfoToVisual = new HashMap<>();
-	private final Map<IEntry, EntryInfo> m_visualToEntryInfo = new HashMap<>();
+	private final Map<EntryInfo, DesignerEntry> m_entryInfoToVisual = new HashMap<>();
+	private final Map<DesignerEntry, EntryInfo> m_visualToEntryInfo = new HashMap<>();
 
 	/**
 	 * Clears all caches for {@link EntryInfo}, {@link IEntry}, etc.
@@ -257,14 +258,14 @@ public class DesignerPalette {
 	}
 
 	/**
-	 * @return the {@link IEntry} for given {@link EntryInfo}.
+	 * @return the {@link DesignerEntry} for given {@link EntryInfo}.
 	 */
-	private IEntry getVisualEntry(final EntryInfo entryInfo) {
-		IEntry entry = m_entryInfoToVisual.get(entryInfo);
+	private DesignerEntry getVisualEntry(final EntryInfo entryInfo) {
+		DesignerEntry entry = m_entryInfoToVisual.get(entryInfo);
 		if (entry == null && !m_knownEntryInfos.contains(entryInfo)) {
 			m_knownEntryInfos.add(entryInfo);
 			if (entryInfo.initialize(m_editPartViewer, m_rootJavaInfo)) {
-				entry = new IEntry() {
+				entry = new DesignerEntry(entryInfo.getName(), entryInfo.getDescription(), entryInfo.getIcon()) {
 					////////////////////////////////////////////////////////////////////////////
 					//
 					// Access
@@ -273,21 +274,6 @@ public class DesignerPalette {
 					@Override
 					public boolean isEnabled() {
 						return entryInfo.isEnabled();
-					}
-
-					@Override
-					public ImageDescriptor getIcon() {
-						return entryInfo.getIcon();
-					}
-
-					@Override
-					public String getText() {
-						return entryInfo.getName();
-					}
-
-					@Override
-					public String getToolTipText() {
-						return entryInfo.getDescription();
 					}
 
 					////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/DesignerEntry.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/DesignerEntry.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Patrick Ziegler and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.core.controls.palette;
+
+import org.eclipse.gef.palette.ToolEntry;
+import org.eclipse.jface.resource.ImageDescriptor;
+
+/**
+ * Single GEF-compatible entry on {@link PaletteComposite}.
+ */
+@SuppressWarnings("removal")
+public abstract class DesignerEntry extends ToolEntry implements IEntry {
+	public DesignerEntry(String label, String shortDescription, ImageDescriptor iconSmall) {
+		super(label, shortDescription, iconSmall, null);
+	}
+
+	/**
+	 * Sometimes we want to show entry, but don't allow to select it.
+	 */
+	@Override
+	public abstract boolean isEnabled();
+
+	/**
+	 * Activates this {@link DesignerEntry}.
+	 *
+	 * @param reload is <code>true</code> if entry should be automatically reloaded
+	 *               after successful using.
+	 *
+	 * @return <code>true</code> if {@link DesignerEntry} was successfully
+	 *         activated.
+	 */
+	@Override
+	public abstract boolean activate(boolean reload);
+
+	/**
+	 * @noreference This method is not intended to be referenced by clients.
+	 * @nooverride This method is not intended to be re-implemented or extended by
+	 *             clients.
+	 * @deprecated Use {@link #getSmallIcon()} instead.
+	 */
+	@Override
+	@Deprecated(since = "1.17.0", forRemoval = true)
+	public final ImageDescriptor getIcon() {
+		return getSmallIcon();
+	}
+
+	/**
+	 * @noreference This method is not intended to be referenced by clients.
+	 * @nooverride This method is not intended to be re-implemented or extended by
+	 *             clients.
+	 * @deprecated Use {@link #getLabel()} instead.
+	 */
+	@Override
+	@Deprecated(since = "1.17.0", forRemoval = true)
+	public final String getText() {
+		return getLabel();
+	}
+
+	/**
+	 * @noreference This method is not intended to be referenced by clients.
+	 * @nooverride This method is not intended to be re-implemented or extended by
+	 *             clients.
+	 * @deprecated Use {@link #getDescription()} instead.
+	 */
+	@Override
+	@Deprecated(since = "1.17.0", forRemoval = true)
+	public final String getToolTipText() {
+		return getDescription();
+	}
+}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/IEntry.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/IEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,10 @@ import org.eclipse.jface.resource.ImageDescriptor;
  *
  * @author scheglov_ke
  * @coverage core.control.palette
+ * @deprecated Use {@link DesignerEntry instead}.
  */
+// TODO GEF
+@Deprecated(since = "1.17.0", forRemoval = true)
 public interface IEntry {
 	////////////////////////////////////////////////////////////////////////////
 	//

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/test/PaletteTest.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/test/PaletteTest.java
@@ -14,6 +14,7 @@ package org.eclipse.wb.core.controls.test;
 import org.eclipse.wb.core.controls.flyout.FlyoutControlComposite;
 import org.eclipse.wb.core.controls.flyout.IFlyoutPreferences;
 import org.eclipse.wb.core.controls.flyout.MemoryFlyoutPreferences;
+import org.eclipse.wb.core.controls.palette.DesignerEntry;
 import org.eclipse.wb.core.controls.palette.ICategory;
 import org.eclipse.wb.core.controls.palette.IEntry;
 import org.eclipse.wb.core.controls.palette.IPalette;
@@ -254,10 +255,8 @@ public class PaletteTest implements ColorConstants {
 	// Entry implementation
 	//
 	////////////////////////////////////////////////////////////////////////////
-	private static final class EntryImpl implements IEntry {
+	private static final class EntryImpl extends DesignerEntry {
 		private final boolean m_enabled;
-		private final ImageDescriptor m_icon;
-		private final String m_text;
 
 		////////////////////////////////////////////////////////////////////////////
 		//
@@ -265,9 +264,8 @@ public class PaletteTest implements ColorConstants {
 		//
 		////////////////////////////////////////////////////////////////////////////
 		public EntryImpl(boolean enabled, ImageDescriptor icon, String text) {
+			super(text, null, icon);
 			m_enabled = enabled;
-			m_icon = icon;
-			m_text = text;
 		}
 
 		////////////////////////////////////////////////////////////////////////////
@@ -278,21 +276,6 @@ public class PaletteTest implements ColorConstants {
 		@Override
 		public boolean isEnabled() {
 			return m_enabled;
-		}
-
-		@Override
-		public ImageDescriptor getIcon() {
-			return m_icon;
-		}
-
-		@Override
-		public String getText() {
-			return m_text;
-		}
-
-		@Override
-		public String getToolTipText() {
-			return null;
 		}
 
 		////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Because the IEntry interface is API, we can't simply rename the methods
to match the ones that are used by GEF. Instead, a new DesignerEntry
class is created, which serves as an adapter between the IEntry
interface and the PaletteEntry class.

The IEntry interface has been marked as deprecated and "for removal",
meaning that they can be removed after a two-year grace period, without
breaking API.