### PR TITLE
[GEF] Move createCompoundCommand() method out of EditPart class

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/core/gef/part/AbstractComponentEditPart.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/core/gef/part/AbstractComponentEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,6 +29,7 @@ import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.draw2d.EventManager;
+import org.eclipse.wb.internal.gef.core.IObjectInfoEditPart;
 
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.geometry.Point;
@@ -48,7 +49,7 @@ import java.util.List;
  * @author scheglov_ke
  * @coverage core.gef
  */
-public abstract class AbstractComponentEditPart extends GraphicalEditPart {
+public abstract class AbstractComponentEditPart extends GraphicalEditPart implements IObjectInfoEditPart {
 	public static final Point TOP_LOCATION = EnvironmentUtils.IS_MAC
 			? new Point(20, 28)
 					: new Point(20, 20);

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/EditPart.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/EditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,6 @@ import org.eclipse.wb.internal.gef.core.EditPartVisitor;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
-import org.eclipse.gef.commands.CompoundCommand;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -328,13 +327,6 @@ public abstract class EditPart extends org.eclipse.gef.editparts.AbstractEditPar
 			}
 		}
 		return null;
-	}
-
-	/**
-	 * @return new instance of {@link CompoundCommand} for further wrapping commands usage.
-	 */
-	public CompoundCommand createCompoundCommand() {
-		return new CompoundCommand();
 	}
 
 	/**

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/DragEditPartTracker.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/DragEditPartTracker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
 import org.eclipse.wb.gef.core.requests.DragPermissionRequest;
 import org.eclipse.wb.gef.core.requests.GroupRequest;
+import org.eclipse.wb.internal.gef.core.IObjectInfoEditPart;
 import org.eclipse.wb.internal.gef.core.SharedCursors;
 
 import org.eclipse.draw2d.geometry.Point;
@@ -275,7 +276,10 @@ public class DragEditPartTracker extends SelectEditPartTracker {
 			org.eclipse.wb.gef.core.EditPart targetEditPart = getTargetEditPart();
 			//
 			if (targetEditPart != null) {
-				CompoundCommand compoundCommand = targetEditPart.createCompoundCommand();
+				CompoundCommand compoundCommand = new CompoundCommand();
+				if (targetEditPart instanceof IObjectInfoEditPart objectInfoEditPart) {
+					compoundCommand = objectInfoEditPart.createCompoundCommand();
+				}
 				if (!operationSet.isEmpty()) {
 					org.eclipse.wb.gef.core.EditPart firstPart = operationSet.get(0);
 					GroupRequest orphanRequest = new GroupRequest(RequestConstants.REQ_ORPHAN);

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/core/IObjectInfoEditPart.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/core/IObjectInfoEditPart.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Patrick Ziegler and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.internal.gef.core;
+
+import org.eclipse.wb.core.model.IObjectInfo;
+
+import org.eclipse.gef.commands.CompoundCommand;
+
+/**
+ * Marker interface to indicate that the compound command is editing an
+ * {@link IObjectInfo}.
+ */
+public interface IObjectInfoEditPart {
+	CompoundCommand createCompoundCommand();
+}


### PR DESCRIPTION
This method is not part of standard GEF and should therefore not be in the base class. Furthermore, this method always returns a plain CompoundCommand, except for the AbstractComponentEditParts, where it instead returns a CompoundEditCommand.

To keep things compatible, a new IObjectInfoEditPart interface has been created, that is implemented by the AbstractComponentEditPart. By default, the DragEditPartTracker uses a normal CompoundCommand. But if the target edit part happens to implement this new interface, then the CompoundEditCommand is used.

This change will greatly reduce the amount of places where we have to use the WindowBuilder-specific edit parts.