### PR TITLE
Change signature of runObjectIgnore to expect a Callable object

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/core/editor/palette/model/entry/ComponentEntryInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/core/editor/palette/model/entry/ComponentEntryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -38,7 +38,6 @@ import org.eclipse.wb.internal.core.model.description.helpers.ComponentPresentat
 import org.eclipse.wb.internal.core.model.util.ScriptUtils;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.external.ExternalFactoriesHelper;
 import org.eclipse.wb.internal.core.utils.jdt.core.ProjectUtils;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
@@ -296,12 +295,9 @@ public final class ComponentEntryInfo extends ToolEntryInfo {
 	public boolean isEnabled() {
 		// try "enabled"
 		if (m_enabledScript != null) {
-			boolean enabled = ExecutionUtils.runObjectIgnore(new RunnableObjectEx<Boolean>() {
-				@Override
-				public Boolean runObject() throws Exception {
-					ClassLoader classLoader = JavaInfoUtils.getClassLoader(m_rootJavaInfo);
-					return (Boolean) ScriptUtils.evaluate(classLoader, m_enabledScript);
-				}
+			boolean enabled = ExecutionUtils.runObjectIgnore(() -> {
+				ClassLoader classLoader = JavaInfoUtils.getClassLoader(m_rootJavaInfo);
+				return (Boolean) ScriptUtils.evaluate(classLoader, m_enabledScript);
 			}, false);
 			if (!enabled) {
 				return false;

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/core/model/JavaInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/core/model/JavaInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -758,18 +758,15 @@ public class JavaInfo extends ObjectInfo implements HasSourcePosition {
 	public final boolean canDelete() {
 		// try "canDelete" script
 		{
-			boolean canDeleteBoolean = ExecutionUtils.runObjectIgnore(new RunnableObjectEx<Boolean>() {
-				@Override
-				public Boolean runObject() throws Exception {
-					Object canDeleteObject = JavaInfoUtils.executeScriptParameter(m_this, "canDelete");
-					if (canDeleteObject == null) {
-						return true;
-					}
-					if (canDeleteObject instanceof Boolean) {
-						return ((Boolean) canDeleteObject).booleanValue();
-					}
-					return false;
+			boolean canDeleteBoolean = ExecutionUtils.runObjectIgnore(() -> {
+				Object canDeleteObject = JavaInfoUtils.executeScriptParameter(m_this, "canDelete");
+				if (canDeleteObject == null) {
+					return true;
 				}
+				if (canDeleteObject instanceof Boolean) {
+					return ((Boolean) canDeleteObject).booleanValue();
+				}
+				return false;
 			}, false);
 			if (!canDeleteBoolean) {
 				return false;

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/eval/evaluators/InvocationEvaluator.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/eval/evaluators/InvocationEvaluator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,7 +22,6 @@ import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.exception.DesignerException;
 import org.eclipse.wb.internal.core.utils.exception.ICoreExceptionConstants;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.external.ExternalFactoriesHelper;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
@@ -622,12 +621,7 @@ public final class InvocationEvaluator implements IExpressionEvaluator {
 	 * @return {@link String} presentation of given argument values, safely.
 	 */
 	public static String getArguments_toString(final Object[] arguments) {
-		return ExecutionUtils.runObjectIgnore(new RunnableObjectEx<String>() {
-			@Override
-			public String runObject() throws Exception {
-				return ArrayUtils.toString(arguments);
-			}
-		}, "<Exception during arguments.toString()>");
+		return ExecutionUtils.runObjectIgnore(() -> ArrayUtils.toString(arguments), "<Exception during arguments.toString()>");
 	}
 
 	/**

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/FieldAccessor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/FieldAccessor.java
@@ -20,7 +20,6 @@ import org.eclipse.wb.internal.core.utils.ast.StatementTarget;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
 import org.eclipse.jdt.core.dom.Assignment;
@@ -84,12 +83,9 @@ public final class FieldAccessor extends ExpressionAccessor {
 	 * <code>GridLayout</code> and its <code>GridLayout2</code>.
 	 */
 	private Object getFieldValue(final JavaInfo javaInfo) {
-		return ExecutionUtils.runObjectIgnore(new RunnableObjectEx<Object>() {
-			@Override
-			public Object runObject() throws Exception {
-				Object object = javaInfo.getObject();
-				return ReflectionUtils.getFieldObject(object, m_fieldName);
-			}
+		return ExecutionUtils.runObjectIgnore(() -> {
+			Object object = javaInfo.getObject();
+			return ReflectionUtils.getFieldObject(object, m_fieldName);
 		}, Property.UNKNOWN_VALUE);
 	}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/SetterAccessor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/SetterAccessor.java
@@ -18,7 +18,6 @@ import org.eclipse.wb.internal.core.model.property.table.PropertyTooltipProvider
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
 import org.eclipse.jdt.core.dom.Expression;
@@ -89,12 +88,7 @@ public final class SetterAccessor extends ExpressionAccessor {
 
 	private Object askDefaultValue(final JavaInfo javaInfo) throws Exception {
 		if (m_getter != null && isDefaultEnabled(javaInfo)) {
-			return ExecutionUtils.runObjectIgnore(new RunnableObjectEx<Object>() {
-				@Override
-				public Object runObject() throws Exception {
-					return m_getter.invoke(javaInfo.getObject());
-				}
-			}, Property.UNKNOWN_VALUE);
+			return ExecutionUtils.runObjectIgnore(() -> m_getter.invoke(javaInfo.getObject()), Property.UNKNOWN_VALUE);
 		} else {
 			return Property.UNKNOWN_VALUE;
 		}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/StringConverter.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/converter/StringConverter.java
@@ -13,7 +13,6 @@ package org.eclipse.wb.internal.core.model.property.converter;
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 
 import org.eclipse.core.resources.IFile;
 
@@ -61,19 +60,16 @@ public final class StringConverter extends ExpressionConverter {
 	}
 
 	private static String toJavaSource_UTF(final JavaInfo javaInfo, final String valueString) {
-		return ExecutionUtils.runObjectIgnore(new RunnableObjectEx<String>() {
-			@Override
-			public String runObject() throws Exception {
-				if (javaInfo != null) {
-					IFile file = (IFile) javaInfo.getEditor().getModelUnit().getUnderlyingResource();
-					String charset = file.getCharset();
-					if (charset.equals("UTF-8") || charset.equals("UTF-16")) {
-						String escaped = StringUtilities.escapeForJavaSource(valueString);
-						return '"' + escaped + '"';
-					}
+		return ExecutionUtils.runObjectIgnore(() -> {
+			if (javaInfo != null) {
+				IFile file = (IFile) javaInfo.getEditor().getModelUnit().getUnderlyingResource();
+				String charset = file.getCharset();
+				if (charset.equals("UTF-8") || charset.equals("UTF-16")) {
+					String escaped = StringUtilities.escapeForJavaSource(valueString);
+					return '"' + escaped + '"';
 				}
-				return null;
 			}
+			return null;
 		}, null);
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/AbstractListPropertyEditor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/AbstractListPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,7 +20,6 @@ import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.model.util.ScriptUtils;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 
 import java.util.List;
 import java.util.Map;
@@ -119,13 +118,10 @@ IClipboardSourceProvider {
 
 	private static Object evaluateExpression(final GenericProperty genericProperty,
 			final String expression) {
-		return ExecutionUtils.runObjectIgnore(new RunnableObjectEx<Object>() {
-			@Override
-			public Object runObject() throws Exception {
-				JavaInfo javaInfo = genericProperty.getJavaInfo();
-				ClassLoader classLoader = JavaInfoUtils.getClassLoader(javaInfo);
-				return ScriptUtils.evaluate(classLoader, expression);
-			}
+		return ExecutionUtils.runObjectIgnore(() -> {
+			JavaInfo javaInfo = genericProperty.getJavaInfo();
+			ClassLoader classLoader = JavaInfoUtils.getClassLoader(javaInfo);
+			return ScriptUtils.evaluate(classLoader, expression);
 		}, Property.UNKNOWN_VALUE);
 	}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/core/ProjectUtils.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/core/ProjectUtils.java
@@ -16,7 +16,6 @@ import org.eclipse.wb.internal.core.utils.IOUtils2;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.NoOpProgressMonitor;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.external.ExternalFactoriesHelper;
 import org.eclipse.wb.internal.core.utils.pde.ReflectivePDE;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
@@ -247,12 +246,7 @@ public final class ProjectUtils {
 	 * @return <code>true</code> if {@link IJavaProject} has type with given name.
 	 */
 	public static boolean hasType(final IJavaProject project, final String className) {
-		return ExecutionUtils.runObjectIgnore(new RunnableObjectEx<Boolean>() {
-			@Override
-			public Boolean runObject() throws Exception {
-				return project.findType(className) != null;
-			}
-		}, false);
+		return ExecutionUtils.runObjectIgnore(() -> project.findType(className) != null, false);
 	}
 
 	/**
@@ -515,12 +509,7 @@ public final class ProjectUtils {
 	 * @return <code>true</code> if {@link IProject} has nature.
 	 */
 	public static boolean hasNature(final IProject project, final String natureId) {
-		return ExecutionUtils.runObjectIgnore(new RunnableObjectEx<Boolean>() {
-			@Override
-			public Boolean runObject() throws Exception {
-				return project.hasNature(natureId);
-			}
-		}, false);
+		return ExecutionUtils.runObjectIgnore(() -> project.hasNature(natureId), false);
 	}
 
 	/**

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/PropertyUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/PropertyUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,6 @@ import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.model.property.editor.complex.IComplexPropertyEditor;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.core.utils.state.GlobalState;
 
@@ -70,16 +69,11 @@ public final class PropertyUtils {
 	 * @return the text presentation of {@link Property} value, may be <code>null</code>.
 	 */
 	public static String getText(final Property property) {
-		return ExecutionUtils.runObjectIgnore(new RunnableObjectEx<String>() {
-			@Override
-			public String runObject() throws Exception {
-				return (String) ReflectionUtils.invokeMethod2(
-						property.getEditor(),
-						"getText",
-						Property.class,
-						property);
-			}
-		}, null);
+		return ExecutionUtils.runObjectIgnore(() -> (String) ReflectionUtils.invokeMethod2(
+				property.getEditor(),
+				"getText",
+				Property.class,
+				property), null);
 	}
 	////////////////////////////////////////////////////////////////////////////
 	//

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/execution/ExecutionUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/execution/ExecutionUtils.java
@@ -288,14 +288,14 @@ public class ExecutionUtils {
 	}
 
 	/**
-	 * Runs given {@link RunnableEx} and ignores exceptions.
+	 * Runs given {@link Callable} and ignores exceptions.
 	 *
-	 * @return the {@link Object} returned by {@link RunnableEx#run()} or <code>defaultValue</code> if
+	 * @return the {@link Object} returned by {@link Callable#call()} or <code>defaultValue</code> if
 	 *         exception happened.
 	 */
-	public static <T> T runObjectIgnore(RunnableObjectEx<T> runnable, T defaultValue) {
+	public static <T> T runObjectIgnore(Callable<T> runnable, T defaultValue) {
 		try {
-			return runnable.runObject();
+			return runnable.call();
 		} catch (Throwable e) {
 			return defaultValue;
 		}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/LayoutJavaInfoParticipator.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/LayoutJavaInfoParticipator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,6 @@ import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.broadcast.ObjectInfoChildAddAfter;
 import org.eclipse.wb.internal.core.model.util.surround.SurroundSupport;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
 import org.apache.commons.lang3.StringUtils;
@@ -124,12 +123,7 @@ public final class LayoutJavaInfoParticipator implements IJavaInfoInitialization
 			}
 			// bind safely
 			final Class<?> finalLayoutClass = layoutClass;
-			boolean success = ExecutionUtils.runObjectIgnore(new RunnableObjectEx<Boolean>() {
-				@Override
-				public Boolean runObject() throws Exception {
-					return processor.run(layout, classLoader, finalLayoutClass, layoutName);
-				}
-			}, false);
+			boolean success = ExecutionUtils.runObjectIgnore(() -> processor.run(layout, classLoader, finalLayoutClass, layoutName), false);
 			if (success) {
 				return;
 			}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/gbl/GridBagConstraintsInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/gbl/GridBagConstraintsInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,6 @@ import org.eclipse.wb.internal.core.model.creation.CreationSupport;
 import org.eclipse.wb.internal.core.model.description.ComponentDescription;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.swing.model.CoordinateUtils;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
@@ -167,12 +166,7 @@ public final class GridBagConstraintsInfo extends AbstractGridBagConstraintsInfo
 		public AlignmentInfoEx(String alignmentString, final String fill, final String anchor) {
 			// some fields not exists in Java6, so return Integer.MIN_VALUE as anchor.
 			super(alignmentString, fill, anchor);
-			anchorValue = ExecutionUtils.runObjectIgnore(new RunnableObjectEx<Integer>() {
-				@Override
-				public Integer runObject() throws Exception {
-					return ReflectionUtils.getFieldInt(GridBagConstraints.class, anchor);
-				}
-			}, Integer.MIN_VALUE);
+			anchorValue = ExecutionUtils.runObjectIgnore(() -> ReflectionUtils.getFieldInt(GridBagConstraints.class, anchor), Integer.MIN_VALUE);
 		}
 
 		////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/spring/SpringAttachmentInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/spring/SpringAttachmentInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,7 +25,6 @@ import org.eclipse.wb.internal.core.utils.ast.DomGenerics;
 import org.eclipse.wb.internal.core.utils.ast.NodeTarget;
 import org.eclipse.wb.internal.core.utils.ast.StatementTarget;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.jdt.core.CodeUtils;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
@@ -536,18 +535,13 @@ public final class SpringAttachmentInfo {
 		if (isVirtual()) {
 			return "<none>";
 		} else {
-			return ExecutionUtils.runObjectIgnore(new RunnableObjectEx<String>() {
-				@Override
-				public String runObject() throws Exception {
-					return "("
-							+ getOffset()
-							+ ", "
-							+ CodeUtils.getShortClass(getSpringSideSource(getAnchorSide()))
-							+ ", "
-							+ getAnchorComponent().getPresentation().getText()
-							+ ")";
-				}
-			},
+			return ExecutionUtils.runObjectIgnore(() -> "("
+					+ getOffset()
+					+ ", "
+					+ CodeUtils.getShortClass(getSpringSideSource(getAnchorSide()))
+					+ ", "
+					+ getAnchorComponent().getPresentation().getText()
+					+ ")",
 					"<exception>");
 		}
 	}

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormUtils.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,6 @@
 package org.eclipse.wb.internal.swt.gef.policy.layout.form;
 
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.swt.model.layout.form.FormLayoutInfoImplClassic;
 import org.eclipse.wb.internal.swt.model.layout.form.IFormLayoutInfo;
@@ -53,12 +52,7 @@ public final class FormUtils {
 	}
 
 	public static <C extends IControlInfo> String getVariableName(final C child) {
-		return ExecutionUtils.runObjectIgnore(new RunnableObjectEx<String>() {
-			@Override
-			public String runObject() throws Exception {
-				return child.getPresentation().getText();
-			}
-		}, "<unknown>");
+		return ExecutionUtils.runObjectIgnore(() -> child.getPresentation().getText(), "<unknown>");
 	}
 
 	/**

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/LayoutJavaInfoParticipator.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/LayoutJavaInfoParticipator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,6 @@ import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.broadcast.ObjectInfoChildAddAfter;
 import org.eclipse.wb.internal.core.model.util.surround.SurroundSupport;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
 import org.apache.commons.lang3.StringUtils;
@@ -116,12 +115,9 @@ public class LayoutJavaInfoParticipator implements IJavaInfoInitializationPartic
 		Class<?> layoutClass = layout.getClass();
 		for (; layoutClass != null; layoutClass = layoutClass.getSuperclass()) {
 			final Class<?> finalLayoutClass = layoutClass;
-			boolean success = ExecutionUtils.runObjectIgnore(new RunnableObjectEx<Boolean>() {
-				@Override
-				public Boolean runObject() throws Exception {
-					run(layout, processor, finalLayoutClass);
-					return true;
-				}
+			boolean success = ExecutionUtils.runObjectIgnore(() -> {
+				run(layout, processor, finalLayoutClass);
+				return true;
 			}, false);
 			if (success) {
 				return;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/execution/ExecutionUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/execution/ExecutionUtilsTest.java
@@ -302,24 +302,14 @@ public class ExecutionUtilsTest extends SwingModelTest {
 	@Test
 	public void test_object_ignore_noException() throws Exception {
 		final Object myResult = new Object();
-		Object result = ExecutionUtils.runObjectIgnore(new RunnableObjectEx<Object>() {
-			@Override
-			public Object runObject() throws Exception {
-				return myResult;
-			}
-		}, null);
+		Object result = ExecutionUtils.runObjectIgnore(() -> myResult, null);
 		assertSame(myResult, result);
 	}
 
 	@Test
 	public void test_object_ignore_withException() throws Exception {
 		final Object myResult = new Object();
-		Object result = ExecutionUtils.runObjectIgnore(new RunnableObjectEx<Object>() {
-			@Override
-			public Object runObject() throws Exception {
-				throw new Exception();
-			}
-		}, myResult);
+		Object result = ExecutionUtils.runObjectIgnore(() -> { throw new Exception(); }, myResult);
 		assertSame(myResult, result);
 	}
 


### PR DESCRIPTION
Our RunnableObjectEx and the Java Callable are functionally identical: The interface defines a single method, which returns a generic object and may throw an exception. So there is no need to use our own interface.

Where applicable, anonymous instances of this interface have been replaced with lambda expressions.