### PR TITLE
Change signature of runObject/runObjectUI to expect a Callable object

### DIFF
--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/Activator.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/Activator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,6 @@
 package org.eclipse.wb.internal.core.databinding;
 
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.resource.ImageDescriptor;
@@ -74,12 +73,8 @@ public final class Activator extends AbstractUIPlugin {
 	 * @return the {@link InputStream} for file from plugin directory.
 	 */
 	public static InputStream getFile(final String path) {
-		return ExecutionUtils.runObject(new RunnableObjectEx<InputStream>() {
-			@Override
-			public InputStream runObject() throws Exception {
-				return m_plugin.getBundle().getEntry(path).openStream();
-			}
-		}, "Unable to open plugin file %s", path);
+		return ExecutionUtils.runObject(() -> m_plugin.getBundle().getEntry(path).openStream(),
+				"Unable to open plugin file %s", path);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/core/model/JavaInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/core/model/JavaInfo.java
@@ -62,7 +62,6 @@ import org.eclipse.wb.internal.core.utils.ast.StatementTarget;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.external.ExternalFactoriesHelper;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.core.utils.state.EditorState;
@@ -391,12 +390,7 @@ public class JavaInfo extends ObjectInfo implements HasSourcePosition {
 	 * @return the {@link JavaEventListener} for hierarchy.
 	 */
 	public final JavaEventListener getBroadcastJava() {
-		return ExecutionUtils.runObject(new RunnableObjectEx<JavaEventListener>() {
-			@Override
-			public JavaEventListener runObject() throws Exception {
-				return getBroadcast(JavaEventListener.class);
-			}
-		});
+		return ExecutionUtils.runObject(() -> getBroadcast(JavaEventListener.class));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/clipboard/JavaInfoMementoTransfer.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/clipboard/JavaInfoMementoTransfer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,6 @@ package org.eclipse.wb.internal.core.model.clipboard;
 
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.external.ExternalFactoriesHelper;
 
 import org.eclipse.swt.dnd.ByteArrayTransfer;
@@ -94,12 +93,9 @@ public class JavaInfoMementoTransfer extends ByteArrayTransfer {
 	@Override
 	public Object nativeToJava(final TransferData transferData) {
 		if (isSupportedType(transferData)) {
-			return ExecutionUtils.runObject(new RunnableObjectEx<Object>() {
-				@Override
-				public Object runObject() throws Exception {
-					byte[] bytes = (byte[]) JavaInfoMementoTransfer.super.nativeToJava(transferData);
-					return convertBytesToObject(bytes);
-				}
+			return ExecutionUtils.runObject(() -> {
+				byte[] bytes = (byte[]) JavaInfoMementoTransfer.super.nativeToJava(transferData);
+				return convertBytesToObject(bytes);
 			});
 		}
 		return null;

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/generic/FlowContainerFactory.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/generic/FlowContainerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,6 @@ import org.eclipse.wb.internal.core.model.util.predicate.AlwaysPredicate;
 import org.eclipse.wb.internal.core.model.util.predicate.ExpressionPredicate;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -66,12 +65,8 @@ public final class FlowContainerFactory {
 	}
 
 	public List<FlowContainerConfiguration> getConfigurations() {
-		return ExecutionUtils.runObject(new RunnableObjectEx<List<FlowContainerConfiguration>>() {
-			@Override
-			public List<FlowContainerConfiguration> runObject() throws Exception {
-				return getConfigurationsEx();
-			}
-		}, "Exception during reading flow container configurations for %s", m_javaInfo);
+		return ExecutionUtils.runObject(() -> getConfigurationsEx(),
+				"Exception during reading flow container configurations for %s", m_javaInfo);
 	}
 
 	private List<FlowContainerConfiguration> getConfigurationsEx() {

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/ConstantSelectionPropertyEditor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/ConstantSelectionPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,7 +27,6 @@ import org.eclipse.wb.internal.core.utils.ast.DomGenerics;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.jdt.core.CodeUtils;
 import org.eclipse.wb.internal.core.utils.jdt.ui.JdtUiUtils;
 import org.eclipse.wb.internal.core.utils.state.EditorState;
@@ -673,15 +672,12 @@ IConfigurablePropertyObject {
 		private class TypeContentProvider implements IStructuredContentProvider {
 			@Override
 			public Object[] getElements(Object inputElement) {
-				return ExecutionUtils.runObject(new RunnableObjectEx<Object[]>() {
-					@Override
-					public Object[] runObject() throws Exception {
-						Set<IType> types = new HashSet<>();
-						types.addAll(m_additionalTypes);
-						types.addAll(getUsedTypes(m_javaInfo));
-						types.addAll(getLocalTypes(m_javaInfo));
-						return types.toArray();
-					}
+				return ExecutionUtils.runObject(() -> {
+					Set<IType> types = new HashSet<>();
+					types.addAll(m_additionalTypes);
+					types.addAll(getUsedTypes(m_javaInfo));
+					types.addAll(getLocalTypes(m_javaInfo));
+					return types.toArray();
 				});
 			}
 
@@ -702,12 +698,7 @@ IConfigurablePropertyObject {
 			@Override
 			public Object[] getElements(Object inputElement) {
 				final IType type = (IType) inputElement;
-				return ExecutionUtils.runObject(new RunnableObjectEx<Object[]>() {
-					@Override
-					public Object[] runObject() throws Exception {
-						return getFields(type).toArray();
-					}
-				});
+				return ExecutionUtils.runObject(() -> getFields(type).toArray());
 			}
 
 			@Override

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/variable/NamesManager.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/variable/NamesManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,7 +21,6 @@ import org.eclipse.wb.internal.core.preferences.IPreferenceConstants;
 import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.jdt.core.CodeUtils;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
@@ -464,13 +463,10 @@ public final class NamesManager {
 			memento.putString("asField", nameDescription.isAsField() ? "true" : "false");
 		}
 		// prepare as String
-		return ExecutionUtils.runObject(new RunnableObjectEx<String>() {
-			@Override
-			public String runObject() throws Exception {
-				StringWriter writer = new StringWriter();
-				rootMemento.save(writer);
-				return writer.toString();
-			}
+		return ExecutionUtils.runObject(() -> {
+			StringWriter writer = new StringWriter();
+			rootMemento.save(writer);
+			return writer.toString();
 		});
 	}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/ui/JdtUiUtils.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/ui/JdtUiUtils.java
@@ -13,7 +13,6 @@ package org.eclipse.wb.internal.core.utils.jdt.ui;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.utils.Messages;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.jdt.core.SubtypesScope;
 
 import org.eclipse.core.runtime.Platform;
@@ -93,12 +92,7 @@ public final class JdtUiUtils {
 	 */
 	private static AbstractUIPlugin getJavaPlugin() {
 		if (m_javaPlugin == null) {
-			m_javaPlugin = ExecutionUtils.runObject(new RunnableObjectEx<AbstractUIPlugin>() {
-				@Override
-				public AbstractUIPlugin runObject() throws Exception {
-					return getJavaPlugin0();
-				}
-			});
+			m_javaPlugin = ExecutionUtils.runObject(() -> getJavaPlugin0());
 		}
 		return m_javaPlugin;
 	}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/BundleResourceProvider.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/BundleResourceProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -130,11 +130,11 @@ public final class BundleResourceProvider {
 	}
 
 	private InputStream getFile0(final String path) {
-		return ExecutionUtils.runObject((RunnableObjectEx<InputStream>) () -> getFile1(path).openStream(), "Unable to open file %s from %s", path, m_id);
+		return ExecutionUtils.runObject(() -> getFile1(path).openStream(), "Unable to open file %s from %s", path, m_id);
 	}
 
 	private URL getFile1(final String path) {
-		return ExecutionUtils.runObject((RunnableObjectEx<URL>) () -> m_bundle.getEntry(path), "Unable to open file %s from %s", path, m_id);
+		return ExecutionUtils.runObject(() -> m_bundle.getEntry(path), "Unable to open file %s from %s", path, m_id);
 	}
 
 	private static String normalizePath(String path) {

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/AbsoluteComplexSelectionEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/AbsoluteComplexSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,7 +27,6 @@ import org.eclipse.wb.internal.core.gef.policy.snapping.PlacementUtils;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Dimension;
@@ -339,12 +338,7 @@ AbsoluteBasedSelectionEditPolicy<C> implements IActionImageProvider {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	protected boolean isAttached(final IAbstractComponentInfo widget, final int side) {
-		return ExecutionUtils.runObject(new RunnableObjectEx<Boolean>() {
-			@Override
-			public Boolean runObject() throws Exception {
-				return m_layout.isAttached(widget, side);
-			}
-		});
+		return ExecutionUtils.runObject(() -> m_layout.isAttached(widget, side));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/SingletonExtensionFactory.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/SingletonExtensionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,6 @@ package org.eclipse.wb.internal.core.utils;
 
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.external.ExternalFactoriesHelper;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
@@ -65,11 +64,6 @@ IExecutableExtensionFactory {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public Object create() throws CoreException {
-		return ExecutionUtils.runObject(new RunnableObjectEx<Object>() {
-			@Override
-			public Object runObject() throws Exception {
-				return ReflectionUtils.getFieldObject(m_objectClass, "INSTANCE");
-			}
-		});
+		return ExecutionUtils.runObject(() -> ReflectionUtils.getFieldObject(m_objectClass, "INSTANCE"));
 	}
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/execution/ExecutionUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/execution/ExecutionUtils.java
@@ -211,17 +211,13 @@ public class ExecutionUtils {
 	}
 
 	/**
-	 * Runs given {@link RunnableEx} inside of UI thread, using {@link Display#syncExec(Runnable)}.
+	 * Runs given {@link Callable} inside of UI thread, using
+	 * {@link Display#syncExec(Runnable)}.
 	 */
 	@SuppressWarnings("unchecked")
-	public static <T> T runObjectUI(final RunnableObjectEx<T> runnable) {
+	public static <T> T runObjectUI(final Callable<T> runnable) {
 		final Object[] result = new Object[1];
-		runRethrowUI(new RunnableEx() {
-			@Override
-			public void run() throws Exception {
-				result[0] = runObject(runnable);
-			}
-		});
+		runRethrowUI(() -> result[0] = runObject(runnable));
 		return (T) result[0];
 	}
 
@@ -244,13 +240,13 @@ public class ExecutionUtils {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * Runs given {@link RunnableEx} and re-throws exceptions using {@link RuntimeException}.
+	 * Runs given {@link Callable} and re-throws exceptions using {@link RuntimeException}.
 	 *
-	 * @return the {@link Object} returned by {@link RunnableEx#run()}.
+	 * @return the {@link Object} returned by {@link Callable#call()}.
 	 */
-	public static <T> T runObject(RunnableObjectEx<T> runnable) {
+	public static <T> T runObject(Callable<T> runnable) {
 		try {
-			return runnable.runObject();
+			return runnable.call();
 		} catch (Throwable e) {
 			throw ReflectionUtils.propagate(e);
 		}
@@ -259,28 +255,28 @@ public class ExecutionUtils {
 	/**
 	 * Runs given {@link RunnableEx} and re-throws exceptions using {@link RuntimeException}.
 	 *
-	 * @return the {@link Object} returned by {@link RunnableObjectEx#run()}.
+	 * @return the {@link Object} returned by {@link Callable#run()}.
 	 */
 	@SuppressWarnings("unchecked")
-	public static <T> T runObject(ObjectInfo object, final RunnableObjectEx<T> runnable) {
+	public static <T> T runObject(ObjectInfo object, final Callable<T> runnable) {
 		final Object[] result = {null};
 		run(object, new RunnableEx() {
 			@Override
 			public void run() throws Exception {
-				result[0] = runnable.runObject();
+				result[0] = runnable.call();
 			}
 		});
 		return (T) result[0];
 	}
 
 	/**
-	 * Runs given {@link RunnableEx} and re-throws exceptions using {@link RuntimeException}.
+	 * Runs given {@link Callable} and re-throws exceptions using {@link RuntimeException}.
 	 *
-	 * @return the {@link Object} returned by {@link RunnableEx#run()}.
+	 * @return the {@link Object} returned by {@link Callable#call()}.
 	 */
-	public static <T> T runObject(RunnableObjectEx<T> runnable, String format, Object... args) {
+	public static <T> T runObject(Callable<T> runnable, String format, Object... args) {
 		try {
-			return runnable.runObject();
+			return runnable.call();
 		} catch (Throwable e) {
 			String message = String.format(format, args);
 			throw new Error(message, e);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/xml/AbstractDocumentEditContext.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/xml/AbstractDocumentEditContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,6 @@ import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.core.utils.xml.parser.QParser;
 
@@ -127,12 +126,8 @@ public abstract class AbstractDocumentEditContext {
 	 * @return the sub-string of document's text.
 	 */
 	public final String getText(final int offset, final int length) {
-		return ExecutionUtils.runObject(new RunnableObjectEx<String>() {
-			@Override
-			public String runObject() throws Exception {
-				return m_document.get(offset, length);
-			}
-		}, "Can not get offset:%d length:%d", offset, length);
+		return ExecutionUtils.runObject(() -> m_document.get(offset, length), "Can not get offset:%d length:%d", offset,
+				length);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/model/GroupLayoutParserVisitor2.java
+++ b/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/model/GroupLayoutParserVisitor2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,6 @@ import org.eclipse.wb.internal.core.model.JavaInfoEvaluationHelper;
 import org.eclipse.wb.internal.core.parser.JavaInfoResolver;
 import org.eclipse.wb.internal.core.utils.ast.AstNodeUtils;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
@@ -261,31 +260,28 @@ final class GroupLayoutParserVisitor2 extends ASTVisitor implements LayoutConsta
 	////////////////////////////////////////////////////////////////////////////
 	private LayoutInterval addChild(final AbstractComponentInfo widget,
 			final Expression associationExpression) {
-		return ExecutionUtils.runObject(new RunnableObjectEx<LayoutInterval>() {
-			@Override
-			public LayoutInterval runObject() throws Exception {
-				// widget may be already added to parent using previous dimension parsing
-				if (widget.getParent() == null && !m_container.getChildren().contains(widget)) {
-					m_container.addChild(widget);
-				}
-				// remember last association expression
-				widget.putArbitraryValue(
-						GroupLayoutCodeSupport.ASSOCIATION_EXPRESSION_KEY,
-						associationExpression);
-				//
-				String id = ObjectInfoUtils.getId(widget);
-				LayoutComponent layoutComponent = m_layoutModel.getLayoutComponent(id);
-				if (layoutComponent == null) {
-					layoutComponent = new LayoutComponent(id, false);
-				}
-				if (layoutComponent.getParent() == null) {
-					LayoutComponent root =
-							m_layoutModel.getLayoutComponent(ObjectInfoUtils.getId(m_container));
-					m_layoutModel.addComponent(layoutComponent, root, -1);
-				}
-				m_codeSupport.checkComponent(widget, m_dimension);
-				return layoutComponent.getLayoutInterval(m_dimension);
+		return ExecutionUtils.runObject(() -> {
+			// widget may be already added to parent using previous dimension parsing
+			if (widget.getParent() == null && !m_container.getChildren().contains(widget)) {
+				m_container.addChild(widget);
 			}
+			// remember last association expression
+			widget.putArbitraryValue(
+					GroupLayoutCodeSupport.ASSOCIATION_EXPRESSION_KEY,
+					associationExpression);
+			//
+			String id = ObjectInfoUtils.getId(widget);
+			LayoutComponent layoutComponent = m_layoutModel.getLayoutComponent(id);
+			if (layoutComponent == null) {
+				layoutComponent = new LayoutComponent(id, false);
+			}
+			if (layoutComponent.getParent() == null) {
+				LayoutComponent root =
+						m_layoutModel.getLayoutComponent(ObjectInfoUtils.getId(m_container));
+				m_layoutModel.addComponent(layoutComponent, root, -1);
+			}
+			m_codeSupport.checkComponent(widget, m_dimension);
+			return layoutComponent.getLayoutInterval(m_dimension);
 		});
 	}
 

--- a/org.eclipse.wb.os.linux/src/org/eclipse/wb/internal/os/linux/OSSupportLinux.java
+++ b/org.eclipse.wb.os.linux/src/org/eclipse/wb/internal/os/linux/OSSupportLinux.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,6 @@ import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.check.AssertionFailedException;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.swt.VisualDataMockupProvider;
 import org.eclipse.wb.os.OSSupport;
@@ -210,15 +209,12 @@ public abstract class OSSupportLinux<H extends Number> extends OSSupport {
 	}
 
 	private boolean bindImage(final Control control, final Image image) {
-		return ExecutionUtils.runObject(new RunnableObjectEx<Boolean>() {
-			@Override
-			public Boolean runObject() throws Exception {
-				if (control.getData(WBP_NEED_IMAGE) != null && control.getData(WBP_IMAGE) == null) {
-					control.setData(WBP_IMAGE, image);
-					return true;
-				}
-				return false;
+		return ExecutionUtils.runObject(() -> {
+			if (control.getData(WBP_NEED_IMAGE) != null && control.getData(WBP_IMAGE) == null) {
+				control.setData(WBP_IMAGE, image);
+				return true;
 			}
+			return false;
 		});
 	}
 

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/forms/ManagedFormInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/forms/ManagedFormInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,6 @@ import org.eclipse.wb.internal.core.model.description.ComponentDescription;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.core.utils.state.EditorState;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
@@ -65,12 +64,7 @@ public final class ManagedFormInfo extends AbstractComponentInfo {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public Object getComponentObject() {
-		return ExecutionUtils.runObject(new RunnableObjectEx<Object>() {
-			@Override
-			public Object runObject() throws Exception {
-				return ReflectionUtils.invokeMethod2(getObject(), "getForm");
-			}
-		});
+		return ExecutionUtils.runObject(() -> ReflectionUtils.invokeMethod2(getObject(), "getForm"));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/forms/layout/table/TableWrapLayoutInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/forms/layout/table/TableWrapLayoutInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -36,7 +36,6 @@ import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.rcp.model.forms.layout.table.actions.SelectionActionsSupport;
 import org.eclipse.wb.internal.swt.model.layout.LayoutClipboardCommand;
@@ -299,13 +298,10 @@ IPreferenceConstants {
 	 * @return {@link TableWrapDataInfo} association with given {@link ControlInfo}.
 	 */
 	public TableWrapDataInfo getTableWrapData(final ControlInfo control) {
-		return ExecutionUtils.runObject(new RunnableObjectEx<TableWrapDataInfo>() {
-			@Override
-			public TableWrapDataInfo runObject() throws Exception {
-				TableWrapDataInfo layoutData = (TableWrapDataInfo) getLayoutData(control);
-				layoutData.initialize(TableWrapLayoutInfo.this, control);
-				return layoutData;
-			}
+		return ExecutionUtils.runObject(() -> {
+			TableWrapDataInfo layoutData = (TableWrapDataInfo) getLayoutData(control);
+			layoutData.initialize(TableWrapLayoutInfo.this, control);
+			return layoutData;
 		});
 	}
 

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/PreferencePageInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/PreferencePageInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,6 @@ import org.eclipse.wb.internal.core.model.description.ComponentDescription;
 import org.eclipse.wb.internal.core.model.util.IJavaInfoRendering;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.swt.support.ContainerSupport;
 
@@ -52,12 +51,7 @@ public class PreferencePageInfo extends DialogPageInfo implements IJavaInfoRende
 	@Override
 	Object getShell() {
 		if (m_shell == null) {
-			return ExecutionUtils.runObject(new RunnableObjectEx<Object>() {
-				@Override
-				public Object runObject() throws Exception {
-					return ReflectionUtils.invokeMethod(m_preferenceDialog, "getShell()");
-				}
-			});
+			return ExecutionUtils.runObject(() -> ReflectionUtils.invokeMethod(m_preferenceDialog, "getShell()"));
 		}
 		return super.getShell();
 	}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/MenuManagerInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/MenuManagerInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,7 +25,6 @@ import org.eclipse.wb.internal.core.model.menu.MenuVisualData;
 import org.eclipse.wb.internal.core.utils.IAdaptable;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.rcp.model.ModelMessages;
 import org.eclipse.wb.internal.swt.support.ControlSupport;
@@ -129,12 +128,9 @@ IAdaptable {
 	 *         widgets with {@link SWT#BAR} style.
 	 */
 	public boolean isBar() {
-		return ExecutionUtils.runObject(new RunnableObjectEx<Boolean>() {
-			@Override
-			public Boolean runObject() throws Exception {
-				Menu menu = (Menu) ReflectionUtils.invokeMethod2(getObject(), "getMenu");
-				return ControlSupport.isStyle(menu, SWT.BAR);
-			}
+		return ExecutionUtils.runObject(() -> {
+			Menu menu = (Menu) ReflectionUtils.invokeMethod2(getObject(), "getMenu");
+			return ControlSupport.isStyle(menu, SWT.BAR);
 		});
 	}
 

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/ToolBarContributionItemInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/ToolBarContributionItemInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,6 @@ import org.eclipse.wb.internal.core.model.creation.CreationSupport;
 import org.eclipse.wb.internal.core.model.description.ComponentDescription;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
 import org.eclipse.jface.action.ToolBarContributionItem;
@@ -45,13 +44,10 @@ public final class ToolBarContributionItemInfo extends ContributionItemInfo {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public Object getComponentObject() {
-		return ExecutionUtils.runObject(new RunnableObjectEx<Object>() {
-			@Override
-			public Object runObject() throws Exception {
-				ToolBarManagerInfo managerInfo = getChildren(ToolBarManagerInfo.class).get(0);
-				Object manager = managerInfo.getObject();
-				return ((ToolBar) ReflectionUtils.invokeMethod(manager, "getControl()")).getParent();
-			}
+		return ExecutionUtils.runObject(() -> {
+			ToolBarManagerInfo managerInfo = getChildren(ToolBarManagerInfo.class).get(0);
+			Object manager = managerInfo.getObject();
+			return ((ToolBar) ReflectionUtils.invokeMethod(manager, "getControl()")).getParent();
 		});
 	}
 }

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/model/FormDimensionUtils.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/model/FormDimensionUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,6 @@
 package org.eclipse.wb.internal.swing.FormLayout.model;
 
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 
 import com.jgoodies.forms.layout.FormSpec;
 import com.jgoodies.forms.layout.FormSpecs;
@@ -80,19 +79,16 @@ public class FormDimensionUtils {
 	 *         or <code>null</code> if there are not such field.
 	 */
 	public static Field getFormFactoryTemplate(final FormSpec o) {
-		return ExecutionUtils.runObject(new RunnableObjectEx<Field>() {
-			@Override
-			public Field runObject() throws Exception {
-				Field[] templateFields = getTemplateFields();
-				for (int i = 0; i < templateFields.length; i++) {
-					Field field = templateFields[i];
-					if (FormDimensionUtils.equals((FormSpec) field.get(null), o)) {
-						return field;
-					}
+		return ExecutionUtils.runObject(() -> {
+			Field[] templateFields = getTemplateFields();
+			for (int i = 0; i < templateFields.length; i++) {
+				Field field = templateFields[i];
+				if (FormDimensionUtils.equals((FormSpec) field.get(null), o)) {
+					return field;
 				}
-				// no field found
-				return null;
 			}
+			// no field found
+			return null;
 		});
 	}
 }

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/Activator.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/Activator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,6 @@
 package org.eclipse.wb.internal.swing.databinding;
 
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.resource.ImageDescriptor;
@@ -66,12 +65,8 @@ public class Activator extends AbstractUIPlugin {
 	 * @return the {@link InputStream} for file from plugin directory.
 	 */
 	public static InputStream getFile(final String path) {
-		return ExecutionUtils.runObject(new RunnableObjectEx<InputStream>() {
-			@Override
-			public InputStream runObject() throws Exception {
-				return m_plugin.getBundle().getEntry(path).openStream();
-			}
-		}, "Unable to open plugin file %s", path);
+		return ExecutionUtils.runObject(() -> m_plugin.getBundle().getEntry(path).openStream(),
+				"Unable to open plugin file %s", path);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/absolute/ConstraintsAbsoluteLayoutInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/absolute/ConstraintsAbsoluteLayoutInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,7 +23,6 @@ import org.eclipse.wb.internal.core.model.variable.VariableSupport;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 import org.eclipse.wb.internal.swing.model.layout.LayoutInfo;
@@ -65,57 +64,54 @@ public final class ConstraintsAbsoluteLayoutInfo extends AbstractAbsoluteLayoutI
 	 * @return the {@link ConstraintsAbsoluteLayoutDataInfo} for given {@link ComponentInfo}.
 	 */
 	public static ConstraintsAbsoluteLayoutDataInfo getConstraints(final ComponentInfo component) {
-		return ExecutionUtils.runObject(new RunnableObjectEx<ConstraintsAbsoluteLayoutDataInfo>() {
-			@Override
-			public ConstraintsAbsoluteLayoutDataInfo runObject() throws Exception {
-				// prepare constraints
-				ConstraintsAbsoluteLayoutDataInfo constraints;
-				{
-					List<ConstraintsAbsoluteLayoutDataInfo> constraintsList =
-							component.getChildren(ConstraintsAbsoluteLayoutDataInfo.class);
-					Assert.isLegal(constraintsList.size() <= 1);
-					if (constraintsList.size() == 1) {
-						constraints = constraintsList.get(0);
-					} else {
-						String constraintsClassName;
-						{
-							ContainerInfo container = (ContainerInfo) component.getParent();
-							LayoutInfo layout = container.getLayout();
-							constraintsClassName =
-									JavaInfoUtils.getParameter(layout, "absoluteLayout.constraintsClass");
-						}
-						constraints =
-								(ConstraintsAbsoluteLayoutDataInfo) JavaInfoUtils.createJavaInfo(
-										component.getEditor(),
-										constraintsClassName,
-										new ConstructorCreationSupport());
-						// prepare add() invocation
-						InvocationChildAssociation association =
-								(InvocationChildAssociation) component.getAssociation();
-						MethodInvocation invocation = association.getInvocation();
-						// ensure LayoutData expression
-						Expression expression;
-						{
-							String source = constraints.getDescription().getCreation(null).getSource();
-							expression = constraints.getEditor().addInvocationArgument(invocation, 1, source);
-						}
-						// set CreationSupport
-						{
-							constraints.setCreationSupport(new ConstructorCreationSupport((ClassInstanceCreation) expression));
-							constraints.addRelatedNode(expression);
-						}
-						// set Association
-						constraints.setAssociation(new InvocationSecondaryAssociation(invocation));
-						// set VariableSupport
-						VariableSupport variableSupport = new EmptyVariableSupport(constraints, expression);
-						constraints.setVariableSupport(variableSupport);
-						// add
-						component.addChild(constraints);
+		return ExecutionUtils.runObject(() -> {
+			// prepare constraints
+			ConstraintsAbsoluteLayoutDataInfo constraints;
+			{
+				List<ConstraintsAbsoluteLayoutDataInfo> constraintsList =
+						component.getChildren(ConstraintsAbsoluteLayoutDataInfo.class);
+				Assert.isLegal(constraintsList.size() <= 1);
+				if (constraintsList.size() == 1) {
+					constraints = constraintsList.get(0);
+				} else {
+					String constraintsClassName;
+					{
+						ContainerInfo container = (ContainerInfo) component.getParent();
+						LayoutInfo layout = container.getLayout();
+						constraintsClassName =
+								JavaInfoUtils.getParameter(layout, "absoluteLayout.constraintsClass");
 					}
+					constraints =
+							(ConstraintsAbsoluteLayoutDataInfo) JavaInfoUtils.createJavaInfo(
+									component.getEditor(),
+									constraintsClassName,
+									new ConstructorCreationSupport());
+					// prepare add() invocation
+					InvocationChildAssociation association =
+							(InvocationChildAssociation) component.getAssociation();
+					MethodInvocation invocation = association.getInvocation();
+					// ensure LayoutData expression
+					Expression expression;
+					{
+						String source = constraints.getDescription().getCreation(null).getSource();
+						expression = constraints.getEditor().addInvocationArgument(invocation, 1, source);
+					}
+					// set CreationSupport
+					{
+						constraints.setCreationSupport(new ConstructorCreationSupport((ClassInstanceCreation) expression));
+						constraints.addRelatedNode(expression);
+					}
+					// set Association
+					constraints.setAssociation(new InvocationSecondaryAssociation(invocation));
+					// set VariableSupport
+					VariableSupport variableSupport = new EmptyVariableSupport(constraints, expression);
+					constraints.setVariableSupport(variableSupport);
+					// add
+					component.addChild(constraints);
 				}
-				// initialize and return
-				return constraints;
 			}
+			// initialize and return
+			return constraints;
 		});
 	}
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/gbl/GridBagLayoutInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/gbl/GridBagLayoutInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,6 @@ import org.eclipse.wb.internal.core.model.description.ComponentDescription;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.exception.DesignerException;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.swing.IExceptionConstants;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
@@ -64,37 +63,34 @@ public final class GridBagLayoutInfo extends AbstractGridBagLayoutInfo {
 	}
 
 	public static GridBagConstraintsInfo getConstraintsFor(final ComponentInfo component) {
-		return ExecutionUtils.runObject(new RunnableObjectEx<GridBagConstraintsInfo>() {
-			@Override
-			public GridBagConstraintsInfo runObject() throws Exception {
-				// prepare constraints
-				GridBagConstraintsInfo constraints;
-				{
-					List<GridBagConstraintsInfo> constraintsList =
-							component.getChildren(GridBagConstraintsInfo.class);
-					if (constraintsList.size() > 1) {
-						throw new DesignerException(IExceptionConstants.MORE_THAN_ONE_CONSTRAINTS,
-								component.toString(),
-								constraintsList.toString(),
-								component.getVariableSupport().getComponentName());
-					}
-					if (constraintsList.size() == 1) {
-						constraints = constraintsList.get(0);
-					} else {
-						constraints =
-								(GridBagConstraintsInfo) JavaInfoUtils.createJavaInfo(
-										component.getEditor(),
-										GridBagConstraints.class,
-										new VirtualConstraintsCreationSupport(component));
-						constraints.setVariableSupport(new VirtualConstraintsVariableSupport(constraints));
-						constraints.setAssociation(new EmptyAssociation());
-						component.addChild(constraints);
-					}
+		return ExecutionUtils.runObject(() -> {
+			// prepare constraints
+			GridBagConstraintsInfo constraints;
+			{
+				List<GridBagConstraintsInfo> constraintsList =
+						component.getChildren(GridBagConstraintsInfo.class);
+				if (constraintsList.size() > 1) {
+					throw new DesignerException(IExceptionConstants.MORE_THAN_ONE_CONSTRAINTS,
+							component.toString(),
+							constraintsList.toString(),
+							component.getVariableSupport().getComponentName());
 				}
-				// initialize and return
-						constraints.init();
-				return constraints;
+				if (constraintsList.size() == 1) {
+					constraints = constraintsList.get(0);
+				} else {
+					constraints =
+							(GridBagConstraintsInfo) JavaInfoUtils.createJavaInfo(
+									component.getEditor(),
+									GridBagConstraints.class,
+									new VirtualConstraintsCreationSupport(component));
+					constraints.setVariableSupport(new VirtualConstraintsVariableSupport(constraints));
+					constraints.setAssociation(new EmptyAssociation());
+					component.addChild(constraints);
+				}
 			}
+			// initialize and return
+					constraints.init();
+			return constraints;
 		});
 	}
 

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/widgets/CompositeInfo.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/widgets/CompositeInfo.java
@@ -54,7 +54,6 @@ import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.exception.DesignerException;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.state.EditorState;
 import org.eclipse.wb.internal.swt.Activator;
 import org.eclipse.wb.internal.swt.IExceptionConstants;
@@ -338,22 +337,19 @@ IThisMethodParameterEvaluator {
 	@Override
 	protected TopBoundsSupport createTopBoundsSupport() {
 		// return implementation from eRCP or RCP bundles
-		return ExecutionUtils.runObject(new RunnableObjectEx<TopBoundsSupport>() {
-			@Override
-			public TopBoundsSupport runObject() throws Exception {
-				// prepare "impl" class
-				Class<?> implClass;
-				{
-					Bundle bundle = getDescription().getToolkit().getBundle();
-					String implClassName =
-							bundle.getSymbolicName() + ".model.widgets.CompositeTopBoundsSupport";
-					implClassName = StringUtils.replace(implClassName, ".wb.", ".wb.internal.");
-					implClass = bundle.loadClass(implClassName);
-				}
-				// create instance
-				Constructor<?> constructor = implClass.getConstructor(CompositeInfo.class);
-				return (TopBoundsSupport) constructor.newInstance(m_this);
+		return ExecutionUtils.runObject(() -> {
+			// prepare "impl" class
+			Class<?> implClass;
+			{
+				Bundle bundle = getDescription().getToolkit().getBundle();
+				String implClassName =
+						bundle.getSymbolicName() + ".model.widgets.CompositeTopBoundsSupport";
+				implClassName = StringUtils.replace(implClassName, ".wb.", ".wb.internal.");
+				implClass = bundle.loadClass(implClassName);
 			}
+			// create instance
+			Constructor<?> constructor = implClass.getConstructor(CompositeInfo.class);
+			return (TopBoundsSupport) constructor.newInstance(m_this);
 		});
 	}
 

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/support/AbstractSupport.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/support/AbstractSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,6 @@
 package org.eclipse.wb.internal.swt.support;
 
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.state.EditorState;
 import org.eclipse.wb.internal.core.utils.state.GlobalState;
 
@@ -44,11 +43,6 @@ public class AbstractSupport {
 	 * @return the {@link Class} with given name loaded from active editor {@link ClassLoader}.
 	 */
 	protected static Class<?> loadClass(final String name) {
-		return ExecutionUtils.runObject(new RunnableObjectEx<Class<?>>() {
-			@Override
-			public Class<?> runObject() throws Exception {
-				return GlobalState.getClassLoader().loadClass(name);
-			}
-		});
+		return ExecutionUtils.runObject(() -> GlobalState.getClassLoader().loadClass(name));
 	}
 }

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/support/ContainerSupport.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/support/ContainerSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,6 @@
 package org.eclipse.wb.internal.swt.support;
 
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -231,12 +230,9 @@ public class ContainerSupport extends AbstractSupport {
 	 * Invoke method <code>Composite.getClientArea()</code> for given composite.
 	 */
 	public static Rectangle getClientArea(final Object composite) {
-		return ExecutionUtils.runObject(new RunnableObjectEx<Rectangle>() {
-			@Override
-			public Rectangle runObject() throws Exception {
-				Object rectangle = ReflectionUtils.invokeMethod(composite, "getClientArea()");
-				return RectangleSupport.getRectangle(rectangle);
-			}
+		return ExecutionUtils.runObject(() -> {
+			Object rectangle = ReflectionUtils.invokeMethod(composite, "getClientArea()");
+			return RectangleSupport.getRectangle(rectangle);
 		});
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/execution/ExecutionUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/execution/ExecutionUtilsTest.java
@@ -28,6 +28,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import java.beans.Beans;
+import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -320,36 +321,21 @@ public class ExecutionUtilsTest extends SwingModelTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_object_rethrow_noException() throws Exception {
-		Object result = ExecutionUtils.runObject(new RunnableObjectEx<Object>() {
-			@Override
-			public Object runObject() throws Exception {
-				return null;
-			}
-		});
+		Object result = ExecutionUtils.runObject(() -> null);
 		assertNull(result);
 	}
 
 	@Test
 	public void test_object_rethrow_noException2() throws Exception {
 		final Object myResult = new Object();
-		Object result = ExecutionUtils.runObject(new RunnableObjectEx<Object>() {
-			@Override
-			public Object runObject() throws Exception {
-				return myResult;
-			}
-		});
+		Object result = ExecutionUtils.runObject(() -> myResult);
 		assertSame(myResult, result);
 	}
 
 	@Test
 	public void test_object_rethrow_noException3() throws Exception {
 		final Integer myResult = 12345;
-		Integer result = ExecutionUtils.runObject(new RunnableObjectEx<Integer>() {
-			@Override
-			public Integer runObject() throws Exception {
-				return myResult;
-			}
-		});
+		Integer result = ExecutionUtils.runObject(() -> myResult);
 		assertSame(myResult, result);
 	}
 
@@ -357,12 +343,7 @@ public class ExecutionUtilsTest extends SwingModelTest {
 	public void test_object_rethrow_withException() throws Exception {
 		final Exception exception = new Exception();
 		try {
-			ExecutionUtils.runObject(new RunnableObjectEx<Object>() {
-				@Override
-				public Object runObject() throws Exception {
-					throw exception;
-				}
-			});
+			ExecutionUtils.runObject(() -> { throw exception; });
 		} catch (Throwable e) {
 			assertSame(exception, e);
 		}
@@ -375,12 +356,7 @@ public class ExecutionUtilsTest extends SwingModelTest {
 		}
 		final MyError myError = new MyError();
 		try {
-			ExecutionUtils.runObject(new RunnableObjectEx<Object>() {
-				@Override
-				public Object runObject() throws Exception {
-					throw myError;
-				}
-			});
+			ExecutionUtils.runObject(() -> { throw myError; });
 			fail();
 		} catch (MyError e) {
 			assertSame(myError, e);
@@ -393,32 +369,22 @@ public class ExecutionUtilsTest extends SwingModelTest {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * Test for {@link ExecutionUtils#runObject(RunnableObjectEx, String, Object...)}.
+	 * Test for {@link ExecutionUtils#runObject(Callable, String, Object...)}.
 	 */
 	@Test
 	public void test_object_rethrowMessage_noException() throws Exception {
-		Object result = ExecutionUtils.runObject(new RunnableObjectEx<Object>() {
-			@Override
-			public Object runObject() throws Exception {
-				return null;
-			}
-		}, "Error message '%s' for %d.", "Not found", 42);
+		Object result = ExecutionUtils.runObject(() -> null, "Error message '%s' for %d.", "Not found", 42);
 		assertNull(result);
 	}
 
 	/**
-	 * Test for {@link ExecutionUtils#runObject(RunnableObjectEx, String, Object...)}.
+	 * Test for {@link ExecutionUtils#runObject(Callable, String, Object...)}.
 	 */
 	@Test
 	public void test_object_rethrowMessage_withException() throws Exception {
 		final Exception exception = new Exception();
 		try {
-			ExecutionUtils.runObject(new RunnableObjectEx<Object>() {
-				@Override
-				public Object runObject() throws Exception {
-					throw exception;
-				}
-			}, "Error message '%s' for %d.", "Not found", 42);
+			ExecutionUtils.runObject(() -> { throw exception; }, "Error message '%s' for %d.", "Not found", 42);
 		} catch (Error e) {
 			assertEquals("Error message 'Not found' for 42.", e.getMessage());
 			assertSame(exception, e.getCause());
@@ -606,12 +572,9 @@ public class ExecutionUtilsTest extends SwingModelTest {
 			@Override
 			public void run() {
 				final Object myResult = new Object();
-				Object result = ExecutionUtils.runObjectUI(new RunnableObjectEx<Object>() {
-					@Override
-					public Object runObject() throws Exception {
-						assertNotNull(Display.getCurrent());
-						return myResult;
-					}
+				Object result = ExecutionUtils.runObjectUI(() -> { 
+					assertNotNull(Display.getCurrent());
+					return myResult;
 				});
 				assertSame(myResult, result);
 			}
@@ -785,12 +748,7 @@ public class ExecutionUtilsTest extends SwingModelTest {
 		};
 		// do edit
 		final String result = "expected";
-		String actual = ExecutionUtils.runObject(object, new RunnableObjectEx<String>() {
-			@Override
-			public String runObject() throws Exception {
-				return result;
-			}
-		});
+		String actual = ExecutionUtils.runObject(object, () -> result);
 		// has expected result
 		assertSame(result, actual);
 		// refresh happened

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/TreeRobot.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/TreeRobot.java
@@ -15,7 +15,6 @@ import org.eclipse.wb.gef.core.tools.Tool;
 import org.eclipse.wb.gef.graphical.tools.SelectionTool;
 import org.eclipse.wb.gef.tree.TreeEditPart;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.core.utils.ui.UiUtils;
 import org.eclipse.wb.internal.gef.tree.TreeViewer;
@@ -193,15 +192,12 @@ public final class TreeRobot {
 	}
 
 	private static Event createDNDEvent() {
-		return ExecutionUtils.runObject(new RunnableObjectEx<Event>() {
-			@Override
-			public Event runObject() throws Exception {
-				Class<?> dndClass =
-						ReflectionUtils.getClassByName(
-								TreeRobot.class.getClassLoader(),
-								"org.eclipse.swt.dnd.DNDEvent");
-				return (Event) ReflectionUtils.getConstructorBySignature(dndClass, "<init>()").newInstance();
-			}
+		return ExecutionUtils.runObject(() -> {
+			Class<?> dndClass =
+					ReflectionUtils.getClassByName(
+							TreeRobot.class.getClassLoader(),
+							"org.eclipse.swt.dnd.DNDEvent");
+			return (Event) ReflectionUtils.getConstructorBySignature(dndClass, "<init>()").newInstance();
 		});
 	}
 


### PR DESCRIPTION
Our RunnableObjectEx and the Java Callable are functionally identical: The interface defines a single method, which returns a generic object and may throw an exception. So there is no need to use our own interface.

Where applicable, anonymous instances of this interface have been replaced with lambda expressions.