### PR TITLE
Change signature of runObject/runObjectUI to expect a Callable object

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/parser/JavaInfoParser.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/parser/JavaInfoParser.java
@@ -70,7 +70,6 @@ import org.eclipse.wb.internal.core.utils.exception.ICoreExceptionConstants;
 import org.eclipse.wb.internal.core.utils.exception.NoEntryPointError;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.external.ExternalFactoriesHelper;
 import org.eclipse.wb.internal.core.utils.jdt.core.CodeUtils;
 import org.eclipse.wb.internal.core.utils.jdt.core.ProjectUtils;
@@ -146,12 +145,7 @@ public final class JavaInfoParser implements IJavaInfoParseResolver {
 	public static JavaInfo parse(ICompilationUnit modelUnit) throws Exception {
 		checkJavaVersion(modelUnit);
 		final JavaInfoParser parser = new JavaInfoParser(modelUnit);
-		return ExecutionUtils.runDesignTime(new RunnableObjectEx<JavaInfo>() {
-			@Override
-			public JavaInfo runObject() throws Exception {
-				return parser.parse();
-			}
-		});
+		return ExecutionUtils.runDesignTime(() -> parser.parse());
 	}
 
 	/**
@@ -160,12 +154,7 @@ public final class JavaInfoParser implements IJavaInfoParseResolver {
 	public static JavaInfo parse(AstEditor editor, MethodDeclaration rootMethod) throws Exception {
 		final JavaInfoParser parser = new JavaInfoParser(editor);
 		parser.m_editorState.setFlowDescription(new ExecutionFlowDescription(rootMethod));
-		return ExecutionUtils.runDesignTime(new RunnableObjectEx<JavaInfo>() {
-			@Override
-			public JavaInfo runObject() throws Exception {
-				return parser.parseRootMethods();
-			}
-		});
+		return ExecutionUtils.runDesignTime(() -> parser.parseRootMethods());
 	}
 
 	/**

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/execution/ExecutionUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/execution/ExecutionUtils.java
@@ -152,13 +152,13 @@ public class ExecutionUtils {
 
 	/**
 	 * Ensures that {@link Beans#isDesignTime()} returns <code>true</code> and runs given
-	 * {@link RunnableEx}.
+	 * {@link Callable}.
 	 */
-	public static <T> T runDesignTime(RunnableObjectEx<T> runnable) throws Exception {
+	public static <T> T runDesignTime(Callable<T> runnable) throws Exception {
 		boolean old_designTime = Beans.isDesignTime();
 		try {
 			Beans.setDesignTime(true);
-			return runnable.runObject();
+			return runnable.call();
 		} finally {
 			Beans.setDesignTime(old_designTime);
 		}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/execution/ExecutionUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/execution/ExecutionUtilsTest.java
@@ -280,17 +280,14 @@ public class ExecutionUtilsTest extends SwingModelTest {
 	}
 
 	/**
-	 * Test for {@link ExecutionUtils#runDesignTime(RunnableObjectEx)}.
+	 * Test for {@link ExecutionUtils#runDesignTime(Callable)}.
 	 */
 	@Test
 	public void test_void_runDesignTime_Object() throws Exception {
 		final Object o = new Object();
-		Object result = ExecutionUtils.runDesignTime(new RunnableObjectEx<Object>() {
-			@Override
-			public Object runObject() throws Exception {
-				assertTrue(Beans.isDesignTime());
-				return o;
-			}
+		Object result = ExecutionUtils.runDesignTime(() -> {
+			assertTrue(Beans.isDesignTime());
+			return o;
 		});
 		assertSame(o, result);
 	}


### PR DESCRIPTION
Our RunnableObjectEx and the Java Callable are functionally identical: The interface defines a single method, which returns a generic object and may throw an exception. So there is no need to use our own interface.

Where applicable, anonymous instances of this interface have been replaced with lambda expressions.