### PR TITLE
[GEF] Harmonize selection methods in IEditPartViewer base interface

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/core/editor/palette/model/entry/TabOrderToolEntryInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/core/editor/palette/model/entry/TabOrderToolEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,12 +11,12 @@
 package org.eclipse.wb.core.editor.palette.model.entry;
 
 import org.eclipse.wb.core.editor.palette.model.EntryInfo;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.tools.Tool;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.editor.Messages;
 import org.eclipse.wb.internal.core.gef.tools.TabOrderTool;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.util.List;
@@ -47,7 +47,7 @@ public final class TabOrderToolEntryInfo extends ToolEntryInfo {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public Tool createTool() throws Exception {
-		List<EditPart> selectedParts = m_editPartViewer.getSelectedEditParts();
+		List<? extends EditPart> selectedParts = m_editPartViewer.getSelectedEditParts();
 		if (selectedParts.size() == 1) {
 			EditPart editPart = selectedParts.get(0);
 			if (TabOrderTool.hasContainerRole(editPart)) {

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/DesignContextMenuProvider.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/DesignContextMenuProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 Google, Inc and others
+ * Copyright (c) 2011, 2024 Google, Inc and others
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,6 @@ package org.eclipse.wb.internal.core.editor;
 import org.eclipse.wb.core.editor.IContextMenuConstants;
 import org.eclipse.wb.core.editor.constants.IEditorPreferenceConstants;
 import org.eclipse.wb.core.model.ObjectInfo;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.internal.core.editor.actions.DesignPageActions;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
@@ -23,6 +22,7 @@ import org.eclipse.wb.internal.gef.core.ContextMenuProvider;
 import org.eclipse.wb.internal.gef.core.MultiSelectionContextMenuProvider;
 
 import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.gef.EditPart;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.Separator;
 
@@ -83,7 +83,7 @@ IContextMenuConstants {
 	private List<ObjectInfo> m_selectedObjects;
 
 	@Override
-	protected void preprocessSelection(List<EditPart> editParts) {
+	protected void preprocessSelection(List<? extends EditPart> editParts) {
 		super.preprocessSelection(editParts);
 		// prepare selected ObjectInfo's
 		m_selectedObjects = new ArrayList<>();

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/actions/CopyAction.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/actions/CopyAction.java
@@ -11,13 +11,13 @@
 package org.eclipse.wb.internal.core.editor.actions;
 
 import org.eclipse.wb.core.model.JavaInfo;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.internal.core.model.clipboard.JavaInfoMemento;
 import org.eclipse.wb.internal.core.model.clipboard.JavaInfoMementoTransfer;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
@@ -68,7 +68,7 @@ public class CopyAction extends Action {
 		ExecutionUtils.runLog(new RunnableEx() {
 			@Override
 			public void run() throws Exception {
-				List<EditPart> editParts = m_viewer.getSelectedEditParts();
+				List<? extends EditPart> editParts = m_viewer.getSelectedEditParts();
 				m_mementos = getMementos(editParts);
 				doCopy(m_mementos);
 			}
@@ -77,7 +77,7 @@ public class CopyAction extends Action {
 
 	@Override
 	public boolean isEnabled() {
-		List<EditPart> editParts = m_viewer.getSelectedEditParts();
+		List<? extends EditPart> editParts = m_viewer.getSelectedEditParts();
 		return hasMementos(editParts);
 	}
 
@@ -105,7 +105,7 @@ public class CopyAction extends Action {
 	/**
 	 * @return <code>true</code> if given {@link JavaInfo}'s can be copy/pasted.
 	 */
-	static boolean hasMementos(final List<EditPart> editParts) {
+	static boolean hasMementos(final List<? extends EditPart> editParts) {
 		return ExecutionUtils.runObjectLog(() -> {
 			// selection required
 			if (editParts.isEmpty()) {
@@ -136,11 +136,11 @@ public class CopyAction extends Action {
 	/**
 	 * @return the {@link JavaInfoMemento}'s with copy/paste information for given {@link JavaInfo}'s.
 	 */
-	static List<JavaInfoMemento> getMementos(final List<EditPart> editParts) {
+	static List<JavaInfoMemento> getMementos(final List<? extends EditPart> editParts) {
 		return ExecutionUtils.runObjectLog(() -> getMemento0(editParts), null);
 	}
 
-	private static List<JavaInfoMemento> getMemento0(List<EditPart> editParts) throws Exception {
+	private static List<JavaInfoMemento> getMemento0(List<? extends EditPart> editParts) throws Exception {
 		// prepare objects
 		List<JavaInfo> objects = new ArrayList<>();
 		for (EditPart editPart : editParts) {

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/actions/CutAction.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/actions/CutAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,12 +10,12 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.editor.actions;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.internal.core.model.clipboard.JavaInfoMemento;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
@@ -64,7 +64,7 @@ public class CutAction extends Action {
 			public void run() throws Exception {
 				// copy
 				{
-					List<EditPart> editParts = m_viewer.getSelectedEditParts();
+					List<? extends EditPart> editParts = m_viewer.getSelectedEditParts();
 					List<JavaInfoMemento> m_mementos = CopyAction.getMementos(editParts);
 					CopyAction.doCopy(m_mementos);
 				}
@@ -76,7 +76,7 @@ public class CutAction extends Action {
 
 	@Override
 	public boolean isEnabled() {
-		List<EditPart> editParts = m_viewer.getSelectedEditParts();
+		List<? extends EditPart> editParts = m_viewer.getSelectedEditParts();
 		m_command = DeleteAction.getCommand(editParts);
 		return CopyAction.hasMementos(editParts) && m_command != null;
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/tools/TabOrderTool.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/tools/TabOrderTool.java
@@ -38,7 +38,7 @@ import java.util.List;
 public final class TabOrderTool extends TargetingTool {
 	private final TabOrderContainerRequest m_containerRequest =
 			new TabOrderContainerRequest(TabOrderContainerEditPolicy.REQ_CONTAINER_TAB_ORDER);
-	private final IEditPartViewer m_viewer;
+	private final EditPartViewer m_viewer;
 	private EditPolicy m_containerPolicy;
 	private int m_currentIndex;
 	private boolean m_saveTabOrder;
@@ -49,7 +49,7 @@ public final class TabOrderTool extends TargetingTool {
 	// Constructor
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public TabOrderTool(org.eclipse.wb.gef.core.EditPart part) {
+	public TabOrderTool(EditPart part) {
 		setDefaultCursor(Cursors.ARROW);
 		m_viewer = part.getViewer();
 		m_viewer.addSelectionChangedListener(m_selectionListener);

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/IEditPartViewer.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/IEditPartViewer.java
@@ -131,47 +131,11 @@ public interface IEditPartViewer extends ISelectionProvider, org.eclipse.gef.Edi
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * Appends the specified <code>{@link EditPart}</code> to the viewer's <i>selection</i>. The
-	 * {@link EditPart} becomes the new primary selection.
-	 */
-	void appendSelection(EditPart part);
-
-	/**
-	 * Replaces the current selection with the specified <code>{@link EditPart EditParts}</code>.
-	 */
-	void setSelection(List<EditPart> editParts);
-
-	/**
-	 * Replaces the current selection with the specified <code>{@link EditPart}</code>. That part
-	 * becomes the primary selection.
-	 */
-	void select(EditPart part);
-
-	/**
-	 * Removes the specified <code>{@link EditPart}</code> from the current selection. The last
-	 * EditPart in the new selection is made {@link EditPart#SELECTED_PRIMARY primary}.
-	 */
-	void deselect(EditPart part);
-
-	/**
 	 * Removes the specified <code>{@link List}</code> of <code>{@link EditPart}</code>'s from the
 	 * current selection. The last EditPart in the new selection is made
 	 * {@link EditPart#SELECTED_PRIMARY primary}.
 	 */
-	void deselect(List<EditPart> editParts);
-
-	/**
-	 * Returns an unmodifiable <code>List</code> containing zero or more selected editparts. This list
-	 * may be empty. This list can be modified indirectly by calling other methods on the viewer.
-	 */
-	List<EditPart> getSelectedEditParts();
-
-	/**
-	 * Returns the {@link EditPart} which is being selected during selection listeners firing. IOW,
-	 * this will allow to track where the selection goes during deselecting another EditPart. After
-	 * all selection listeners fired this method returns <code>null</code>.
-	 */
-	EditPart getSelectingEditPart();
+	void deselect(List<? extends org.eclipse.gef.EditPart> editParts);
 
 	////////////////////////////////////////////////////////////////////////////
 	//

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/DragEditPartTracker.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/DragEditPartTracker.java
@@ -24,6 +24,7 @@ import org.eclipse.gef.RequestConstants;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.commands.CompoundCommand;
 import org.eclipse.gef.requests.GroupRequest;
+import org.eclipse.jface.viewers.StructuredSelection;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -142,9 +143,9 @@ public class DragEditPartTracker extends SelectEditPartTracker {
 	 * target request.
 	 */
 	@Override
-	protected List<org.eclipse.wb.gef.core.EditPart> createOperationSet() {
+	protected List<? extends EditPart> createOperationSet() {
 		// extract OperationSet from selection
-		List<org.eclipse.wb.gef.core.EditPart> operationSet = ToolUtilities.getSelectionWithoutDependants(getCurrentViewer());
+		List<EditPart> operationSet = ToolUtilities.getSelectionWithoutDependants(getCurrentViewer());
 		// check understandsRequest() from parent
 		// FIXME Kosta.20071115 I don't understand, why we should ask parent _here_
 		// Yes, if parent does not support move, we should not allow operation.
@@ -166,7 +167,7 @@ public class DragEditPartTracker extends SelectEditPartTracker {
 		// check permission for move and reparenting
 		{
 			DragPermissionRequest request = new DragPermissionRequest();
-			for (org.eclipse.wb.gef.core.EditPart editPart : operationSet) {
+			for (EditPart editPart : operationSet) {
 				editPart.performRequest(request);
 			}
 			m_canMove = request.canMove();
@@ -247,15 +248,15 @@ public class DragEditPartTracker extends SelectEditPartTracker {
 		if (models != null) {
 			IEditPartViewer viewer = getCurrentViewer();
 			// prepare new EditPart's
-			List<org.eclipse.wb.gef.core.EditPart> newEditParts = new ArrayList<>();
+			List<EditPart> newEditParts = new ArrayList<>();
 			for (Object model : models) {
-				org.eclipse.wb.gef.core.EditPart newEditPart = (org.eclipse.wb.gef.core.EditPart) viewer.getEditPartRegistry().get(model);
+				EditPart newEditPart = (EditPart) viewer.getEditPartRegistry().get(model);
 				if (newEditPart != null) {
 					newEditParts.add(newEditPart);
 				}
 			}
 			// set new selection
-			viewer.setSelection(newEditParts);
+			viewer.setSelection(new StructuredSelection(newEditParts));
 		}
 	}
 

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/PasteTool.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/PasteTool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.core.requests.PasteRequest;
 
 import org.eclipse.gef.Request;
+import org.eclipse.jface.viewers.StructuredSelection;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -75,6 +76,6 @@ public class PasteTool extends AbstractCreationTool {
 			}
 		}
 		// select EditPart's
-		viewer.setSelection(editParts);
+		viewer.setSelection(new StructuredSelection(editParts));
 	}
 }

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/ToolUtilities.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/ToolUtilities.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,8 +10,9 @@
  *******************************************************************************/
 package org.eclipse.wb.gef.core.tools;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
+
+import org.eclipse.gef.EditPart;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -32,7 +33,7 @@ public class ToolUtilities {
 		List<EditPart> operationSet = new ArrayList<>();
 		// add selected EditPart's only if their parent is not added yet
 		{
-			List<EditPart> selectedParts = viewer.getSelectedEditParts();
+			List<? extends EditPart> selectedParts = viewer.getSelectedEditParts();
 			for (EditPart part : selectedParts) {
 				if (!isAncestorContainedIn(selectedParts, part)) {
 					operationSet.add(part);
@@ -62,7 +63,7 @@ public class ToolUtilities {
 	/**
 	 * @return <code>true</code> if <code>containers</code> contains parent of given {@link EditPart}.
 	 */
-	private static boolean isAncestorContainedIn(List<EditPart> container, EditPart part) {
+	private static boolean isAncestorContainedIn(List<? extends EditPart> container, EditPart part) {
 		EditPart parent = part.getParent();
 		while (parent != null) {
 			if (container.contains(parent)) {

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/tools/MarqueeSelectionTool.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/tools/MarqueeSelectionTool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,6 @@ package org.eclipse.wb.gef.graphical.tools;
 
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.core.tools.Tool;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
@@ -21,8 +20,10 @@ import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Cursors;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.RequestConstants;
+import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Cursor;
 
@@ -177,10 +178,10 @@ public class MarqueeSelectionTool extends Tool {
 				}
 			}
 			//
-			viewer.setSelection(selected);
+			viewer.setSelection(new StructuredSelection(selected));
 		} else {
 			// replace selection to all new selection elements
-			viewer.setSelection(newSelections);
+			viewer.setSelection(new StructuredSelection(newSelections));
 		}
 	}
 
@@ -291,7 +292,7 @@ public class MarqueeSelectionTool extends Tool {
 	private List<EditPart> getAllChildren() {
 		if (m_allChildren == null || m_allChildren.isEmpty()) {
 			m_allChildren = new ArrayList<>();
-			getAllChildren(m_allChildren, (EditPart) getCurrentViewer().getRootEditPart());
+			getAllChildren(m_allChildren, getCurrentViewer().getRootEditPart());
 		}
 		return m_allChildren;
 	}

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/core/AbstractEditPartViewer.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/core/AbstractEditPartViewer.java
@@ -11,7 +11,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.gef.core;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartFactory;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 
@@ -19,11 +18,11 @@ import org.eclipse.core.runtime.Assert;
 import org.eclipse.draw2d.EventListenerList;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.RootEditPart;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
-import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.widgets.Composite;
@@ -146,7 +145,7 @@ public abstract class AbstractEditPartViewer extends org.eclipse.gef.ui.parts.Ab
 	@Override
 	public ISelection getSelection() {
 		if (m_selectionList.isEmpty()) {
-			EditPart content = (EditPart) getRootEditPart().getContents();
+			EditPart content = getRootEditPart().getContents();
 			if (content != null) {
 				return new StructuredSelection(content);
 			}
@@ -155,13 +154,6 @@ public abstract class AbstractEditPartViewer extends org.eclipse.gef.ui.parts.Ab
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public void setSelection(ISelection selection) {
-		if (selection instanceof IStructuredSelection structuredSelection) {
-			setSelection(structuredSelection.toList());
-		}
-	}
-
 	protected void fireSelectionChanged() {
 		Iterator<ISelectionChangedListener> listeners = getListeners(ISelectionChangedListener.class);
 		if (listeners != null) {
@@ -205,8 +197,10 @@ public abstract class AbstractEditPartViewer extends org.eclipse.gef.ui.parts.Ab
 	 * Replaces the current selection with the specified <code>{@link EditPart EditParts}</code>.
 	 */
 	@Override
-	public void setSelection(List<EditPart> editParts) {
+	public void setSelection(ISelection selection) {
 		try {
+			@SuppressWarnings("unchecked")
+			List<EditPart> editParts = ((StructuredSelection) selection).toList();
 			if (!editParts.isEmpty()) {
 				m_selecting = editParts.get(0);
 			}
@@ -274,7 +268,7 @@ public abstract class AbstractEditPartViewer extends org.eclipse.gef.ui.parts.Ab
 	 * {@link EditPart#SELECTED_PRIMARY primary}.
 	 */
 	@Override
-	public void deselect(List<EditPart> editParts) {
+	public void deselect(List<? extends EditPart> editParts) {
 		for (EditPart part : editParts) {
 			Assert.isNotNull(part);
 			m_selectionList.remove(part);
@@ -312,16 +306,8 @@ public abstract class AbstractEditPartViewer extends org.eclipse.gef.ui.parts.Ab
 	 * viewer.
 	 */
 	@Override
-	public List<EditPart> getSelectedEditParts() {
+	public List<? extends EditPart> getSelectedEditParts() {
 		return m_selectionList;
-	}
-
-	/**
-	 * @return The EditPart which is being selected in selection process.
-	 */
-	@Override
-	public EditPart getSelectingEditPart() {
-		return m_selecting;
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -352,7 +338,7 @@ public abstract class AbstractEditPartViewer extends org.eclipse.gef.ui.parts.Ab
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public EditPart findObjectAtExcluding(Point location, Collection<IFigure> exclusionSet, Conditional conditional) {
+	public org.eclipse.wb.gef.core.EditPart findObjectAtExcluding(Point location, Collection<IFigure> exclusionSet, Conditional conditional) {
 		return null;
 	}
 

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/core/MultiSelectionContextMenuProvider.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/core/MultiSelectionContextMenuProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,10 +10,10 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.gef.core;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.internal.core.utils.ui.MenuIntersector;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
 
@@ -43,7 +43,7 @@ public abstract class MultiSelectionContextMenuProvider extends ContextMenuProvi
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	protected final void buildContextMenu() {
-		List<EditPart> editParts = m_viewer.getSelectedEditParts();
+		List<? extends EditPart> editParts = m_viewer.getSelectedEditParts();
 		preprocessSelection(editParts);
 		// check empty
 		if (editParts.isEmpty()) {
@@ -70,7 +70,7 @@ public abstract class MultiSelectionContextMenuProvider extends ContextMenuProvi
 	 * Notifies that given {@link EditPart}'s are selected and we are going to call later
 	 * {@link #buildContextMenu(EditPart, IMenuManager)} for each of them.
 	 */
-	protected void preprocessSelection(List<EditPart> editParts) {
+	protected void preprocessSelection(List<? extends EditPart> editParts) {
 	}
 
 	/**

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/tree/TreeViewer.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/tree/TreeViewer.java
@@ -11,7 +11,6 @@
 package org.eclipse.wb.internal.gef.tree;
 
 import org.eclipse.wb.draw2d.Layer;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.graphical.handles.Handle;
 import org.eclipse.wb.gef.tree.TreeEditPart;
 import org.eclipse.wb.internal.core.utils.ui.UiUtils;
@@ -20,6 +19,7 @@ import org.eclipse.wb.internal.gef.core.AbstractEditPartViewer;
 import org.eclipse.wb.internal.gef.core.EditDomain;
 
 import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.gef.EditPart;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.viewers.StructuredSelection;
@@ -230,9 +230,9 @@ public class TreeViewer extends AbstractEditPartViewer {
 	 * the given exclusion set and conditional.
 	 */
 	@Override
-	public EditPart findTargetEditPart(int x,
+	public org.eclipse.wb.gef.core.EditPart findTargetEditPart(int x,
 			int y,
-			Collection<? extends org.eclipse.gef.EditPart> exclude,
+			Collection<? extends EditPart> exclude,
 			Conditional conditional) {
 		// simple check location
 		Rectangle clientArea = m_tree.getClientArea();
@@ -240,12 +240,12 @@ public class TreeViewer extends AbstractEditPartViewer {
 			return null;
 		}
 		// find EditPart
-		EditPart result = null;
+		org.eclipse.wb.gef.core.EditPart result = null;
 		TreeItem item = m_tree.getItem(new org.eclipse.swt.graphics.Point(x, y));
 		if (item == null) {
 			result = m_rootEditPart;
 		} else {
-			result = (EditPart) item.getData();
+			result = (org.eclipse.wb.gef.core.EditPart) item.getData();
 		}
 		// apply conditional
 		while (result != null) {
@@ -258,9 +258,9 @@ public class TreeViewer extends AbstractEditPartViewer {
 	}
 
 	@Override
-	public EditPart findTargetEditPart(int x,
+	public org.eclipse.wb.gef.core.EditPart findTargetEditPart(int x,
 			int y,
-			Collection<? extends org.eclipse.gef.EditPart> exclude,
+			Collection<? extends EditPart> exclude,
 			Conditional conditional,
 			String layer) {
 		return null;

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/tree/dnd/TreeDropListener.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/tree/dnd/TreeDropListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,15 +10,16 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.gef.tree.dnd;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
 
 import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPartViewer.Conditional;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.RequestConstants;
 import org.eclipse.gef.commands.Command;
+import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.dnd.DND;
 import org.eclipse.swt.dnd.DropTarget;
 import org.eclipse.swt.dnd.DropTargetEvent;
@@ -120,11 +121,11 @@ public class TreeDropListener implements DropTargetListener {
 		m_target = null;
 	}
 
-	private List<EditPart> getDragSource() {
+	private List<? extends EditPart> getDragSource() {
 		return m_viewer.getSelectedEditParts();
 	}
 
-	private List<Object> getModels(List<EditPart> editParts) {
+	private List<Object> getModels(List<? extends EditPart> editParts) {
 		List<Object> models = new ArrayList<>();
 		for (EditPart editPart : editParts) {
 			models.add(editPart.getModel());
@@ -144,7 +145,7 @@ public class TreeDropListener implements DropTargetListener {
 				newEditParts.add(newEditPart);
 			}
 			// set new selection
-			m_viewer.setSelection(newEditParts);
+			m_viewer.setSelection(new StructuredSelection(newEditParts));
 		}
 	}
 
@@ -242,7 +243,7 @@ public class TreeDropListener implements DropTargetListener {
 		return editPart -> editPart.getTargetEditPart(getTargetRequest()) != null;
 	}
 
-	private static List<EditPart> includeChildren(List<EditPart> parts) {
+	private static List<? extends EditPart> includeChildren(List<? extends EditPart> parts) {
 		List<EditPart> result = new ArrayList<>();
 		for (EditPart editPart : parts) {
 			result.add(editPart);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gefTree/part/ObjectEditPart.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gefTree/part/ObjectEditPart.java
@@ -25,6 +25,7 @@ import org.eclipse.wb.internal.gef.tree.policies.SelectionEditPolicy;
 
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Event;
@@ -114,7 +115,7 @@ public class ObjectEditPart extends TreeEditPart {
 					if (editParts == null) {
 						return false;
 					}
-					viewer.setSelection(editParts);
+					viewer.setSelection(new StructuredSelection(editParts));
 					return true;
 				}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/DesignToolbarHelper.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/DesignToolbarHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,12 +12,12 @@ package org.eclipse.wb.internal.core.editor;
 
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.broadcast.ObjectEventListener;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.jface.action.ActionContributionItem;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.IContributionItem;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/actions/DeleteAction.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/actions/DeleteAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,9 +13,9 @@ package org.eclipse.wb.internal.core.editor.actions;
 import org.eclipse.wb.core.gef.command.CompoundEditCommand;
 import org.eclipse.wb.core.gef.command.EditCommand;
 import org.eclipse.wb.core.model.ObjectInfo;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
@@ -78,7 +78,7 @@ public class DeleteAction extends Action {
 	/**
 	 * @return the {@link Command} for deleting given {@link EditPart}'s.
 	 */
-	public static Command getCommand(List<EditPart> editParts) {
+	public static Command getCommand(List<? extends EditPart> editParts) {
 		if (editParts.isEmpty()) {
 			return null;
 		}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/actions/SelectSupport.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/actions/SelectSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,6 @@ package org.eclipse.wb.internal.core.editor.actions;
 import org.eclipse.wb.core.editor.IContextMenuConstants;
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.broadcast.ObjectEventListener;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.EnvironmentUtils;
@@ -23,8 +22,10 @@ import org.eclipse.wb.internal.core.model.util.ObjectInfoAction;
 import org.eclipse.wb.internal.core.utils.state.GlobalState;
 import org.eclipse.wb.internal.core.utils.state.IDescriptionHelper;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
+import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Event;
@@ -188,7 +189,7 @@ public final class SelectSupport {
 	private void doBeforeSelect() {
 		m_selectingSet.clear();
 		m_selectedObjects.clear();
-		List<EditPart> selectedEditParts = m_graphicalViewer.getSelectedEditParts();
+		List<? extends EditPart> selectedEditParts = m_graphicalViewer.getSelectedEditParts();
 		for (EditPart editPart : selectedEditParts) {
 			Object model = editPart.getModel();
 			if (model instanceof ObjectInfo) {
@@ -208,7 +209,7 @@ public final class SelectSupport {
 				editParts.add(editPart);
 			}
 		}
-		m_graphicalViewer.setSelection(editParts);
+		m_graphicalViewer.setSelection(new StructuredSelection(editParts));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/actions/assistant/LayoutAssistantAction.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/actions/assistant/LayoutAssistantAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,11 +12,11 @@ package org.eclipse.wb.internal.core.editor.actions.assistant;
 
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.broadcast.ObjectEventListener;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.editor.Messages;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.viewers.ISelectionChangedListener;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/structure/components/ComponentsTreePage.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/structure/components/ComponentsTreePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,6 @@ package org.eclipse.wb.internal.core.editor.structure.components;
 import org.eclipse.wb.core.editor.IDesignPageSite;
 import org.eclipse.wb.core.model.HasSourcePosition;
 import org.eclipse.wb.core.model.ObjectInfo;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.editor.DesignPageSite;
@@ -28,6 +27,7 @@ import org.eclipse.wb.internal.core.utils.gef.EditPartsSelectionProvider;
 import org.eclipse.wb.internal.core.utils.ui.UiUtils;
 import org.eclipse.wb.internal.gef.tree.TreeViewer;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.IToolBarManager;
@@ -35,6 +35,7 @@ import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
+import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
@@ -140,7 +141,7 @@ public final class ComponentsTreePage implements IPage {
 	 * .
 	 */
 	private void selectTreeViewer() {
-		List<EditPart> selectedEditParts = m_graphicalViewer.getSelectedEditParts();
+		List<? extends EditPart> selectedEditParts = m_graphicalViewer.getSelectedEditParts();
 		setSelection(m_viewer, m_selectionListener_Tree, selectedEditParts);
 		showComponentDefinition(selectedEditParts);
 	}
@@ -149,7 +150,7 @@ public final class ComponentsTreePage implements IPage {
 	 * Selects {@link EditPart}'s in {@link #m_graphicalViewer} using selection in {@link #m_viewer}.
 	 */
 	private void selectGraphicalViewer() {
-		final List<EditPart> selectedEditParts = m_viewer.getSelectedEditParts();
+		final List<? extends EditPart> selectedEditParts = m_viewer.getSelectedEditParts();
 		// refresh if necessary
 		ExecutionUtils.runLog(new RunnableEx() {
 			@Override
@@ -196,7 +197,7 @@ public final class ComponentsTreePage implements IPage {
 	 */
 	private static void setSelection(IEditPartViewer targetViewer,
 			ISelectionChangedListener selectionListener,
-			List<EditPart> sourceEditParts) {
+			List<? extends EditPart> sourceEditParts) {
 		// prepare EditPart's in target viewer
 		List<EditPart> targetEditParts = new ArrayList<>();
 		for (EditPart sourceEditPart : sourceEditParts) {
@@ -212,7 +213,7 @@ public final class ComponentsTreePage implements IPage {
 		// set selection
 		targetViewer.removeSelectionChangedListener(selectionListener);
 		try {
-			targetViewer.setSelection(targetEditParts);
+			targetViewer.setSelection(new StructuredSelection(targetEditParts));
 		} finally {
 			targetViewer.addSelectionChangedListener(selectionListener);
 		}
@@ -221,7 +222,7 @@ public final class ComponentsTreePage implements IPage {
 	/**
 	 * Shows definition in source for primary selected {@link EditPart} with {@link ObjectInfo} model.
 	 */
-	private static void showComponentDefinition(List<EditPart> sourceEditParts) {
+	private static void showComponentDefinition(List<? extends EditPart> sourceEditParts) {
 		IPreferenceStore preferences = DesignerPlugin.getPreferences();
 		if (preferences.getBoolean(IPreferenceConstants.P_EDITOR_GOTO_DEFINITION_ON_SELECTION)
 				&& !sourceEditParts.isEmpty()) {

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/header/HeadersContainerEditPart.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/header/HeadersContainerEditPart.java
@@ -174,9 +174,9 @@ IHeaderMenuProvider {
 	 */
 	private IHeadersProvider getHeadersProvider() {
 		// prepare selected EditPart
-		org.eclipse.wb.gef.core.EditPart selectedEditPart;
+		EditPart selectedEditPart;
 		{
-			List<org.eclipse.wb.gef.core.EditPart> selectedEditParts = m_viewer.getSelectedEditParts();
+			List<? extends EditPart> selectedEditParts = m_viewer.getSelectedEditParts();
 			if (selectedEditParts.size() != 1) {
 				return null;
 			}
@@ -187,7 +187,7 @@ IHeaderMenuProvider {
 		}
 		// get provider from container of selected EditPart
 		{
-			org.eclipse.wb.gef.core.EditPart containerEditPart = selectedEditPart.getParent();
+			EditPart containerEditPart = selectedEditPart.getParent();
 			if (containerEditPart != null) {
 				IHeadersProvider headersProvider = getHeadersProvider(containerEditPart);
 				if (headersProvider != null) {
@@ -210,9 +210,9 @@ IHeaderMenuProvider {
 	 * @return the {@link IHeadersProvider} implemented by one of the {@link EditPolicy} of given
 	 *         {@link EditPart}.
 	 */
-	private static IHeadersProvider getHeadersProvider(org.eclipse.wb.gef.core.EditPart editPart) {
+	private static IHeadersProvider getHeadersProvider(EditPart editPart) {
 		// find policy that implements IHeadersProvider
-		for (EditPolicy editPolicy : editPart.getEditPolicies()) {
+		for (EditPolicy editPolicy : ((org.eclipse.wb.gef.core.EditPart) editPart).getEditPolicies()) {
 			if (editPolicy instanceof IHeadersProvider headersProvider && headersProvider.isActive()) {
 				return headersProvider;
 			}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/header/HeadersContextMenuProvider.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/header/HeadersContextMenuProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,11 +11,11 @@
 package org.eclipse.wb.internal.core.gef.header;
 
 import org.eclipse.wb.core.gef.header.IHeaderMenuProvider;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.internal.gef.core.ContextMenuProvider;
 import org.eclipse.wb.internal.gef.core.MultiSelectionContextMenuProvider;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.jface.action.IMenuManager;
 
 /**

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/SubmenuAwareEditPart.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/SubmenuAwareEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,6 @@
 package org.eclipse.wb.internal.core.gef.part.menu;
 
 import org.eclipse.wb.draw2d.Figure;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.core.gef.policy.menu.MenuSelectionEditPolicy;
@@ -20,6 +19,7 @@ import org.eclipse.wb.internal.core.model.menu.IMenuInfo;
 import org.eclipse.wb.internal.core.model.menu.IMenuObjectInfo;
 import org.eclipse.wb.internal.core.model.menu.MenuObjectInfoUtils;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.EditPolicy;
 
@@ -91,7 +91,7 @@ public abstract class SubmenuAwareEditPart extends MenuObjectEditPart {
 		// prepare selected object
 		IMenuObjectInfo selectedObject = null;
 		{
-			List<EditPart> selectedEditParts = getViewer().getSelectedEditParts();
+			List<? extends EditPart> selectedEditParts = getViewer().getSelectedEditParts();
 			if (!selectedEditParts.isEmpty()) {
 				EditPart selectedEditPart = selectedEditParts.get(selectedEditParts.size() - 1);
 				MenuObjectEditPart menuObjectEditPart = getMenuObjectEditPart(selectedEditPart);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/gef/EditPartsSelectionProvider.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/gef/EditPartsSelectionProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,10 +10,10 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.utils.gef;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 
 import org.eclipse.draw2d.EventListenerList;
+import org.eclipse.gef.EditPart;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.ISelectionProvider;
@@ -76,7 +76,7 @@ public final class EditPartsSelectionProvider implements ISelectionProvider {
 			}
 		}
 		// set selection in viewer
-		m_viewer.setSelection(editParts);
+		m_viewer.setSelection(new StructuredSelection(editParts));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/header/actions/DimensionHeaderAction.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/header/actions/DimensionHeaderAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,13 +10,13 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.gef.policy.forms.layout.grid.header.actions;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.internal.core.model.util.ObjectInfoAction;
 import org.eclipse.wb.internal.rcp.gef.policy.forms.layout.grid.header.edit.DimensionHeaderEditPart;
 import org.eclipse.wb.internal.rcp.model.forms.layout.table.TableWrapDimensionInfo;
 import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.util.ArrayList;

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/actions/DimensionHeaderAction.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/actions/DimensionHeaderAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,13 +10,13 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.FormLayout.gef.header.actions;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.internal.core.model.util.ObjectInfoAction;
 import org.eclipse.wb.internal.swing.FormLayout.gef.header.edit.DimensionHeaderEditPart;
 import org.eclipse.wb.internal.swing.FormLayout.model.FormDimensionInfo;
 import org.eclipse.wb.internal.swing.FormLayout.model.FormLayoutInfo;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.util.ArrayList;
@@ -82,7 +82,7 @@ public abstract class DimensionHeaderAction<T extends FormDimensionInfo> extends
 		// prepare selection
 		List<T> dimensions = new ArrayList<>();
 		{
-			List<EditPart> editParts = m_viewer.getSelectedEditParts();
+			List<? extends EditPart> editParts = m_viewer.getSelectedEditParts();
 			for (EditPart editPart : editParts) {
 				if (editPart instanceof DimensionHeaderEditPart) {
 					@SuppressWarnings("unchecked")

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/edit/ColumnHeaderEditPart.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/edit/ColumnHeaderEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,6 @@
 package org.eclipse.wb.internal.swing.FormLayout.gef.header.edit;
 
 import org.eclipse.wb.draw2d.Figure;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.model.util.ObjectInfoAction;
@@ -30,6 +29,7 @@ import org.eclipse.draw2d.TextUtilities;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Interval;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.EditPart;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.action.Separator;

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/edit/RowHeaderEditPart.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/edit/RowHeaderEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,6 @@
 package org.eclipse.wb.internal.swing.FormLayout.gef.header.edit;
 
 import org.eclipse.wb.draw2d.Figure;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.model.util.ObjectInfoAction;
@@ -30,6 +29,7 @@ import org.eclipse.draw2d.TextUtilities;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Interval;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.EditPart;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.action.Separator;

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/actions/DimensionHeaderAction.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/actions/DimensionHeaderAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.MigLayout.gef.header.actions;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.internal.core.model.util.ObjectInfoAction;
 import org.eclipse.wb.internal.swing.MigLayout.gef.header.edit.ColumnHeaderEditPart;
@@ -18,6 +17,7 @@ import org.eclipse.wb.internal.swing.MigLayout.gef.header.edit.DimensionHeaderEd
 import org.eclipse.wb.internal.swing.MigLayout.model.MigDimensionInfo;
 import org.eclipse.wb.internal.swing.MigLayout.model.MigLayoutInfo;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.util.ArrayList;
@@ -85,7 +85,7 @@ public abstract class DimensionHeaderAction<T extends MigDimensionInfo> extends 
 		// prepare selection
 		List<T> dimensions = new ArrayList<>();
 		{
-			List<EditPart> editParts = m_viewer.getSelectedEditParts();
+			List<? extends EditPart> editParts = m_viewer.getSelectedEditParts();
 			for (EditPart editPart : editParts) {
 				if (editPart instanceof DimensionHeaderEditPart) {
 					@SuppressWarnings("unchecked")

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/header/actions/DimensionHeaderAction.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/header/actions/DimensionHeaderAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,12 +10,12 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.gef.policy.layout.gbl.header.actions;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.internal.core.model.util.ObjectInfoAction;
 import org.eclipse.wb.internal.swing.gef.policy.layout.gbl.header.edit.DimensionHeaderEditPart;
 import org.eclipse.wb.internal.swing.model.layout.gbl.DimensionInfo;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.util.ArrayList;
@@ -79,7 +79,7 @@ public abstract class DimensionHeaderAction<T extends DimensionInfo> extends Obj
 		// prepare selection
 		List<T> dimensions = new ArrayList<>();
 		{
-			List<EditPart> editParts = m_viewer.getSelectedEditParts();
+			List<? extends EditPart> editParts = m_viewer.getSelectedEditParts();
 			for (EditPart editPart : editParts) {
 				if (editPart instanceof DimensionHeaderEditPart) {
 					@SuppressWarnings("unchecked")

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/header/actions/DimensionHeaderAction.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/header/actions/DimensionHeaderAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,13 +10,13 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swt.gef.policy.layout.grid.header.actions;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.internal.core.model.util.ObjectInfoAction;
 import org.eclipse.wb.internal.swt.gef.policy.layout.grid.header.edit.DimensionHeaderEditPart;
 import org.eclipse.wb.internal.swt.model.layout.grid.GridDimensionInfo;
 import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.jface.resource.ImageDescriptor;
 
 import java.util.ArrayList;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/palette/TabOrderToolEntryInfoTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/palette/TabOrderToolEntryInfoTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,11 +13,13 @@ package org.eclipse.wb.tests.designer.core.palette;
 import org.eclipse.wb.core.editor.palette.model.entry.TabOrderToolEntryInfo;
 import org.eclipse.wb.core.gef.policy.TabOrderContainerEditPolicy;
 import org.eclipse.wb.core.model.JavaInfo;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.internal.core.gef.tools.TabOrderTool;
 
+import org.eclipse.gef.EditPart;
+
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -89,7 +91,7 @@ public class TabOrderToolEntryInfoTest extends AbstractPaletteTest {
 			//
 			when(selectedEditPart.getViewer()).thenReturn(viewer);
 			when(selectedEditPart.getEditPolicy(TabOrderContainerEditPolicy.TAB_CONTAINER_ROLE)).thenReturn(tabContainerRole);
-			when(viewer.getSelectedEditParts()).thenReturn(List.of(selectedEditPart));
+			doReturn(List.of(selectedEditPart)).when(viewer).getSelectedEditParts();
 		}
 		// check tool
 		assertTrue(entry.initialize(viewer, panel));

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/DesignerEditorTestCase.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/DesignerEditorTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -288,11 +288,11 @@ public abstract class DesignerEditorTestCase extends AbstractJavaInfoRelatedTest
 	 * Asserts that {@link EditPart}'s selected in GEF viewer has given models.
 	 */
 	protected final void assertSelectionModels(Object... models) {
-		List<org.eclipse.wb.gef.core.EditPart> editParts = m_viewerCanvas.getSelectedEditParts();
+		List<? extends EditPart> editParts = m_viewerCanvas.getSelectedEditParts();
 		assertEquals(models.length, editParts.size());
 		for (int i = 0; i < models.length; i++) {
 			Object model = models[i];
-			org.eclipse.wb.gef.core.EditPart editPart = editParts.get(i);
+			EditPart editPart = editParts.get(i);
 			assertSame(model, editPart.getModel());
 		}
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/UndoManagerTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/UndoManagerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,6 @@ package org.eclipse.wb.tests.designer.editor;
 import org.eclipse.wb.core.editor.IDesignPageSite;
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.editor.DesignPageSite;
@@ -32,6 +31,7 @@ import org.eclipse.wb.tests.gef.UiContext;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.ResourceAttributes;
+import org.eclipse.gef.EditPart;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.ui.JavaUI;
@@ -194,7 +194,7 @@ public class UndoManagerTest extends SwingGefTest {
 			openDesignPage();
 			// "contentPane" should be selected, despite reparsing
 			{
-				List<EditPart> selectedEditParts = m_viewerCanvas.getSelectedEditParts();
+				List<? extends EditPart> selectedEditParts = m_viewerCanvas.getSelectedEditParts();
 				assertEquals(1, selectedEditParts.size());
 				EditPart selectedEditPart = selectedEditParts.get(0);
 				assertEquals(contentPane.toString(), selectedEditPart.getModel().toString());

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/EmptyEditPartViewer.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/EmptyEditPartViewer.java
@@ -11,7 +11,6 @@
 package org.eclipse.wb.tests.gef;
 
 import org.eclipse.wb.draw2d.Layer;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartFactory;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.graphical.handles.Handle;
@@ -20,6 +19,7 @@ import org.eclipse.wb.internal.gef.core.AbstractEditPartViewer;
 import org.eclipse.wb.internal.gef.core.EditDomain;
 
 import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.RootEditPart;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.viewers.ISelection;
@@ -46,7 +46,7 @@ public class EmptyEditPartViewer extends AbstractEditPartViewer implements IEdit
 	}
 
 	@Override
-	public void deselect(List<EditPart> editParts) {
+	public void deselect(List<? extends EditPart> editParts) {
 	}
 
 	@Override
@@ -54,17 +54,17 @@ public class EmptyEditPartViewer extends AbstractEditPartViewer implements IEdit
 	}
 
 	@Override
-	public EditPart findTargetEditPart(int x,
+	public org.eclipse.wb.gef.core.EditPart findTargetEditPart(int x,
 			int y,
-			Collection<? extends org.eclipse.gef.EditPart> exclude,
+			Collection<? extends EditPart> exclude,
 			Conditional conditional) {
 		return null;
 	}
 
 	@Override
-	public EditPart findTargetEditPart(int x,
+	public org.eclipse.wb.gef.core.EditPart findTargetEditPart(int x,
 			int y,
-			Collection<? extends org.eclipse.gef.EditPart> exclude,
+			Collection<? extends EditPart> exclude,
 			Conditional conditional,
 			String layer) {
 		return null;
@@ -106,12 +106,7 @@ public class EmptyEditPartViewer extends AbstractEditPartViewer implements IEdit
 	}
 
 	@Override
-	public List<EditPart> getSelectedEditParts() {
-		return null;
-	}
-
-	@Override
-	public EditPart getSelectingEditPart() {
+	public List<org.eclipse.wb.gef.core.EditPart> getSelectedEditParts() {
 		return null;
 	}
 
@@ -130,10 +125,6 @@ public class EmptyEditPartViewer extends AbstractEditPartViewer implements IEdit
 
 	@Override
 	public void setContextMenu(MenuManager manager) {
-	}
-
-	@Override
-	public void setSelection(List<EditPart> editParts) {
 	}
 
 	@Override

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/GraphicalRobot.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/GraphicalRobot.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,6 @@ import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.draw2d.Layer;
 import org.eclipse.wb.draw2d.Polyline;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.core.tools.Tool;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
@@ -31,7 +30,9 @@ import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.PointList;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.commands.Command;
+import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Text;
 
@@ -132,7 +133,7 @@ public final class GraphicalRobot {
 	 */
 	public void select(Object... models) {
 		EditPart[] editParts = getEditParts(models);
-		m_viewer.setSelection(List.of(editParts));
+		m_viewer.setSelection(new StructuredSelection(editParts));
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -904,7 +905,7 @@ public final class GraphicalRobot {
 	 * Asserts that selection is empty, i.e. no {@link EditPart} selected.
 	 */
 	public GraphicalRobot assertSelectedEmpty() {
-		List<EditPart> selectedEditParts = m_viewer.getSelectedEditParts();
+		List<? extends EditPart> selectedEditParts = m_viewer.getSelectedEditParts();
 		Assertions.assertThat(selectedEditParts).isEmpty();
 		return this;
 	}
@@ -918,7 +919,8 @@ public final class GraphicalRobot {
 	 * Assert that selection contains exactly given {@link EditPart}s.
 	 */
 	public void assertSelection(Object... objects) {
-		List<EditPart> selectedEditParts = m_viewer.getSelectedEditParts();
+		@SuppressWarnings("unchecked")
+		List<EditPart> selectedEditParts = (List<EditPart>) m_viewer.getSelectedEditParts();
 		GraphicalEditPart[] editParts = getEditParts(objects);
 		Assertions.assertThat(selectedEditParts).containsExactly(editParts);
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/GraphicalViewerTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/GraphicalViewerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -157,7 +157,7 @@ public class GraphicalViewerTest extends GefTestCase {
 		List<EditPart> selection = new ArrayList<>();
 		selection.add(part2);
 		selection.add(part1);
-		m_viewer.setSelection(selection);
+		m_viewer.setSelection(new StructuredSelection(selection));
 		//
 		assertEquals(EditPart.SELECTED_PRIMARY, part1.getSelected());
 		assertEquals(EditPart.SELECTED, part2.getSelected());
@@ -223,7 +223,7 @@ public class GraphicalViewerTest extends GefTestCase {
 		List<EditPart> selection = new ArrayList<>();
 		selection.add(part2);
 		selection.add(part1);
-		m_viewer.setSelection(selection);
+		m_viewer.setSelection(new StructuredSelection(selection));
 		expectedLogger.log("selectionChanged("
 				+ new SelectionChangedEvent(m_viewer, new StructuredSelection(selection))
 				+ ")");

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/TreeRobot.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/TreeRobot.java
@@ -11,7 +11,6 @@
 package org.eclipse.wb.tests.gef;
 
 import org.eclipse.wb.core.model.ObjectInfo;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.tools.Tool;
 import org.eclipse.wb.gef.graphical.tools.SelectionTool;
 import org.eclipse.wb.gef.tree.TreeEditPart;
@@ -24,7 +23,9 @@ import org.eclipse.wb.tests.designer.tests.DesignerTestCase;
 
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.commands.Command;
+import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.dnd.DND;
 import org.eclipse.swt.dnd.DropTarget;
 import org.eclipse.swt.widgets.Display;
@@ -219,7 +220,7 @@ public final class TreeRobot {
 	public TreeRobot select(Object... models) {
 		TreeEditPart[] editParts = getEditParts(models);
 		m_justSelectedEditParts = editParts;
-		m_viewer.setSelection(List.of(editParts));
+		m_viewer.setSelection(new StructuredSelection(editParts));
 		DesignerTestCase.waitEventLoop(100, 0);
 		return this;
 	}
@@ -416,7 +417,7 @@ public final class TreeRobot {
 	 * Asserts that selection is empty, i.e. no {@link EditPart} selected.
 	 */
 	public TreeRobot assertSelectedEmpty() {
-		List<EditPart> selectedEditParts = m_viewer.getSelectedEditParts();
+		List<? extends EditPart> selectedEditParts = m_viewer.getSelectedEditParts();
 		Assertions.assertThat(selectedEditParts).isEmpty();
 		return this;
 	}


### PR DESCRIPTION
Both the IEditPartViewer and the EditPartViewer interfaces specify a selection API. One is using the GEF edit parts, the other the WindowBuilder edit parts. Because those methods have the same name but not the same signature, one doesn't overwrite the other and it is therefore ambiguous which one is actually called at which point.

To solve this, the API has been removed from IEditPartViewer and all invocations have been adapted to support the GEF edit parts.

See https://github.com/eclipse-windowbuilder/windowbuilder/pull/829