### PR TITLE
[GEF] Harmonize inclusion/exclusion set in tools

### DIFF
--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/IEditPartViewer.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/IEditPartViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -184,7 +184,7 @@ public interface IEditPartViewer extends ISelectionProvider, org.eclipse.gef.Edi
 	 */
 	EditPart findTargetEditPart(int x,
 			int y,
-			final Collection<EditPart> exclude,
+			final Collection<? extends org.eclipse.gef.EditPart> exclude,
 			final Conditional conditional);
 
 	/**
@@ -193,7 +193,7 @@ public interface IEditPartViewer extends ISelectionProvider, org.eclipse.gef.Edi
 	 */
 	EditPart findTargetEditPart(int x,
 			int y,
-			final Collection<EditPart> exclude,
+			final Collection<? extends org.eclipse.gef.EditPart> exclude,
 			final Conditional conditional,
 			String layer);
 

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/DragEditPartTracker.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/DragEditPartTracker.java
@@ -108,13 +108,13 @@ public class DragEditPartTracker extends SelectEditPartTracker {
 	// Handling operations
 	//
 	////////////////////////////////////////////////////////////////////////////
-	private Collection<org.eclipse.wb.gef.core.EditPart> m_exclusionSet;
+	private Collection<EditPart> m_exclusionSet;
 
 	/**
 	 * Returns a list of all the edit parts in the {@link Tool#getOperationSet() operation set}.
 	 */
 	@Override
-	protected Collection<org.eclipse.wb.gef.core.EditPart> getExclusionSet() {
+	protected Collection<EditPart> getExclusionSet() {
 		if (m_exclusionSet == null) {
 			m_exclusionSet = new ArrayList<>(getOperationSet());
 		}
@@ -234,7 +234,7 @@ public class DragEditPartTracker extends SelectEditPartTracker {
 	 */
 	private List<Object> getOperationSetModels() {
 		List<Object> models = new ArrayList<>();
-		for (org.eclipse.wb.gef.core.EditPart part : getOperationSet()) {
+		for (EditPart part : getOperationSet()) {
 			models.add(part.getModel());
 		}
 		return models;
@@ -262,12 +262,12 @@ public class DragEditPartTracker extends SelectEditPartTracker {
 	@Override
 	protected Command getCommand() {
 		Request request = getTargetRequest();
-		List<org.eclipse.wb.gef.core.EditPart> operationSet = getOperationSet();
+		List<? extends EditPart> operationSet = getOperationSet();
 		//
 		if (isMove()) {
 			if (m_canMove && !operationSet.isEmpty()) {
 				// if move get command from parent
-				org.eclipse.wb.gef.core.EditPart firstPart = operationSet.get(0);
+				EditPart firstPart = operationSet.get(0);
 				//
 				return firstPart.getParent().getCommand(request);
 			}
@@ -281,7 +281,7 @@ public class DragEditPartTracker extends SelectEditPartTracker {
 					compoundCommand = objectInfoEditPart.createCompoundCommand();
 				}
 				if (!operationSet.isEmpty()) {
-					org.eclipse.wb.gef.core.EditPart firstPart = operationSet.get(0);
+					EditPart firstPart = operationSet.get(0);
 					GroupRequest orphanRequest = new GroupRequest(RequestConstants.REQ_ORPHAN);
 					orphanRequest.setEditParts(operationSet);
 					compoundCommand.add(firstPart.getParent().getCommand(orphanRequest));

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/TargetingTool.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/TargetingTool.java
@@ -141,7 +141,7 @@ public abstract class TargetingTool extends Tool {
 	/**
 	 * Returns a List of objects that should be excluded as potential targets for the operation.
 	 */
-	protected Collection<org.eclipse.wb.gef.core.EditPart> getExclusionSet() {
+	protected Collection<? extends EditPart> getExclusionSet() {
 		return Collections.emptyList();
 	}
 

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/Tool.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/Tool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,12 +10,12 @@
  *******************************************************************************/
 package org.eclipse.wb.gef.core.tools;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.internal.gef.core.EditDomain;
 
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.gef.DragTracker;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.swt.SWT;
@@ -128,14 +128,14 @@ public abstract class Tool extends org.eclipse.gef.tools.AbstractTool implements
 	// OperationSet
 	//
 	////////////////////////////////////////////////////////////////////////////
-	private List<EditPart> m_operationSet;
+	private List<? extends EditPart> m_operationSet;
 
 	/**
 	 * Lazily creates and returns the list of {@link EditPart}'s on which the tool operates. The list
 	 * is initially <code>null</code>, in which case {@link #createOperationSet()} is called, and its
 	 * results cached until the tool is deactivated.
 	 */
-	protected final List<EditPart> getOperationSet() {
+	protected final List<? extends EditPart> getOperationSet() {
 		if (m_operationSet == null) {
 			m_operationSet = createOperationSet();
 		}
@@ -149,7 +149,7 @@ public abstract class Tool extends org.eclipse.gef.tools.AbstractTool implements
 	 * By default, the operations set is the current viewer's entire selection. Subclasses may
 	 * override this method to filter or alter the operation set as necessary.
 	 */
-	protected List<EditPart> createOperationSet() {
+	protected List<? extends EditPart> createOperationSet() {
 		return new ArrayList<>(getCurrentViewer().getSelectedEditParts());
 	}
 

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/tools/ResizeTracker.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/tools/ResizeTracker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.gef.graphical.tools;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
 import org.eclipse.wb.gef.core.requests.KeyRequest;
 import org.eclipse.wb.gef.core.tools.Tool;
@@ -19,6 +18,7 @@ import org.eclipse.draw2d.Cursors;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
@@ -195,12 +195,12 @@ public class ResizeTracker extends Tool {
 	 * Returns all selected parts which understand resizing.
 	 */
 	@Override
-	protected List<EditPart> createOperationSet() {
+	protected List<? extends EditPart> createOperationSet() {
 		if (m_operationSet != null) {
 			return m_operationSet;
 		}
 		// find target EditPart's that agree to process current request
-		List<EditPart> operationSet = super.createOperationSet();
+		List<EditPart> operationSet = new ArrayList<>(super.createOperationSet());
 		for (ListIterator<EditPart> I = operationSet.listIterator(); I.hasNext();) {
 			EditPart part = I.next();
 			// find target for current EditPart

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/graphical/GraphicalViewer.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/graphical/GraphicalViewer.java
@@ -160,7 +160,7 @@ public class GraphicalViewer extends AbstractEditPartViewer {
 	@Override
 	public EditPart findTargetEditPart(int x,
 			int y,
-			final Collection<EditPart> exclude,
+			final Collection<? extends org.eclipse.gef.EditPart> exclude,
 			final Conditional conditional) {
 		EditPart editPart = findTargetEditPart(x, y, exclude, conditional, MENU_PRIMARY_LAYER);
 		if (editPart == null) {
@@ -176,13 +176,13 @@ public class GraphicalViewer extends AbstractEditPartViewer {
 	@Override
 	public EditPart findTargetEditPart(int x,
 			int y,
-			final Collection<EditPart> exclude,
+			final Collection<? extends org.eclipse.gef.EditPart> exclude,
 			final Conditional conditional,
 			String layer) {
 		TargetEditPartFindVisitor visitor = new TargetEditPartFindVisitor(m_canvas, x, y, this) {
 			@Override
 			protected boolean acceptVisit(Figure figure) {
-				for (EditPart editPart : exclude) {
+				for (org.eclipse.gef.EditPart editPart : exclude) {
 					GraphicalEditPart graphicalPart = (GraphicalEditPart) editPart;
 					if (ObjectUtils.equals(figure, graphicalPart.getFigure())) {
 						return false;

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/tree/TreeViewer.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/tree/TreeViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -232,7 +232,7 @@ public class TreeViewer extends AbstractEditPartViewer {
 	@Override
 	public EditPart findTargetEditPart(int x,
 			int y,
-			Collection<EditPart> exclude,
+			Collection<? extends org.eclipse.gef.EditPart> exclude,
 			Conditional conditional) {
 		// simple check location
 		Rectangle clientArea = m_tree.getClientArea();
@@ -260,7 +260,7 @@ public class TreeViewer extends AbstractEditPartViewer {
 	@Override
 	public EditPart findTargetEditPart(int x,
 			int y,
-			Collection<EditPart> exclude,
+			Collection<? extends org.eclipse.gef.EditPart> exclude,
 			Conditional conditional,
 			String layer) {
 		return null;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/EmptyEditPartViewer.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/EmptyEditPartViewer.java
@@ -56,7 +56,7 @@ public class EmptyEditPartViewer extends AbstractEditPartViewer implements IEdit
 	@Override
 	public EditPart findTargetEditPart(int x,
 			int y,
-			Collection<EditPart> exclude,
+			Collection<? extends org.eclipse.gef.EditPart> exclude,
 			Conditional conditional) {
 		return null;
 	}
@@ -64,7 +64,7 @@ public class EmptyEditPartViewer extends AbstractEditPartViewer implements IEdit
 	@Override
 	public EditPart findTargetEditPart(int x,
 			int y,
-			Collection<EditPart> exclude,
+			Collection<? extends org.eclipse.gef.EditPart> exclude,
 			Conditional conditional,
 			String layer) {
 		return null;


### PR DESCRIPTION
This makes it so that those sets work directly on the GEF edit parts instead of the WindowBuilder edit parts, thus matching the signatures of the Tool base class.

See https://github.com/eclipse-windowbuilder/windowbuilder/pull/829