### PR TITLE
[GEF] Make IContainer compatible with PaletteDrawer

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPalette.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPalette.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.editor.palette;
 
+import org.eclipse.wb.core.controls.palette.DesignerContainer;
 import org.eclipse.wb.core.controls.palette.DesignerEntry;
 import org.eclipse.wb.core.controls.palette.ICategory;
 import org.eclipse.wb.core.controls.palette.IEntry;
@@ -236,8 +237,8 @@ public class DesignerPalette {
 	// Palette displaying
 	//
 	////////////////////////////////////////////////////////////////////////////
-	private final Map<CategoryInfo, ICategory> m_categoryInfoToVisual = new HashMap<>();
-	private final Map<ICategory, CategoryInfo> m_visualToCategoryInfo = new HashMap<>();
+	private final Map<CategoryInfo, DesignerContainer> m_categoryInfoToVisual = new HashMap<>();
+	private final Map<DesignerContainer, CategoryInfo> m_visualToCategoryInfo = new HashMap<>();
 	private final Map<String, Boolean> m_openCategories = new HashMap<>();
 	private final Set<EntryInfo> m_knownEntryInfos = new HashSet<>();
 	private final Set<EntryInfo> m_goodEntryInfos = new HashSet<>();
@@ -303,15 +304,15 @@ public class DesignerPalette {
 	/**
 	 * @return the {@link ICategory} for given {@link CategoryInfo}.
 	 */
-	private ICategory getVisualCategory(final CategoryInfo categoryInfo) {
-		ICategory category = m_categoryInfoToVisual.get(categoryInfo);
+	private DesignerContainer getVisualCategory(final CategoryInfo categoryInfo) {
+		DesignerContainer category = m_categoryInfoToVisual.get(categoryInfo);
 		if (category == null) {
 			final String categoryId = categoryInfo.getId();
-			category = new ICategory() {
+			category = new DesignerContainer(categoryInfo.getName(), categoryInfo.getDescription()) {
 				private boolean m_open;
 
 				@Override
-				public List<IEntry> getEntries() {
+				public List<DesignerEntry> getEntries() {
 					final List<EntryInfo> entryInfoList = new ArrayList<>(categoryInfo.getEntries());
 					// add new EntryInfo's using broadcast
 					ExecutionUtils.runIgnore(new RunnableEx() {
@@ -321,7 +322,7 @@ public class DesignerPalette {
 						}
 					});
 					// convert EntryInfo's into IEntry's
-					List<IEntry> entries = new ArrayList<>();
+					List<DesignerEntry> entries = new ArrayList<>();
 					for (EntryInfo entryInfo : entryInfoList) {
 						if (entryInfo.isVisible()) {
 							if (categoryId.equals(ENTRYINFO_CATEGORY)) {
@@ -329,13 +330,13 @@ public class DesignerPalette {
 										IEditorPreferenceConstants.P_AVAILABLE_LAYOUTS_NODE).getBoolean(
 												entryInfo.getId().substring(entryInfo.getId().indexOf(' ') + 1),
 												true)) {
-									IEntry entry = getVisualEntry(entryInfo);
+									DesignerEntry entry = getVisualEntry(entryInfo);
 									if (entry != null) {
 										entries.add(entry);
 									}
 								}
 							} else {
-								IEntry entry = getVisualEntry(entryInfo);
+								DesignerEntry entry = getVisualEntry(entryInfo);
 								if (entry != null) {
 									entries.add(entry);
 								}
@@ -343,16 +344,6 @@ public class DesignerPalette {
 						}
 					}
 					return entries;
-				}
-
-				@Override
-				public String getText() {
-					return categoryInfo.getName();
-				}
-
-				@Override
-				public String getToolTipText() {
-					return categoryInfo.getDescription();
 				}
 
 				@Override

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/DesignerContainer.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/DesignerContainer.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Patrick Ziegler and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.core.controls.palette;
+
+import org.eclipse.gef.palette.PaletteDrawer;
+
+import java.util.List;
+
+/**
+ * Category - collection of {@link DesignerEntry}.
+ */
+@SuppressWarnings("removal")
+public abstract class DesignerContainer extends PaletteDrawer implements ICategory {
+
+	protected DesignerContainer(String label, String desc) {
+		super(label, null);
+		setDescription(desc);
+	}
+
+	/**
+	 * @noreference This method is not intended to be referenced by clients.
+	 * @nooverride This method is not intended to be re-implemented or extended by
+	 *             clients.
+	 * @deprecated Use {@link #getLabel()} instead.
+	 */
+	@Override
+	@Deprecated(since = "1.17.0", forRemoval = true)
+	public final String getText() {
+		return getLabel();
+	}
+
+	/**
+	 * @noreference This method is not intended to be referenced by clients.
+	 * @nooverride This method is not intended to be re-implemented or extended by
+	 *             clients.
+	 * @deprecated Use {@link #getDescription()} instead.
+	 */
+	@Override
+	@Deprecated(since = "1.17.0", forRemoval = true)
+	public final String getToolTipText() {
+		return getDescription();
+	}
+
+	/**
+	 * @return <code>true</code> if this category is open.
+	 * @noreference This method is not intended to be referenced by clients.
+	 * @nooverride This method is not intended to be re-implemented or extended by
+	 *             clients.
+	 * @deprecated Set in the {@code DrawerFigure}.
+	 */
+	@Override
+	@Deprecated(since = "1.17.0", forRemoval = true)
+	public abstract boolean isOpen();
+
+	/**
+	 * Sets if this category is open.
+	 *
+	 * @noreference This method is not intended to be referenced by clients.
+	 * @nooverride This method is not intended to be re-implemented or extended by
+	 *             clients.
+	 * @deprecated Set in the {@code DrawerFigure}.
+	 */
+	@Override
+	@Deprecated(since = "1.17.0", forRemoval = true)
+	public abstract void setOpen(boolean b);
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public List<DesignerEntry> getEntries() {
+		return (List<DesignerEntry>) super.getChildren();
+	}
+
+}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/ICategory.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/ICategory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,10 @@ import java.util.List;
  *
  * @author scheglov_ke
  * @coverage core.control.palette
+ * @deprecated Use {@link DesignerContainer} instead.
  */
+//TODO GEF
+@Deprecated(since = "1.17.0", forRemoval = true)
 public interface ICategory {
 	/**
 	 * @return the title text of category.
@@ -42,5 +45,5 @@ public interface ICategory {
 	/**
 	 * @return the {@link List} of {@link IEntry}'s.
 	 */
-	List<IEntry> getEntries();
+	List<? extends IEntry> getEntries();
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/test/PaletteTest.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/test/PaletteTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ package org.eclipse.wb.core.controls.test;
 import org.eclipse.wb.core.controls.flyout.FlyoutControlComposite;
 import org.eclipse.wb.core.controls.flyout.IFlyoutPreferences;
 import org.eclipse.wb.core.controls.flyout.MemoryFlyoutPreferences;
+import org.eclipse.wb.core.controls.palette.DesignerContainer;
 import org.eclipse.wb.core.controls.palette.DesignerEntry;
 import org.eclipse.wb.core.controls.palette.ICategory;
 import org.eclipse.wb.core.controls.palette.IEntry;
@@ -108,26 +109,26 @@ public class PaletteTest implements ColorConstants {
 			{
 				CategoryImpl category = new CategoryImpl("First category", true);
 				palette.addCategory(category);
-				category.addEntry(new EntryImpl(true, createIcon(red), "AAAAAAAAAAA"));
-				category.addEntry(new EntryImpl(false, createIcon(green), "BBBBB"));
-				category.addEntry(new EntryImpl(true, createIcon(blue), "CCCCCCCCCCCCCCC"));
-				category.addEntry(new EntryImpl(true, createIcon(yellow), "DDDDDDDDD"));
-				category.addEntry(new EntryImpl(false, createIcon(orange), "EEEEEEEEEEE"));
-				category.addEntry(new EntryImpl(true, createIcon(cyan), "FFFFF"));
+				category.add(new EntryImpl(true, createIcon(red), "AAAAAAAAAAA"));
+				category.add(new EntryImpl(false, createIcon(green), "BBBBB"));
+				category.add(new EntryImpl(true, createIcon(blue), "CCCCCCCCCCCCCCC"));
+				category.add(new EntryImpl(true, createIcon(yellow), "DDDDDDDDD"));
+				category.add(new EntryImpl(false, createIcon(orange), "EEEEEEEEEEE"));
+				category.add(new EntryImpl(true, createIcon(cyan), "FFFFF"));
 			}
 			{
 				CategoryImpl category = new CategoryImpl("Second category", false);
 				palette.addCategory(category);
-				category.addEntry(new EntryImpl(true, createIcon(red), "0123456789"));
-				category.addEntry(new EntryImpl(true, createIcon(green), "012345"));
-				category.addEntry(new EntryImpl(true, createIcon(blue), "0123456789123"));
+				category.add(new EntryImpl(true, createIcon(red), "0123456789"));
+				category.add(new EntryImpl(true, createIcon(green), "012345"));
+				category.add(new EntryImpl(true, createIcon(blue), "0123456789123"));
 			}
 			{
 				CategoryImpl category = new CategoryImpl("Third category", true);
 				palette.addCategory(category);
-				category.addEntry(new EntryImpl(true, createIcon(red), "0123456789"));
-				category.addEntry(new EntryImpl(true, createIcon(green), "012345"));
-				category.addEntry(new EntryImpl(true, createIcon(blue), "0123456789123"));
+				category.add(new EntryImpl(true, createIcon(red), "0123456789"));
+				category.add(new EntryImpl(true, createIcon(green), "012345"));
+				category.add(new EntryImpl(true, createIcon(blue), "0123456789123"));
 			}
 		}
 		// set palette
@@ -196,10 +197,8 @@ public class PaletteTest implements ColorConstants {
 	// Category implementation
 	//
 	////////////////////////////////////////////////////////////////////////////
-	private static final class CategoryImpl implements ICategory {
-		private final String m_text;
+	private static final class CategoryImpl extends DesignerContainer {
 		private boolean m_open;
-		private final List<IEntry> m_entries = new ArrayList<>();
 
 		////////////////////////////////////////////////////////////////////////////
 		//
@@ -207,17 +206,8 @@ public class PaletteTest implements ColorConstants {
 		//
 		////////////////////////////////////////////////////////////////////////////
 		public CategoryImpl(String text, boolean open) {
-			m_text = text;
+			super(text, null);
 			m_open = open;
-		}
-
-		////////////////////////////////////////////////////////////////////////////
-		//
-		// Access
-		//
-		////////////////////////////////////////////////////////////////////////////
-		public void addEntry(IEntry entry) {
-			m_entries.add(entry);
 		}
 
 		////////////////////////////////////////////////////////////////////////////
@@ -225,15 +215,6 @@ public class PaletteTest implements ColorConstants {
 		// ICategory
 		//
 		////////////////////////////////////////////////////////////////////////////
-		@Override
-		public String getText() {
-			return m_text;
-		}
-
-		@Override
-		public String getToolTipText() {
-			return null;
-		}
 
 		@Override
 		public boolean isOpen() {
@@ -243,11 +224,6 @@ public class PaletteTest implements ColorConstants {
 		@Override
 		public void setOpen(boolean b) {
 			m_open = b;
-		}
-
-		@Override
-		public List<IEntry> getEntries() {
-			return m_entries;
 		}
 	}
 	////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Because the IContainer interface is API, we can't simply rename the methods to match the ones that are used by GEF. Instead, a new DesignerContainer class is created, which serves as an adapter between the IContainer interface and the PaletteDrawer class.

The IContainer interface has been marked as deprecated and "for removal", meaning that they can be removed after a two-year grace period, without breaking API.