### PR TITLE
Change signatures in SwingUtils to expect a Callable object

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/top/SwingTopBoundsSupport.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/top/SwingTopBoundsSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,6 @@ import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.model.TopBoundsSupport;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.swing.model.ModelMessages;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.utils.SwingUtils;
@@ -172,39 +171,36 @@ public class SwingTopBoundsSupport extends TopBoundsSupport {
 	 */
 	private static Window prepareWindow(final Component component, final Rectangle clientArea)
 			throws Exception {
-		return SwingUtils.runObjectLaterAndWait(new RunnableObjectEx<Window>() {
-			@Override
-			public Window runObject() throws Exception {
-				final Window window;
-				if (component instanceof Window) {
-					window = (Window) component;
-				} else {
-					JFrame frame = new JFrame();
-					window = frame;
-					// add component on frame
-					component.setPreferredSize(component.getSize());
-					frame.getContentPane().add(component, BorderLayout.CENTER);
-					// configure frame
-					frame.setTitle(ModelMessages.SwingTopBoundsSupport_wrapperTitle);
-					frame.pack();
-				}
-				// set window location
-				{
-					int x = clientArea.x + (clientArea.width - window.getWidth()) / 2;
-					int y = clientArea.y + (clientArea.height - window.getHeight()) / 2;
-					window.setLocation(x, y);
-				}
-				// configure special windows
-				{
-					if (window instanceof Dialog) {
-						((Dialog) window).setModal(false);
-					}
-					if (window instanceof JFrame) {
-						((JFrame) window).setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-					}
-				}
-				return window;
+		return SwingUtils.runObjectLaterAndWait(() -> {
+			final Window window;
+			if (component instanceof Window) {
+				window = (Window) component;
+			} else {
+				JFrame frame = new JFrame();
+				window = frame;
+				// add component on frame
+				component.setPreferredSize(component.getSize());
+				frame.getContentPane().add(component, BorderLayout.CENTER);
+				// configure frame
+				frame.setTitle(ModelMessages.SwingTopBoundsSupport_wrapperTitle);
+				frame.pack();
 			}
+			// set window location
+			{
+				int x = clientArea.x + (clientArea.width - window.getWidth()) / 2;
+				int y = clientArea.y + (clientArea.height - window.getHeight()) / 2;
+				window.setLocation(x, y);
+			}
+			// configure special windows
+			{
+				if (window instanceof Dialog) {
+					((Dialog) window).setModal(false);
+				}
+				if (window instanceof JFrame) {
+					((JFrame) window).setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+				}
+			}
+			return window;
 		});
 	}
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingUtils.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,6 @@ import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.EnvironmentUtils;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.core.utils.state.GlobalState;
 import org.eclipse.wb.os.OSSupport;
@@ -33,6 +32,7 @@ import java.awt.Container;
 import java.awt.EventQueue;
 import java.awt.IllegalComponentStateException;
 import java.awt.Point;
+import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.swing.JFrame;
@@ -109,10 +109,10 @@ public final class SwingUtils {
 
 	/**
 	 * Same as {@link #runLaterAndWait(RunnableEx)} but returns the result of execution. See
-	 * {@link ExecutionUtils#runObject(RunnableObjectEx)}.
+	 * {@link ExecutionUtils#runObject(Callable)}.
 	 */
 	@SuppressWarnings("unchecked")
-	public static <T> T runObjectLaterAndWait(final RunnableObjectEx<T> runnableEx) throws Exception {
+	public static <T> T runObjectLaterAndWait(final Callable<T> runnableEx) throws Exception {
 		final AtomicBoolean done = new AtomicBoolean();
 		final Throwable ex[] = new Throwable[1];
 		final Object[] result = new Object[1];
@@ -120,7 +120,7 @@ public final class SwingUtils {
 			@Override
 			public void run() {
 				try {
-					result[0] = runnableEx.runObject();
+					result[0] = runnableEx.call();
 				} catch (Throwable e) {
 					ex[0] = e;
 				} finally {
@@ -300,12 +300,7 @@ public final class SwingUtils {
 	 */
 	public static Point getScreenLocation(final Component component) throws Exception {
 		try {
-			return runObjectLaterAndWait(new RunnableObjectEx<Point>() {
-				@Override
-				public Point runObject() throws Exception {
-					return component.getLocationOnScreen();
-				}
-			});
+			return runObjectLaterAndWait(() -> component.getLocationOnScreen());
 		} catch (IllegalComponentStateException e) {
 			return new Point();
 		}


### PR DESCRIPTION
Our RunnableObjectEx and the Java Callable are functionally identical: The interface defines a single method, which returns a generic object and may throw an exception. So there is no need to use our own interface.

Where applicable, anonymous instances of this interface have been replaced with lambda expressions.