### PR TITLE
Change signature of runObjectLog to expect a Callable object

### DIFF
--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/ObserveComparator.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/model/ObserveComparator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,6 @@
 package org.eclipse.wb.internal.core.databinding.model;
 
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 
 import java.util.Comparator;
 
@@ -31,13 +30,10 @@ public final class ObserveComparator implements Comparator<IObserveInfo> {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public int compare(final IObserveInfo observe1, final IObserveInfo observe2) {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<Integer>() {
-			@Override
-			public Integer runObject() throws Exception {
-				String text1 = observe1.getPresentation().getText();
-				String text2 = observe2.getPresentation().getText();
-				return text1.compareTo(text2);
-			}
+		return ExecutionUtils.runObjectLog(() -> {
+			String text1 = observe1.getPresentation().getText();
+			String text2 = observe2.getPresentation().getText();
+			return text1.compareTo(text2);
 		}, 0);
 	}
 }

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/BindDialog.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/BindDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,6 @@ import org.eclipse.wb.internal.core.databinding.ui.editor.IUiContentProvider;
 import org.eclipse.wb.internal.core.databinding.ui.editor.UiContentProviderComposite;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 import org.eclipse.wb.internal.core.utils.ui.dialogs.ResizableTitleAreaDialog;
 
@@ -81,13 +80,8 @@ public final class BindDialog extends ResizableTitleAreaDialog implements IPageL
 				new ScrolledComposite((Composite) super.createDialogArea(parent), SWT.BORDER | SWT.V_SCROLL);
 		container.setExpandHorizontal(true);
 		//
-		List<IUiContentProvider> providers =
-				ExecutionUtils.runObjectLog(new RunnableObjectEx<List<IUiContentProvider>>() {
-					@Override
-					public List<IUiContentProvider> runObject() throws Exception {
-						return m_databindingsProvider.getContentProviders(m_binding, BindDialog.this);
-					}
-				}, Collections.<IUiContentProvider>emptyList());
+		List<IUiContentProvider> providers = ExecutionUtils.runObjectLog(
+				() -> m_databindingsProvider.getContentProviders(m_binding, BindDialog.this), Collections.emptyList());
 		m_providerComposite = new UiContentProviderComposite(this, providers, container, SWT.NONE);
 		container.setContent(m_providerComposite);
 		container.addControlListener(new ControlAdapter() {

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/BindWizard.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/BindWizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,6 @@ import org.eclipse.wb.internal.core.databinding.Messages;
 import org.eclipse.wb.internal.core.databinding.model.IObserveInfo;
 import org.eclipse.wb.internal.core.databinding.ui.property.Context;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 
 import org.eclipse.jface.wizard.Wizard;
 
@@ -59,12 +58,9 @@ public class BindWizard extends Wizard {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public boolean performFinish() {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<Boolean>() {
-			@Override
-			public Boolean runObject() throws Exception {
-				m_context.provider.addBinding(m_secondPage.performFinish());
-				return true;
-			}
+		return ExecutionUtils.runObjectLog(() -> {
+			m_context.provider.addBinding(m_secondPage.performFinish());
+			return true;
 		}, true);
 	}
 }

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/BindWizardPage.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/BindWizardPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,6 @@ import org.eclipse.wb.internal.core.databinding.ui.editor.UiContentProviderCompo
 import org.eclipse.wb.internal.core.databinding.ui.property.Context;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 
 import org.eclipse.jface.wizard.IWizardContainer;
 import org.eclipse.jface.wizard.WizardPage;
@@ -101,13 +100,10 @@ public class BindWizardPage extends WizardPage implements IPageListener {
 			m_providerComposite = null;
 		}
 		List<IUiContentProvider> providers =
-				ExecutionUtils.runObjectLog(new RunnableObjectEx<List<IUiContentProvider>>() {
-					@Override
-					public List<IUiContentProvider> runObject() throws Exception {
-						m_binding = m_firstPage.getBinding();
-						return m_context.provider.getContentProviders(m_binding, BindWizardPage.this);
-					}
-				}, Collections.<IUiContentProvider>emptyList());
+				ExecutionUtils.runObjectLog(() -> {
+					m_binding = m_firstPage.getBinding();
+					return m_context.provider.getContentProviders(m_binding, BindWizardPage.this);
+				}, Collections.emptyList());
 		m_providerComposite = new UiContentProviderComposite(this, providers, m_composite, SWT.NONE);
 		// initial state
 		ExecutionUtils.runLog(new RunnableEx() {

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/BindingElementsComposite.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/BindingElementsComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,6 @@ import org.eclipse.wb.internal.core.databinding.Messages;
 import org.eclipse.wb.internal.core.databinding.model.IBindingInfo;
 import org.eclipse.wb.internal.core.databinding.model.IDatabindingsProvider;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
 import org.eclipse.wb.internal.core.utils.ui.TableFactory;
@@ -461,22 +460,18 @@ public final class BindingElementsComposite extends Composite {
 			final IBindingInfo binding,
 			Shell shell) {
 		// prepare message
-		String message = ExecutionUtils.runObjectLog(new RunnableObjectEx<String>() {
-			@Override
-			public String runObject() throws Exception {
-				String message = databindingsProvider.getBindingPresentationText(binding);
-				if (message == null) {
-					message =
-							"Binding["
-									+ UiUtils.getPresentationText(binding.getTarget(), binding.getTargetProperty())
-									+ " : "
-									+ UiUtils.getPresentationText(binding.getModel(), binding.getModelProperty())
-									+ "]";
-				}
-				return message;
+		String message = ExecutionUtils.runObjectLog(() -> {
+			String bindingMessage = databindingsProvider.getBindingPresentationText(binding);
+			if (bindingMessage == null) {
+				bindingMessage =
+						"Binding["
+								+ UiUtils.getPresentationText(binding.getTarget(), binding.getTargetProperty())
+								+ " : "
+								+ UiUtils.getPresentationText(binding.getModel(), binding.getModelProperty())
+								+ "]";
 			}
-		},
-				"<exception, see log>");
+			return bindingMessage;
+		}, "<exception, see log>");
 		// open confirm
 		boolean canDelete =
 				MessageDialog.openConfirm(

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/ObserveElementsComposite.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/ObserveElementsComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,6 @@ import org.eclipse.wb.internal.core.databinding.ui.filter.PropertyFilter;
 import org.eclipse.wb.internal.core.databinding.ui.providers.ObserveLabelProvider;
 import org.eclipse.wb.internal.core.databinding.ui.providers.ObserveTreeContentProvider;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
 
@@ -332,12 +331,7 @@ final class ObserveElementsComposite extends SashForm {
 			StringBuffer buffer = new StringBuffer();
 			final IObserveInfo[] observe = {(IObserveInfo) selection.getFirstElement()};
 			while (true) {
-				buffer.insert(0, ExecutionUtils.runObjectLog(new RunnableObjectEx<String>() {
-					@Override
-					public String runObject() throws Exception {
-						return observe[0].getPresentation().getTextForBinding();
-					}
-				}, "<error>"));
+				buffer.insert(0, ExecutionUtils.runObjectLog(() -> observe[0].getPresentation().getTextForBinding(), "<error>"));
 				observe[0] = observe[0].getParent();
 				if (observe[0] == null) {
 					break;
@@ -490,12 +484,7 @@ final class ObserveElementsComposite extends SashForm {
 					return true;
 				}
 			}
-			return ExecutionUtils.runObjectLog(new RunnableObjectEx<Boolean>() {
-				@Override
-				public Boolean runObject() throws Exception {
-					return m_matcher.matches(observe.getPresentation().getText());
-				}
-			}, Boolean.FALSE);
+			return ExecutionUtils.runObjectLog(() -> m_matcher.matches(observe.getPresentation().getText()), Boolean.FALSE);
 		}
 	}
 

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/ObserveElementsWizardPage.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/ObserveElementsWizardPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,6 @@ import org.eclipse.wb.internal.core.databinding.model.IBindingInfo;
 import org.eclipse.wb.internal.core.databinding.model.IObserveInfo;
 import org.eclipse.wb.internal.core.databinding.ui.property.Context;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
 
@@ -103,16 +102,13 @@ public class ObserveElementsWizardPage extends WizardPage {
 				.createFont(null);
 		valueLabel.setFont(boldFont);
 		valueLabel.addDisposeListener(event -> boldFont.dispose());
-		valueLabel.setText(ExecutionUtils.runObjectLog(new RunnableObjectEx<String>() {
-			@Override
-			public String runObject() throws Exception {
-				String text = m_context.observeObject.getPresentation().getTextForBinding();
-				String propertyText = m_observeProperty.getPresentation().getTextForBinding();
-				if (propertyText.length() > 0) {
-					text += "." + propertyText;
-				}
-				return text;
+		valueLabel.setText(ExecutionUtils.runObjectLog(() -> {
+			String text = m_context.observeObject.getPresentation().getTextForBinding();
+			String propertyText = m_observeProperty.getPresentation().getTextForBinding();
+			if (propertyText.length() > 0) {
+				text += "." + propertyText;
 			}
+			return text;
 		}, "<exception, see log>"));
 		//
 		ISelectionChangedListener listener = new ISelectionChangedListener() {

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/providers/ObjectsTreeContentProvider.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/providers/ObjectsTreeContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,6 @@ package org.eclipse.wb.internal.core.databinding.ui.providers;
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.model.presentation.IObjectPresentation;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.Viewer;
@@ -72,12 +71,7 @@ public class ObjectsTreeContentProvider implements ITreeContentProvider {
 			final IObjectPresentation presentation = info.getPresentation();
 			if (presentation != null) {
 				// check children
-				return ExecutionUtils.runObjectLog(new RunnableObjectEx<Boolean>() {
-					@Override
-					public Boolean runObject() throws Exception {
-						return presentation.isVisible() && !presentation.getChildrenTree().isEmpty();
-					}
-				}, false);
+				return ExecutionUtils.runObjectLog(() -> presentation.isVisible() && !presentation.getChildrenTree().isEmpty(), false);
 			}
 		}
 		return false;
@@ -90,12 +84,7 @@ public class ObjectsTreeContentProvider implements ITreeContentProvider {
 			final IObjectPresentation presentation = info.getPresentation();
 			if (presentation != null) {
 				// get children
-				return ExecutionUtils.runObjectLog(new RunnableObjectEx<Object[]>() {
-					@Override
-					public Object[] runObject() throws Exception {
-						return presentation.getChildrenTree().toArray();
-					}
-				}, ArrayUtils.EMPTY_OBJECT_ARRAY);
+				return ExecutionUtils.runObjectLog(() -> presentation.getChildrenTree().toArray(), ArrayUtils.EMPTY_OBJECT_ARRAY);
 			}
 		}
 		return ArrayUtils.EMPTY_OBJECT_ARRAY;

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/providers/ObserveLabelProvider.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/providers/ObserveLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,6 @@ package org.eclipse.wb.internal.core.databinding.ui.providers;
 import org.eclipse.wb.internal.core.databinding.model.IObserveInfo;
 import org.eclipse.wb.internal.core.databinding.model.IObservePresentation;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.resource.LocalResourceManager;
@@ -52,21 +51,11 @@ public class ObserveLabelProvider extends LabelProvider {
 
 	@Override
 	public String getText(final Object element) {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<String>() {
-			@Override
-			public String runObject() throws Exception {
-				return getPresentation(element).getText();
-			}
-		}, "<exception, see log>");
+		return ExecutionUtils.runObjectLog(() -> getPresentation(element).getText(), "<exception, see log>");
 	}
 
 	@Override
 	public Image getImage(final Object element) {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<Image>() {
-			@Override
-			public Image runObject() throws Exception {
-				return m_resourceManager.createImage(getPresentation(element).getImageDescriptor());
-			}
-		}, null);
+		return ExecutionUtils.runObjectLog(() -> m_resourceManager.createImage(getPresentation(element).getImageDescriptor()), null);
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/core/editor/palette/model/entry/ToolEntryInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/core/editor/palette/model/entry/ToolEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,6 @@ package org.eclipse.wb.core.editor.palette.model.entry;
 import org.eclipse.wb.core.editor.palette.model.EntryInfo;
 import org.eclipse.wb.gef.core.tools.Tool;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.gef.core.EditDomain;
 
 /**
@@ -30,22 +29,19 @@ public abstract class ToolEntryInfo extends EntryInfo {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public final boolean activate(final boolean reload) {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<Boolean>() {
-			@Override
-			public Boolean runObject() throws Exception {
-				// prepare tool
-				Tool tool;
-				{
-					tool = createTool();
-					if (tool == null) {
-						return false;
-					}
-					tool.setUnloadWhenFinished(!reload);
+		return ExecutionUtils.runObjectLog(() -> {
+			// prepare tool
+			Tool tool;
+			{
+				tool = createTool();
+				if (tool == null) {
+					return false;
 				}
-				// OK
-				m_editPartViewer.getEditDomain().setActiveTool(tool);
-				return true;
+				tool.setUnloadWhenFinished(!reload);
 			}
+			// OK
+			m_editPartViewer.getEditDomain().setActiveTool(tool);
+			return true;
 		}, false);
 	}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/core/eval/AstEvaluationEngine.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/core/eval/AstEvaluationEngine.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,6 @@ import org.eclipse.wb.internal.core.utils.exception.DesignerException;
 import org.eclipse.wb.internal.core.utils.exception.DesignerExceptionUtils;
 import org.eclipse.wb.internal.core.utils.exception.ICoreExceptionConstants;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.external.ExternalFactoriesHelper;
 
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
@@ -58,12 +57,7 @@ public final class AstEvaluationEngine {
 		try {
 			return evaluate0(context, expression);
 		} catch (final Throwable e) {
-			Object result = ExecutionUtils.runObjectLog(new RunnableObjectEx<Object>() {
-				@Override
-				public Object runObject() throws Exception {
-					return context.evaluationFailed(expression, e);
-				}
-			}, UNKNOWN);
+			Object result = ExecutionUtils.runObjectLog(() -> context.evaluationFailed(expression, e), UNKNOWN);
 			if (result != UNKNOWN) {
 				return result;
 			}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/core/eval/ExecutionFlowUtils.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/core/eval/ExecutionFlowUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -34,7 +34,6 @@ import org.eclipse.wb.internal.core.utils.exception.DesignerException;
 import org.eclipse.wb.internal.core.utils.exception.ICoreExceptionConstants;
 import org.eclipse.wb.internal.core.utils.exception.MultipleConstructorsError;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.external.ExternalFactoriesHelper;
 
 import org.eclipse.jdt.core.dom.ASTNode;
@@ -393,16 +392,13 @@ public final class ExecutionFlowUtils {
 	 * there are special cases, such as <code>EventQueue.invokeLater(Runnable)</code> in Swing.
 	 */
 	private static boolean shouldVisitAnonymousClassDeclaration(final AnonymousClassDeclaration anonymous) {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<Boolean>() {
-			@Override
-			public Boolean runObject() throws Exception {
-				for (ExecutionFlowProvider provider : getExecutionFlowProviders()) {
-					if (provider.shouldVisit(anonymous)) {
-						return true;
-					}
+		return ExecutionUtils.runObjectLog(() -> {
+			for (ExecutionFlowProvider provider : getExecutionFlowProviders()) {
+				if (provider.shouldVisit(anonymous)) {
+					return true;
 				}
-				return false;
 			}
+			return false;
 		}, false);
 	}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/core/gef/part/AbstractComponentEditPart.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/core/gef/part/AbstractComponentEditPart.java
@@ -27,7 +27,6 @@ import org.eclipse.wb.internal.core.gef.policy.OpenListenerEditPolicy;
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.draw2d.EventManager;
 import org.eclipse.wb.internal.gef.core.IObjectInfoEditPart;
 
@@ -198,12 +197,7 @@ public abstract class AbstractComponentEditPart extends GraphicalEditPart implem
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	protected List<?> getModelChildren() {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<List<?>>() {
-			@Override
-			public List<?> runObject() throws Exception {
-				return m_component.getPresentation().getChildrenGraphical();
-			}
-		}, Collections.emptyList());
+		return ExecutionUtils.runObjectLog(() -> m_component.getPresentation().getChildrenGraphical(), Collections.emptyList());
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/core/gef/policy/DirectTextPropertyEditPolicy.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/core/gef/policy/DirectTextPropertyEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,7 +26,6 @@ import org.eclipse.wb.internal.core.preferences.IPreferenceConstants;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
@@ -132,12 +131,7 @@ public final class DirectTextPropertyEditPolicy extends DirectTextEditPolicy {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	protected String getText() {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<String>() {
-			@Override
-			public String runObject() throws Exception {
-				return (String) m_property.getValue();
-			}
-		}, StringUtils.EMPTY);
+		return ExecutionUtils.runObjectLog(() -> (String) m_property.getValue(), StringUtils.EMPTY);
 	}
 
 	@Override

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/actions/CopyAction.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/actions/CopyAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,6 @@ import org.eclipse.wb.internal.core.model.clipboard.JavaInfoMemento;
 import org.eclipse.wb.internal.core.model.clipboard.JavaInfoMementoTransfer;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
@@ -107,47 +106,38 @@ public class CopyAction extends Action {
 	 * @return <code>true</code> if given {@link JavaInfo}'s can be copy/pasted.
 	 */
 	static boolean hasMementos(final List<EditPart> editParts) {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<Boolean>() {
-			@Override
-			public Boolean runObject() throws Exception {
-				// selection required
-				if (editParts.isEmpty()) {
-					return false;
-				}
-				// check that JavaInfoMemento's can be created
-				for (EditPart editPart : editParts) {
-					// prepare model
-					JavaInfo javaInfo;
-					{
-						Object model = editPart.getModel();
-						if (model instanceof JavaInfo) {
-							javaInfo = (JavaInfo) model;
-						} else {
-							return false;
-						}
-					}
-					// check for memento
-					if (!JavaInfoMemento.hasMemento(javaInfo)) {
+		return ExecutionUtils.runObjectLog(() -> {
+			// selection required
+			if (editParts.isEmpty()) {
+				return false;
+			}
+			// check that JavaInfoMemento's can be created
+			for (EditPart editPart : editParts) {
+				// prepare model
+				JavaInfo javaInfo;
+				{
+					Object model = editPart.getModel();
+					if (model instanceof JavaInfo) {
+						javaInfo = (JavaInfo) model;
+					} else {
 						return false;
 					}
 				}
-				// OK
-				return true;
+				// check for memento
+				if (!JavaInfoMemento.hasMemento(javaInfo)) {
+					return false;
+				}
 			}
+			// OK
+			return true;
 		}, false);
 	}
 
 	/**
 	 * @return the {@link JavaInfoMemento}'s with copy/paste information for given {@link JavaInfo}'s.
 	 */
-	@SuppressWarnings({"unchecked", "rawtypes"})
 	static List<JavaInfoMemento> getMementos(final List<EditPart> editParts) {
-		return (List<JavaInfoMemento>) ExecutionUtils.runObjectLog(new RunnableObjectEx() {
-			@Override
-			public Object runObject() throws Exception {
-				return getMemento0(editParts);
-			}
-		}, null);
+		return ExecutionUtils.runObjectLog(() -> getMemento0(editParts), null);
 	}
 
 	private static List<JavaInfoMemento> getMemento0(List<EditPart> editParts) throws Exception {

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/policy/nonvisual/NonVisualLayoutEditPolicy.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/policy/nonvisual/NonVisualLayoutEditPolicy.java
@@ -26,7 +26,6 @@ import org.eclipse.wb.internal.core.model.clipboard.JavaInfoMemento;
 import org.eclipse.wb.internal.core.model.nonvisual.NonVisualBeanContainerInfo;
 import org.eclipse.wb.internal.core.model.nonvisual.NonVisualBeanInfo;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -208,12 +207,7 @@ public final class NonVisualLayoutEditPolicy extends LayoutEditPolicy {
 				NonVisualBeanEditPart part = (NonVisualBeanEditPart) editParts.get(i);
 				final JavaInfo info = part.getNonVisualInfo().getJavaInfo();
 				BeanFigure figure = new BeanFigure(info.getDescription().getIcon());
-				String text = ExecutionUtils.runObjectLog(new RunnableObjectEx<String>() {
-					@Override
-					public String runObject() throws Exception {
-						return info.getVariableSupport().getTitle();
-					}
-				}, null);
+				String text = ExecutionUtils.runObjectLog(() -> info.getVariableSupport().getTitle(), null);
 				figure.update(text, request.getLocation());
 				//
 				m_moveFeedbackFigures[i] = figure;

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/policy/nonvisual/NonVisualValidator.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/policy/nonvisual/NonVisualValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,7 +22,6 @@ import org.eclipse.wb.internal.core.model.clipboard.JavaInfoMemento;
 import org.eclipse.wb.internal.core.model.description.ComponentDescription;
 import org.eclipse.wb.internal.core.preferences.IPreferenceConstants;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 
 import org.eclipse.gef.EditPart;
 
@@ -61,12 +60,9 @@ final class NonVisualValidator implements ILayoutRequestValidator {
 		}
 		final Object newObject = request.getNewObject();
 		if (newObject instanceof JavaInfo) {
-			return ExecutionUtils.runObjectLog(new RunnableObjectEx<Boolean>() {
-				@Override
-				public Boolean runObject() throws Exception {
-					JavaInfo newInfo = (JavaInfo) newObject;
-					return validateJavaInfo(newInfo);
-				}
+			return ExecutionUtils.runObjectLog(() -> {
+				JavaInfo newInfo = (JavaInfo) newObject;
+				return validateJavaInfo(newInfo);
 			}, false);
 		}
 		return false;
@@ -77,17 +73,14 @@ final class NonVisualValidator implements ILayoutRequestValidator {
 		if (!acceptDropNonVisualBeans()) {
 			return false;
 		}
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<Boolean>() {
-			@Override
+		return ExecutionUtils.runObjectLog(() -> {
 			@SuppressWarnings("unchecked")
-			public Boolean runObject() throws Exception {
-				List<JavaInfoMemento> mementos = (List<JavaInfoMemento>) request.getMemento();
-				if (mementos.size() == 1) {
-					JavaInfo newInfo = mementos.get(0).create(m_infoForMemento);
-					return validateJavaInfo(newInfo);
-				}
-				return false;
+			List<JavaInfoMemento> mementos = (List<JavaInfoMemento>) request.getMemento();
+			if (mementos.size() == 1) {
+				JavaInfo newInfo = mementos.get(0).create(m_infoForMemento);
+				return validateJavaInfo(newInfo);
 			}
+			return false;
 		}, false);
 	}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gefTree/policy/ArrayObjectRequestValidator.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gefTree/policy/ArrayObjectRequestValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,6 @@ import org.eclipse.wb.gef.core.requests.PasteRequest;
 import org.eclipse.wb.internal.core.model.nonvisual.AbstractArrayObjectInfo;
 import org.eclipse.wb.internal.core.model.variable.EmptyVariableSupport;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
 import org.eclipse.gef.EditPart;
@@ -85,14 +84,11 @@ public final class ArrayObjectRequestValidator implements ILayoutRequestValidato
 	////////////////////////////////////////////////////////////////////////////
 	public boolean isValidModel(final Object objectModel) {
 		if (objectModel instanceof JavaInfo) {
-			return ExecutionUtils.runObjectLog(new RunnableObjectEx<Boolean>() {
-				@Override
-				public Boolean runObject() throws Exception {
-					JavaInfo info = (JavaInfo) objectModel;
-					return ReflectionUtils.isSuccessorOf(
-							info.getDescription().getComponentClass(),
-							m_arrayInfo.getItemClass().getCanonicalName());
-				}
+			return ExecutionUtils.runObjectLog(() -> {
+				JavaInfo info = (JavaInfo) objectModel;
+				return ReflectionUtils.isSuccessorOf(
+						info.getDescription().getComponentClass(),
+						m_arrayInfo.getItemClass().getCanonicalName());
 			}, false);
 		}
 		return false;

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/nls/ui/PropertiesComposite.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/nls/ui/PropertiesComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,7 +22,6 @@ import org.eclipse.wb.internal.core.nls.edit.StringPropertyInfo;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
 
@@ -395,17 +394,14 @@ public final class PropertiesComposite extends Composite {
 	ITreeContentProvider {
 		@Override
 		public Object[] getElements(Object inputElement) {
-			return ExecutionUtils.runObjectLog(new RunnableObjectEx<Object[]>() {
-				@Override
-				public Object[] runObject() throws Exception {
-					JavaInfo root = m_support.getRoot();
-					// show root only if there are properties
-					if (m_support.hasPropertiesInTree(root)) {
-						return new Object[]{root};
-					}
-					// else, show empty tree
-					return ArrayUtils.EMPTY_OBJECT_ARRAY;
+			return ExecutionUtils.runObjectLog(() -> {
+				JavaInfo root = m_support.getRoot();
+				// show root only if there are properties
+				if (m_support.hasPropertiesInTree(root)) {
+					return new Object[]{root};
 				}
+				// else, show empty tree
+				return ArrayUtils.EMPTY_OBJECT_ARRAY;
 			}, ArrayUtils.EMPTY_OBJECT_ARRAY);
 		}
 
@@ -472,31 +468,25 @@ public final class PropertiesComposite extends Composite {
 
 		@Override
 		public String getText(final Object element) {
-			return ExecutionUtils.runObjectLog(new RunnableObjectEx<String>() {
-				@Override
-				public String runObject() throws Exception {
-					if (element instanceof JavaInfo component) {
-						return component.getPresentation().getText();
-					} else {
-						Assert.instanceOf(StringPropertyInfo.class, element);
-						StringPropertyInfo propertyInfo = (StringPropertyInfo) element;
-						return propertyInfo.getTitle();
-					}
+			return ExecutionUtils.runObjectLog(() -> {
+				if (element instanceof JavaInfo component) {
+					return component.getPresentation().getText();
+				} else {
+					Assert.instanceOf(StringPropertyInfo.class, element);
+					StringPropertyInfo propertyInfo = (StringPropertyInfo) element;
+					return propertyInfo.getTitle();
 				}
 			}, null);
 		}
 
 		@Override
 		public Image getImage(final Object element) {
-			ImageDescriptor imageDescriptor = ExecutionUtils.runObjectLog(new RunnableObjectEx<ImageDescriptor>() {
-				@Override
-				public ImageDescriptor runObject() throws Exception {
-					if (element instanceof JavaInfo component) {
-						return component.getPresentation().getIcon();
-					} else {
-						Assert.instanceOf(StringPropertyInfo.class, element);
-						return DesignerPlugin.getImageDescriptor("nls/property.gif");
-					}
+			ImageDescriptor imageDescriptor = ExecutionUtils.runObjectLog(() -> {
+				if (element instanceof JavaInfo component) {
+					return component.getPresentation().getIcon();
+				} else {
+					Assert.instanceOf(StringPropertyInfo.class, element);
+					return DesignerPlugin.getImageDescriptor("nls/property.gif");
 				}
 			}, null);
 			return imageDescriptor == null ? null : m_resourceManager.createImage(imageDescriptor);

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/ui/JdtUiUtils.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/ui/JdtUiUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -155,13 +155,10 @@ public final class JdtUiUtils {
 	public static IType selectSubType(final Shell shell,
 			final IJavaProject javaProject,
 			final String superTypeName) {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<IType>() {
-			@Override
-			public IType runObject() throws Exception {
-				IType actionType = javaProject.findType(superTypeName);
-				SubtypesScope scope = new SubtypesScope(actionType);
-				return JdtUiUtils.selectType(DesignerPlugin.getShell(), scope);
-			}
+		return ExecutionUtils.runObjectLog(() -> {
+			IType actionType = javaProject.findType(superTypeName);
+			SubtypesScope scope = new SubtypesScope(actionType);
+			return JdtUiUtils.selectType(DesignerPlugin.getShell(), scope);
 		}, null);
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/editor/actions/assistant/AbstractAssistantPage.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/editor/actions/assistant/AbstractAssistantPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,6 @@ import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.model.property.editor.complex.IComplexPropertyEditor;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.core.utils.state.GlobalState;
 import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
@@ -180,20 +179,17 @@ public abstract class AbstractAssistantPage extends Composite implements ILayout
 		 */
 		protected final Object getValue() {
 			prepareProperties();
-			m_currentValue = ExecutionUtils.runObjectLog(new RunnableObjectEx<Object>() {
-				@Override
-				public Object runObject() throws Exception {
-					Object commonValue = NO_VALUE;
-					for (Property property : m_propertyList) {
-						Object value = property.getValue();
-						if (commonValue == NO_VALUE) {
-							commonValue = value;
-						} else if (!ObjectUtils.equals(commonValue, value)) {
-							return Property.UNKNOWN_VALUE;
-						}
+			m_currentValue = ExecutionUtils.runObjectLog(() -> {
+				Object commonValue = NO_VALUE;
+				for (Property property : m_propertyList) {
+					Object value = property.getValue();
+					if (commonValue == NO_VALUE) {
+						commonValue = value;
+					} else if (!ObjectUtils.equals(commonValue, value)) {
+						return Property.UNKNOWN_VALUE;
 					}
-					return commonValue;
 				}
+				return commonValue;
 			}, null);
 			return m_currentValue;
 		}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/validator/AbstractLayoutRequestValidator.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/validator/AbstractLayoutRequestValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,6 @@ import org.eclipse.wb.gef.core.requests.CreateRequest;
 import org.eclipse.wb.gef.core.requests.PasteRequest;
 import org.eclipse.wb.internal.core.model.description.IComponentDescription;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.state.GlobalState;
 import org.eclipse.wb.internal.core.utils.state.ILayoutRequestValidatorHelper;
 
@@ -44,22 +43,18 @@ public abstract class AbstractLayoutRequestValidator implements ILayoutRequestVa
 
 	@Override
 	public boolean validatePasteRequest(final EditPart host, final PasteRequest request) {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<Boolean>() {
-			@Override
-			public Boolean runObject() throws Exception {
-				ILayoutRequestValidatorHelper validatorHelper = GlobalState.getValidatorHelper();
-				List<?> mementos = (List<?>) request.getMemento();
-				for (Object memento : mementos) {
-					IComponentDescription description = validatorHelper.getPasteComponentDescription(memento);
-					if (!validateDescription(host, description)) {
-						return false;
-					}
+		return ExecutionUtils.runObjectLog(() -> {
+			ILayoutRequestValidatorHelper validatorHelper = GlobalState.getValidatorHelper();
+			List<?> mementos = (List<?>) request.getMemento();
+			for (Object memento : mementos) {
+				IComponentDescription description = validatorHelper.getPasteComponentDescription(memento);
+				if (!validateDescription(host, description)) {
+					return false;
 				}
-				// OK, all pasted components are valid
-				return true;
 			}
-		},
-				false);
+			// OK, all pasted components are valid
+			return true;
+		}, false);
 	}
 
 	@Override

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/validator/CompatibleLayoutRequestValidator.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/validator/CompatibleLayoutRequestValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,6 @@ import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.internal.core.model.description.IComponentDescription;
 import org.eclipse.wb.internal.core.model.util.ScriptUtils;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.state.GlobalState;
 
 import org.eclipse.gef.EditPart;
@@ -68,15 +67,11 @@ public final class CompatibleLayoutRequestValidator extends AbstractLayoutReques
 	 * @return <code>true</code> if given parent and child objects are compatible.
 	 */
 	private static boolean areCompatible(final EditPart host, final Object child) {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<Boolean>() {
-			@Override
-			public Boolean runObject() throws Exception {
-				Object parent = host.getModel();
-				return parentAgreeToAcceptChild(parent, child)
-						&& childAgreeToBeDroppedOnParent(parent, child);
-			}
-		},
-				false);
+		return ExecutionUtils.runObjectLog(() -> {
+			Object parent = host.getModel();
+			return parentAgreeToAcceptChild(parent, child)
+					&& childAgreeToBeDroppedOnParent(parent, child);
+		}, false);
 	}
 
 	private static boolean parentAgreeToAcceptChild(Object parent, Object child) throws Exception {

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gefTree/part/ObjectEditPart.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gefTree/part/ObjectEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,6 @@ import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.gef.tree.TreeEditPart;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.gef.tree.TreeViewer;
 import org.eclipse.wb.internal.gef.tree.policies.AutoExpandEditPolicy;
 import org.eclipse.wb.internal.gef.tree.policies.SelectionEditPolicy;
@@ -225,12 +224,7 @@ public class ObjectEditPart extends TreeEditPart {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	protected List<?> getModelChildren() {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<List<?>>() {
-			@Override
-			public List<?> runObject() throws Exception {
-				return m_object.getPresentation().getChildrenTree();
-			}
-		}, Collections.emptyList());
+		return ExecutionUtils.runObjectLog(() -> m_object.getPresentation().getChildrenTree(), Collections.emptyList());
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/generic/AbstractContainerRequestValidator.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/generic/AbstractContainerRequestValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,6 @@ import org.eclipse.wb.gef.core.requests.PasteRequest;
 import org.eclipse.wb.gef.tree.policies.LayoutEditPolicy;
 import org.eclipse.wb.internal.core.model.generic.AbstractContainer;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.state.GlobalState;
 
 import org.eclipse.gef.EditPart;
@@ -55,18 +54,15 @@ public final class AbstractContainerRequestValidator implements ILayoutRequestVa
 
 	@Override
 	public boolean validatePasteRequest(EditPart host, final PasteRequest request) {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<Boolean>() {
-			@Override
-			public Boolean runObject() throws Exception {
-				List<?> mementos = (List<?>) request.getMemento();
-				for (Object memento : mementos) {
-					Object component = GlobalState.getValidatorHelper().getPasteComponent(memento);
-					if (!m_container.validateComponent(component)) {
-						return false;
-					}
+		return ExecutionUtils.runObjectLog(() -> {
+			List<?> mementos = (List<?>) request.getMemento();
+			for (Object memento : mementos) {
+				Object component = GlobalState.getValidatorHelper().getPasteComponent(memento);
+				if (!m_container.validateComponent(component)) {
+					return false;
 				}
-				return true;
 			}
+			return true;
 		}, false);
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/execution/ExecutionUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/execution/ExecutionUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.swt.widgets.Display;
 
 import java.beans.Beans;
+import java.util.concurrent.Callable;
 
 /**
  * Utilities for executing actions, such as {@link RunnableEx}.
@@ -301,14 +302,14 @@ public class ExecutionUtils {
 	}
 
 	/**
-	 * Runs given {@link RunnableEx} and logs exceptions using {@link DesignerPlugin#log(Throwable)}.
+	 * Runs given {@link Callable} and logs exceptions using {@link DesignerPlugin#log(Throwable)}.
 	 *
-	 * @return the {@link Object} returned by {@link RunnableEx#run()} or <code>defaultValue</code> if
+	 * @return the {@link Object} returned by {@link Callable#call()} or <code>defaultValue</code> if
 	 *         exception was logged.
 	 */
-	public static <T> T runObjectLog(RunnableObjectEx<T> runnable, T defaultValue) {
+	public static <T> T runObjectLog(Callable<T> runnable, T defaultValue) {
 		try {
-			return runnable.runObject();
+			return runnable.call();
 		} catch (Throwable e) {
 			DesignerPlugin.log(e);
 			return defaultValue;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/ui/dialogs/StringsDialog.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/ui/dialogs/StringsDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,6 @@
 package org.eclipse.wb.internal.core.utils.ui.dialogs;
 
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
@@ -60,20 +59,17 @@ public class StringsDialog extends TextDialog {
 	 * @return the edited items.
 	 */
 	public String[] getItems() {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<String[]>() {
-			@Override
-			public String[] runObject() throws Exception {
-				List<String> strings = new ArrayList<>();
-				BufferedReader br = new BufferedReader(new StringReader(getText()));
-				while (true) {
-					String s = br.readLine();
-					if (s == null) {
-						break;
-					}
-					strings.add(s);
+		return ExecutionUtils.runObjectLog(() -> {
+			List<String> strings = new ArrayList<>();
+			BufferedReader br = new BufferedReader(new StringReader(getText()));
+			while (true) {
+				String s = br.readLine();
+				if (s == null) {
+					break;
 				}
-				return strings.toArray(new String[strings.size()]);
+				strings.add(s);
 			}
+			return strings.toArray(new String[strings.size()]);
 		}, ArrayUtils.EMPTY_STRING_ARRAY);
 	}
 }

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/contentproviders/ViewerColumnsUiContentProvider.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/contentproviders/ViewerColumnsUiContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,6 @@ import org.eclipse.wb.internal.core.databinding.ui.UiUtils;
 import org.eclipse.wb.internal.core.databinding.ui.editor.IUiContentProvider;
 import org.eclipse.wb.internal.core.databinding.ui.editor.UiContentProviderAdapter;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
 import org.eclipse.wb.internal.core.utils.ui.TableFactory;
@@ -266,28 +265,13 @@ public class ViewerColumnsUiContentProvider extends UiContentProviderAdapter {
 			switch (column) {
 			case 0 :
 				// Viewer column
-				return ExecutionUtils.runObjectLog(new RunnableObjectEx<String>() {
-					@Override
-					public String runObject() throws Exception {
-						return editingSupport.getViewerColumn().getPresentation().getText();
-					}
-				}, null);
+				return ExecutionUtils.runObjectLog(() -> editingSupport.getViewerColumn().getPresentation().getText(), null);
 			case 1 :
 				// CellEditor
-				return ExecutionUtils.runObjectLog(new RunnableObjectEx<String>() {
-					@Override
-					public String runObject() throws Exception {
-						return editingSupport.getCellEditorPresentationText();
-					}
-				}, null);
+				return ExecutionUtils.runObjectLog(() -> editingSupport.getCellEditorPresentationText(), null);
 			case 2 :
 				// Element property
-				return ExecutionUtils.runObjectLog(new RunnableObjectEx<String>() {
-					@Override
-					public String runObject() throws Exception {
-						return editingSupport.getElementPropertyPresentationText();
-					}
-				}, null);
+				return ExecutionUtils.runObjectLog(() -> editingSupport.getElementPropertyPresentationText(), null);
 			}
 			return null;
 		}
@@ -297,12 +281,7 @@ public class ViewerColumnsUiContentProvider extends UiContentProviderAdapter {
 			if (column == 0) {
 				// Viewer column
 				final VirtualEditingSupportInfo editingSupport = (VirtualEditingSupportInfo) element;
-				return ExecutionUtils.runObjectLog(new RunnableObjectEx<Image>() {
-					@Override
-					public Image runObject() throws Exception {
-						return m_resourceManager.createImage(editingSupport.getViewerColumn().getPresentation().getImageDescriptor());
-					}
-				}, null);
+				return ExecutionUtils.runObjectLog(() -> m_resourceManager.createImage(editingSupport.getViewerColumn().getPresentation().getImageDescriptor()), null);
 			}
 			return null;
 		}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/part/rcp/perspective/shortcuts/AbstractShortcutContainerEditPart.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/part/rcp/perspective/shortcuts/AbstractShortcutContainerEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,6 @@ import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.rcp.model.rcp.perspective.shortcuts.AbstractShortcutContainerInfo;
 
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -76,11 +75,6 @@ abstract class AbstractShortcutContainerEditPart extends GraphicalEditPart {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	protected List<?> getModelChildren() {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<List<?>>() {
-			@Override
-			public List<?> runObject() throws Exception {
-				return m_container.getPresentation().getChildrenGraphical();
-			}
-		}, Collections.emptyList());
+		return ExecutionUtils.runObjectLog(() -> m_container.getPresentation().getChildrenGraphical(), Collections.emptyList());
 	}
 }

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/menu/MenuPopupDropLayoutEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/menu/MenuPopupDropLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,7 +23,6 @@ import org.eclipse.wb.gef.core.requests.PasteRequest;
 import org.eclipse.wb.gef.graphical.policies.LayoutEditPolicy;
 import org.eclipse.wb.internal.core.model.clipboard.JavaInfoMemento;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.menu.JMenuBarInfo;
 import org.eclipse.wb.internal.swing.model.component.menu.JPopupMenuInfo;
@@ -147,22 +146,19 @@ public class MenuPopupDropLayoutEditPolicy extends LayoutEditPolicy {
 
 		@Override
 		public boolean validatePasteRequest(EditPart host, final PasteRequest request) {
-			return ExecutionUtils.runObjectLog(new RunnableObjectEx<Boolean>() {
-				@Override
-				public Boolean runObject() throws Exception {
-					// check that memento contains JPopupMenu_Info
-					@SuppressWarnings("unchecked")
-					List<JavaInfoMemento> mementos = (List<JavaInfoMemento>) request.getMemento();
-					if (mementos.size() == 1) {
-						JavaInfo javaInfo = mementos.get(0).create(m_component);
-						if (javaInfo instanceof JPopupMenuInfo) {
-							request.setObject(javaInfo);
-							return true;
-						}
+			return ExecutionUtils.runObjectLog(() -> {
+				// check that memento contains JPopupMenu_Info
+				@SuppressWarnings("unchecked")
+				List<JavaInfoMemento> mementos = (List<JavaInfoMemento>) request.getMemento();
+				if (mementos.size() == 1) {
+					JavaInfo javaInfo = mementos.get(0).create(m_component);
+					if (javaInfo instanceof JPopupMenuInfo) {
+						request.setObject(javaInfo);
+						return true;
 					}
-					// not a JPopupMenu_Info
-					return false;
 				}
+				// not a JPopupMenu_Info
+				return false;
 			}, false);
 		}
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/menu/JMenuPolicyImpl.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/menu/JMenuPolicyImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,7 +23,6 @@ import org.eclipse.wb.internal.core.model.menu.IMenuPolicy;
 import org.eclipse.wb.internal.core.model.util.TemplateUtils;
 import org.eclipse.wb.internal.core.model.variable.VoidInvocationVariableSupport;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.swing.model.bean.ActionContainerInfo;
 import org.eclipse.wb.internal.swing.model.bean.ActionInfo;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
@@ -66,18 +65,15 @@ final class JMenuPolicyImpl implements IMenuPolicy {
 	@Override
 	@SuppressWarnings("unchecked")
 	public boolean validatePaste(final Object mementoObject) {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<Boolean>() {
-			@Override
-			public Boolean runObject() throws Exception {
-				List<JavaInfoMemento> mementos = (List<JavaInfoMemento>) mementoObject;
-				for (JavaInfoMemento memento : mementos) {
-					JavaInfo component = memento.create(m_menu);
-					if (!isValidObjectType(component)) {
-						return false;
-					}
+		return ExecutionUtils.runObjectLog(() -> {
+			List<JavaInfoMemento> mementos = (List<JavaInfoMemento>) mementoObject;
+			for (JavaInfoMemento memento : mementos) {
+				JavaInfo component = memento.create(m_menu);
+				if (!isValidObjectType(component)) {
+					return false;
 				}
-				return true;
 			}
+			return true;
 		}, false);
 	}
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/BorderDialog.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/BorderDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,6 @@ import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.ast.DomGenerics;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.state.EditorState;
 import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
@@ -270,12 +269,9 @@ public final class BorderDialog extends ResizableDialog {
 	 * @return the source of {@link Border} from currently selected {@link AbstractBorderComposite}.
 	 */
 	private String getCurrentBorderSource() {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<String>() {
-			@Override
-			public String runObject() throws Exception {
-				int index = m_typeCombo.getSelectionIndex();
-				return m_pages.get(index).getSource();
-			}
+		return ExecutionUtils.runObjectLog(() -> {
+			int index = m_typeCombo.getSelectionIndex();
+			return m_pages.get(index).getSource();
 		}, null);
 	}
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/models/combo/ComboBoxModelDialog.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/models/combo/ComboBoxModelDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,6 @@ package org.eclipse.wb.internal.swing.model.property.editor.models.combo;
 
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
 import org.eclipse.wb.internal.core.utils.ui.dialogs.ResizableDialog;
@@ -266,24 +265,21 @@ public class ComboBoxModelDialog extends ResizableDialog {
 	 * @return the edited items.
 	 */
 	public String[] getItems() {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<String[]>() {
-			@Override
-			public String[] runObject() throws Exception {
-				List<String> strings = new ArrayList<>();
-				String stringItems =
-						itemsText != null && !itemsText.isDisposed()
-						? itemsText.getText()
-								: ComboBoxModelDialog.this.stringItems;
-				BufferedReader br = new BufferedReader(new StringReader(stringItems));
-				while (true) {
-					String s = br.readLine();
-					if (s == null) {
-						break;
-					}
-					strings.add(s);
+		return ExecutionUtils.runObjectLog(() -> {
+			List<String> strings = new ArrayList<>();
+			String stringItems =
+					itemsText != null && !itemsText.isDisposed()
+					? itemsText.getText()
+							: ComboBoxModelDialog.this.stringItems;
+			BufferedReader br = new BufferedReader(new StringReader(stringItems));
+			while (true) {
+				String s = br.readLine();
+				if (s == null) {
+					break;
 				}
-				return strings.toArray(new String[strings.size()]);
+				strings.add(s);
 			}
+			return strings.toArray(new String[strings.size()]);
 		}, ArrayUtils.EMPTY_STRING_ARRAY);
 	}
 }

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormSelectionEditPolicyClassic.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormSelectionEditPolicyClassic.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,7 +35,6 @@ import org.eclipse.wb.internal.core.gef.policy.layout.absolute.AbsolutePolicyUti
 import org.eclipse.wb.internal.core.gef.policy.layout.absolute.LineEndFigure;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.swt.model.layout.form.FormLayoutInfoImplClassic;
 import org.eclipse.wb.internal.swt.model.layout.form.IFormAttachmentInfo;
 import org.eclipse.wb.internal.swt.model.layout.form.IFormDataInfo;
@@ -598,12 +597,7 @@ SelectionEditPolicy {
 	@Override
 	public Command getCommand(final Request request) {
 		if (AbsoluteBasedSelectionEditPolicy.REQ_RESIZE.equals(request.getType())) {
-			return ExecutionUtils.<Command>runObjectLog(new RunnableObjectEx<Command>() {
-				@Override
-				public Command runObject() throws Exception {
-					return getResizeCommand((ChangeBoundsRequest) request);
-				}
-			}, null);
+			return ExecutionUtils.runObjectLog(() -> getResizeCommand((ChangeBoundsRequest) request), null);
 		}
 		return null;
 	}

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/widgets/menu/MenuInfo.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/widgets/menu/MenuInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -41,7 +41,6 @@ import org.eclipse.wb.internal.core.utils.IAdaptable;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.ast.NodeTarget;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.swt.model.widgets.WidgetInfo;
 import org.eclipse.wb.internal.swt.model.widgets.live.SwtLiveManager;
 import org.eclipse.wb.internal.swt.model.widgets.live.menu.MenuLiveManager;
@@ -446,18 +445,15 @@ public final class MenuInfo extends WidgetInfo implements IAdaptable {
 		@Override
 		@SuppressWarnings("unchecked")
 		public boolean validatePaste(final Object mementoObject) {
-			return ExecutionUtils.runObjectLog(new RunnableObjectEx<Boolean>() {
-				@Override
-				public Boolean runObject() throws Exception {
-					List<JavaInfoMemento> mementos = (List<JavaInfoMemento>) mementoObject;
-					for (JavaInfoMemento memento : mementos) {
-						JavaInfo component = memento.create(m_this);
-						if (!(component instanceof MenuItemInfo)) {
-							return false;
-						}
+			return ExecutionUtils.runObjectLog(() -> {
+				List<JavaInfoMemento> mementos = (List<JavaInfoMemento>) mementoObject;
+				for (JavaInfoMemento memento : mementos) {
+					JavaInfo component = memento.create(m_this);
+					if (!(component instanceof MenuItemInfo)) {
+						return false;
 					}
-					return true;
 				}
+				return true;
 			}, false);
 		}
 

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/support/FillLayoutSupport.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/support/FillLayoutSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,6 @@
 package org.eclipse.wb.internal.swt.support;
 
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
 /**
@@ -31,12 +30,7 @@ public class FillLayoutSupport extends AbstractSupport {
 	 * @return value of field <code>type</code>.
 	 */
 	public static int getType(final Object layout) {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<Integer>() {
-			@Override
-			public Integer runObject() throws Exception {
-				return ReflectionUtils.getFieldInt(layout, "type");
-			}
-		}, SwtSupport.HORIZONTAL);
+		return ExecutionUtils.runObjectLog(() -> ReflectionUtils.getFieldInt(layout, "type"), SwtSupport.HORIZONTAL);
 	}
 
 	/**

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/support/RowLayoutSupport.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/support/RowLayoutSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,6 @@
 package org.eclipse.wb.internal.swt.support;
 
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
 /**
@@ -38,12 +37,7 @@ public class RowLayoutSupport extends AbstractSupport {
 	 * @return value of field <code>type</code>.
 	 */
 	public static int getType(final Object layout) {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<Integer>() {
-			@Override
-			public Integer runObject() throws Exception {
-				return ReflectionUtils.getFieldInt(layout, "type");
-			}
-		}, SwtSupport.HORIZONTAL);
+		return ExecutionUtils.runObjectLog(() -> ReflectionUtils.getFieldInt(layout, "type"), SwtSupport.HORIZONTAL);
 	}
 
 	/**

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/execution/ExecutionUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/execution/ExecutionUtilsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -443,12 +443,7 @@ public class ExecutionUtilsTest extends SwingModelTest {
 	@Test
 	public void test_object_log_noException() throws Exception {
 		final Object myResult = new Object();
-		Object result = ExecutionUtils.runObjectLog(new RunnableObjectEx<Object>() {
-			@Override
-			public Object runObject() throws Exception {
-				return myResult;
-			}
-		}, null);
+		Object result = ExecutionUtils.runObjectLog(() -> myResult, null);
 		assertSame(myResult, result);
 	}
 
@@ -459,12 +454,7 @@ public class ExecutionUtilsTest extends SwingModelTest {
 		Object result;
 		try {
 			DesignerPlugin.setDisplayExceptionOnConsole(false);
-			result = ExecutionUtils.runObjectLog(new RunnableObjectEx<Object>() {
-				@Override
-				public Object runObject() throws Exception {
-					throw new Exception();
-				}
-			}, myResult);
+			result = ExecutionUtils.runObjectLog(() -> { throw new Exception(); }, myResult);
 		} finally {
 			DesignerPlugin.setDisplayExceptionOnConsole(true);
 		}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/TreeRobot.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/TreeRobot.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -168,13 +168,10 @@ public final class TreeRobot {
 	 * @return the currently active command in {@link TreeViewer} drag listener.
 	 */
 	private Command getDragCommand() {
-		return ExecutionUtils.runObjectLog(new RunnableObjectEx<Command>() {
-			@Override
-			public Command runObject() throws Exception {
-				Object eventManager = ReflectionUtils.getFieldObject(m_viewer, "m_eventManager");
-				Object dropListener = ReflectionUtils.getFieldObject(eventManager, "m_dropListener");
-				return (Command) ReflectionUtils.getFieldObject(dropListener, "m_command");
-			}
+		return ExecutionUtils.runObjectLog(() -> {
+			Object eventManager = ReflectionUtils.getFieldObject(m_viewer, "m_eventManager");
+			Object dropListener = ReflectionUtils.getFieldObject(eventManager, "m_dropListener");
+			return (Command) ReflectionUtils.getFieldObject(dropListener, "m_command");
 		}, null);
 	}
 


### PR DESCRIPTION
Our RunnableObjectEx and the Java Callable are functionally identical: The interface defines a single method, which returns a generic object and may throw an exception. So there is no need to use our own interface.

Where applicable, anonymous instances of this interface have been replaced with lambda expressions.