### PR TITLE
[Draw2D] Harmonize Parent/Children accessors in Figure with base class

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/part/DesignRootEditPart.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/part/DesignRootEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,6 +22,7 @@ import org.eclipse.wb.internal.core.model.nonvisual.NonVisualBeanInfo;
 import org.eclipse.wb.internal.draw2d.FigureCanvas;
 import org.eclipse.wb.internal.draw2d.IPreferredSizeProvider;
 
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -153,7 +154,7 @@ public final class DesignRootEditPart extends GraphicalEditPart {
 		////////////////////////////////////////////////////////////////////////////
 		@Override
 		public Rectangle getBounds() {
-			Figure parentFigure = getParent();
+			IFigure parentFigure = getParent();
 			if (parentFigure != null) {
 				return new Rectangle(new Point(), parentFigure.getSize());
 			}

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/FigureUtils.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/FigureUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,6 @@ import org.eclipse.wb.internal.draw2d.RootFigure;
 
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Dimension;
-import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.draw2d.geometry.Translatable;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.GC;
@@ -59,11 +58,11 @@ public class FigureUtils {
 	}
 
 	/**
-	 * Translates given {@link Translatable} from <code>source</code> {@link Figure} local coordinates
-	 * to local coordinates from <code>target</code> {@link Figure}.
+	 * Translates given {@link Translatable} from <code>source</code> {@link IFigure} local coordinates
+	 * to local coordinates from <code>target</code> {@link IFigure}.
 	 */
-	public static final void translateFigureToFigure2(Figure source,
-			Figure target,
+	public static final void translateFigureToFigure2(IFigure source,
+			IFigure target,
 			Translatable translatable) {
 		translateFigureToAbsolute2(source, translatable);
 		translateAbsoluteToFigure2(target, translatable);
@@ -81,10 +80,10 @@ public class FigureUtils {
 	}
 
 	/**
-	 * Translates given {@link Translatable} from this {@link Figure} local coordinates to absolute (
+	 * Translates given {@link Translatable} from this {@link IFigure} local coordinates to absolute (
 	 * {@link RootFigure} relative) coordinates.
 	 */
-	public static final void translateFigureToAbsolute2(Figure figure, Translatable translatable) {
+	public static final void translateFigureToAbsolute2(IFigure figure, Translatable translatable) {
 		for (; figure != null; figure = figure.getParent()) {
 			translatable.performTranslate(figure.getInsets());
 			translatable.performTranslate(figure.getLocation());
@@ -116,24 +115,13 @@ public class FigureUtils {
 
 	/**
 	 * Translates given {@link Translatable} from this absolute ({@link RootFigure} relative)
-	 * coordinates to local {@link Figure} coordinates.
+	 * coordinates to local {@link IFigure} coordinates.
 	 */
-	public static final void translateAbsoluteToFigure2(Figure figure, Translatable translatable) {
+	public static final void translateAbsoluteToFigure2(IFigure figure, Translatable translatable) {
 		for (; figure != null; figure = figure.getParent()) {
 			translatable.performTranslate(figure.getLocation().negate());
 			translatable.performTranslate(figure.getInsets().getNegated());
 		}
-	}
-
-	/**
-	 * @return the bounds of given {@link Figure} on screen.
-	 */
-	public static Rectangle getScreenBounds(Figure figure) {
-		FigureCanvas figureCanvas = figure.getFigureCanvas();
-		Rectangle bounds = figure.getBounds();
-		translateFigureToCanvas(figure.getParent(), bounds);
-		org.eclipse.swt.graphics.Point location = figureCanvas.toDisplay(bounds.x, bounds.y);
-		return new Rectangle(location.x, location.y, bounds.width, bounds.height);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/policies/DirectTextEditPolicy.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/policies/DirectTextEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -161,7 +161,7 @@ public abstract class DirectTextEditPolicy extends GraphicalEditPolicy {
 		Rectangle hostBounds;
 		{
 			hostBounds = getHostFigure().getBounds().getCopy();
-			FigureUtils.translateFigureToCanvas(getHostFigure().getParent(), hostBounds);
+			FigureUtils.translateFigureToCanvas((Figure) getHostFigure().getParent(), hostBounds);
 		}
 		// prepare text size
 		org.eclipse.swt.graphics.Point textSize;

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/policies/GraphicalEditPolicy.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/policies/GraphicalEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,8 @@ import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
+
+import org.eclipse.draw2d.IFigure;
 
 /**
  * @author lobas_av
@@ -97,7 +99,7 @@ public class GraphicalEditPolicy extends EditPolicy {
 	 */
 	private boolean isOnMenuLayer() {
 		Layer menuPrimaryLayer = getHost().getViewer().getLayer(IEditPartViewer.MENU_PRIMARY_LAYER);
-		for (Figure figure = getHostFigure(); figure != null; figure = figure.getParent()) {
+		for (IFigure figure = getHostFigure(); figure != null; figure = figure.getParent()) {
 			if (figure == menuPrimaryLayer) {
 				return true;
 			}

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/core/TargetEditPartFindVisitor.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/core/TargetEditPartFindVisitor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,11 +10,11 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.gef.core;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.internal.draw2d.FigureCanvas;
 import org.eclipse.wb.internal.draw2d.TargetFigureFindVisitor;
 
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.gef.EditPartViewer;
 
 /**
@@ -54,9 +54,9 @@ public class TargetEditPartFindVisitor extends TargetFigureFindVisitor {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * Extract {@link EditPart} from given {@link Figure}.
+	 * Extract {@link EditPart} from given {@link IFigure}.
 	 */
-	protected EditPart extractEditPart(Figure figure) {
+	protected EditPart extractEditPart(IFigure figure) {
 		EditPart editPart = null;
 		while (editPart == null && figure != null) {
 			editPart = (EditPart) m_viewer.getVisualPartMap().get(figure);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
@@ -25,6 +25,7 @@ import org.eclipse.wb.internal.draw2d.TargetFigureFindVisitor;
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.FigureUtilities;
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.MouseEvent;
 import org.eclipse.draw2d.MouseListener;
 import org.eclipse.draw2d.MouseMotionListener;
@@ -491,7 +492,7 @@ public final class PaletteComposite extends Composite {
 			move_eraseFeedback();
 			m_moveCommand = null;
 			// prepare target figure
-			Figure targetFigure = getTargetFigure(this, p);
+			IFigure targetFigure = getTargetFigure(this, p);
 			if (targetFigure instanceof EntryFigure) {
 				targetFigure = targetFigure.getParent();
 			}
@@ -501,8 +502,8 @@ public final class PaletteComposite extends Composite {
 				final ICategory category_1 = ((CategoryFigure) targetFigure).m_category;
 				final ICategory category_2;
 				{
-					List<Figure> siblings = targetFigure.getParent().getChildren();
-					Figure nextFigure = GenericsUtils.getNextOrNull(siblings, targetFigure);
+					List<? extends IFigure> siblings = targetFigure.getParent().getChildren();
+					IFigure nextFigure = GenericsUtils.getNextOrNull(siblings, targetFigure);
 					category_2 = nextFigure != null ? ((CategoryFigure) nextFigure).m_category : null;
 				}
 				// prepare feedback location
@@ -674,6 +675,7 @@ public final class PaletteComposite extends Composite {
 		 */
 		private Rectangle getTitleRectangle() {
 			Rectangle r = getClientArea().getCopy();
+			translateToRelative(r);
 			r.height = m_titleHeight;
 			return r;
 		}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/part/jface/ControlDecorationEditPart.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/part/jface/ControlDecorationEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.rcp.model.jface.ControlDecorationInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 
@@ -51,7 +52,7 @@ public final class ControlDecorationEditPart extends AbstractComponentEditPart {
 	protected void refreshVisuals() {
 		Figure figure = getFigure();
 		Figure controlFigure = getControlFigure();
-		Figure controlParentFigure = controlFigure.getParent();
+		IFigure controlParentFigure = controlFigure.getParent();
 		// ensure that decoration is located on _parent_ of Control
 		if (figure.getParent() != controlParentFigure) {
 			m_originalControlFigure = controlFigure;

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/rcp/perspective/AbstractPartSelectionEditPolicy.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/rcp/perspective/AbstractPartSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,6 +25,7 @@ import org.eclipse.wb.internal.rcp.model.rcp.perspective.SashLineInfo;
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Cursors;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
@@ -85,7 +86,7 @@ public final class AbstractPartSelectionEditPolicy extends SelectionEditPolicy {
 				bounds.expand(0, 6);
 			}
 			// set bounds relative to layer
-			Figure pageFigure = getHostFigure().getParent();
+			IFigure pageFigure = getHostFigure().getParent();
 			FigureUtils.translateFigureToAbsolute2(pageFigure, bounds);
 			target.setBounds(bounds);
 		}) {

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigurePaintingTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigurePaintingTest.java
@@ -95,7 +95,7 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		// check reset state during add child figure with empty bounds
 		testFigure.add(new Figure());
 		expectedLogger.log("invalidate");
-		expectedLogger.log("repaint(10, 11, 0, 0)");
+		expectedLogger.log("repaint(0, 0, 0, 0)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check reset state during add(Figure) child figure with not empty bounds
@@ -103,13 +103,13 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		testChildFigure.setBounds(new Rectangle(1, 2, 3, 4));
 		testFigure.add(testChildFigure);
 		expectedLogger.log("invalidate");
-		expectedLogger.log("repaint(11, 13, 3, 4)");
+		expectedLogger.log("repaint(1, 2, 3, 4)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check reset state during add(Figure, Rectangle) child figure with not empty bounds
 		testFigure.add(new Figure(), new Rectangle(1, 2, 3, 4));
 		expectedLogger.log("invalidate");
-		expectedLogger.log("repaint(10, 11, 0, 0)"); // erase
+		expectedLogger.log("repaint(0, 0, 0, 0)"); // erase
 		m_actualLogger.assertEquals(expectedLogger);
 		testFigure.getLayoutManager().layout(testFigure);
 		expectedLogger.log("repaint(10, 11, 0, 0)"); // erase
@@ -119,7 +119,7 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		// check reset state during add(Figure, Rectangle, int) child figure with not empty bounds
 		testFigure.add(new Figure(), new Rectangle(1, 2, 3, 4), -1);
 		expectedLogger.log("invalidate");
-		expectedLogger.log("repaint(10, 11, 0, 0)"); // erase
+		expectedLogger.log("repaint(0, 0, 0, 0)"); // erase
 		m_actualLogger.assertEquals(expectedLogger);
 		testFigure.getLayoutManager().layout(testFigure);
 		expectedLogger.log("repaint(10, 11, 0, 0)"); // erase
@@ -140,14 +140,14 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		//
 		// check reset state during remove child figure
 		testFigure.remove(testChildFigure);
-		expectedLogger.log("invalidate");
 		expectedLogger.log("repaint(31, 28, 25, 24)");
+		expectedLogger.log("invalidate");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check reset state during remove all children figures
 		testFigure.removeAll();
+		expectedLogger.log("repaint(10, 11, 0, 0)"); // empty figure is erased
 		expectedLogger.log("invalidate");
-		expectedLogger.log("repaint(10, 11, 50, 78)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check no reset state during remove if not childrens

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigureTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigureTest.java
@@ -44,13 +44,9 @@ import java.util.List;
  *
  */
 public class FigureTest extends Draw2dFigureTestCase {
-	private static final String ERROR_MESSAGE_CYCLE =
-			"IWAG0002E Figure.add(...) Cycle created in figure heirarchy";
-	private static final String ERROR_MESSAGE_EMPTY_PARENT = "This parent is empty";
-	private static final String ERROR_MESSAGE_WRONG_PARENT =
-			"IWAG0003E Figure is not a child of this parent";
-	private static final String ERROR_MESSAGE_INVALID_INDEX =
-			"IWAG0001E Figure.add(...) invalid index";
+	private static final String ERROR_MESSAGE_CYCLE = "Figure being added introduces cycle";
+	private static final String ERROR_MESSAGE_EMPTY_PARENT = "Figure is not a child";
+	private static final String ERROR_MESSAGE_INVALID_INDEX = "Index does not exist";
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -95,9 +91,7 @@ public class FigureTest extends Draw2dFigureTestCase {
 			parentFigure.add(parentFigure);
 			fail();
 		} catch (IllegalArgumentException e) {
-			if (!ERROR_MESSAGE_CYCLE.equals(e.getMessage())) {
-				fail();
-			}
+			assertEquals(ERROR_MESSAGE_CYCLE, e.getMessage());
 		}
 	}
 
@@ -146,9 +140,7 @@ public class FigureTest extends Draw2dFigureTestCase {
 			parentFigure.add(parentFigure, 2);
 			fail();
 		} catch (IllegalArgumentException e) {
-			if (!ERROR_MESSAGE_CYCLE.equals(e.getMessage())) {
-				fail();
-			}
+			assertEquals(ERROR_MESSAGE_CYCLE, e.getMessage());
 		}
 		/*
 		 * === assert wrong index ===
@@ -157,17 +149,13 @@ public class FigureTest extends Draw2dFigureTestCase {
 			parentFigure.add(new Figure(), -2);
 			fail();
 		} catch (IndexOutOfBoundsException e) {
-			if (!ERROR_MESSAGE_INVALID_INDEX.equals(e.getMessage())) {
-				fail();
-			}
+			assertEquals(ERROR_MESSAGE_INVALID_INDEX, e.getMessage());
 		}
 		try {
 			parentFigure.add(new Figure(), parentFigure.getChildren().size() + 1);
 			fail();
 		} catch (IndexOutOfBoundsException e) {
-			if (!ERROR_MESSAGE_INVALID_INDEX.equals(e.getMessage())) {
-				fail();
-			}
+			assertEquals(ERROR_MESSAGE_INVALID_INDEX, e.getMessage());
 		}
 	}
 
@@ -211,9 +199,7 @@ public class FigureTest extends Draw2dFigureTestCase {
 			parentFigure.add(parentFigure, null);
 			fail();
 		} catch (IllegalArgumentException e) {
-			if (!ERROR_MESSAGE_CYCLE.equals(e.getMessage())) {
-				fail();
-			}
+			assertEquals(ERROR_MESSAGE_CYCLE, e.getMessage());
 		}
 		/*
 		 * === assert add with bounds ===
@@ -276,9 +262,7 @@ public class FigureTest extends Draw2dFigureTestCase {
 			parentFigure.add(parentFigure, null, 2);
 			fail();
 		} catch (IllegalArgumentException e) {
-			if (!ERROR_MESSAGE_CYCLE.equals(e.getMessage())) {
-				fail();
-			}
+			assertEquals(ERROR_MESSAGE_CYCLE, e.getMessage());
 		}
 		/*
 		 * === assert wrong index ===
@@ -287,17 +271,13 @@ public class FigureTest extends Draw2dFigureTestCase {
 			parentFigure.add(new Figure(), null, -2);
 			fail();
 		} catch (IndexOutOfBoundsException e) {
-			if (!ERROR_MESSAGE_INVALID_INDEX.equals(e.getMessage())) {
-				fail();
-			}
+			assertEquals(ERROR_MESSAGE_INVALID_INDEX, e.getMessage());
 		}
 		try {
 			parentFigure.add(new Figure(), null, parentFigure.getChildren().size() + 1);
 			fail();
 		} catch (IndexOutOfBoundsException e) {
-			if (!ERROR_MESSAGE_INVALID_INDEX.equals(e.getMessage())) {
-				fail();
-			}
+			assertEquals(ERROR_MESSAGE_INVALID_INDEX, e.getMessage());
 		}
 		/*
 		 * === assert add with bounds ===
@@ -320,31 +300,20 @@ public class FigureTest extends Draw2dFigureTestCase {
 		/*
 		 * === assert remove from empty parent ===
 		 */
-		try {
-			parentFigure.remove(null);
-			fail();
-		} catch (IllegalArgumentException e) {
-			if (!ERROR_MESSAGE_EMPTY_PARENT.equals(e.getMessage())) {
-				fail();
-			}
-		}
+		assertThrows(NullPointerException.class, () -> parentFigure.remove(null));
 		//
 		try {
 			parentFigure.remove(new Figure());
 			fail();
 		} catch (IllegalArgumentException e) {
-			if (!ERROR_MESSAGE_EMPTY_PARENT.equals(e.getMessage())) {
-				fail();
-			}
+			assertEquals(ERROR_MESSAGE_EMPTY_PARENT, e.getMessage());
 		}
 		// assert remove itself
 		try {
 			parentFigure.remove(parentFigure);
 			fail();
 		} catch (IllegalArgumentException e) {
-			if (!ERROR_MESSAGE_EMPTY_PARENT.equals(e.getMessage())) {
-				fail();
-			}
+			assertEquals(ERROR_MESSAGE_EMPTY_PARENT, e.getMessage());
 		}
 		/*
 		 * === assert remove figure ===
@@ -363,9 +332,7 @@ public class FigureTest extends Draw2dFigureTestCase {
 			parentFigure.remove(childFigure);
 			fail();
 		} catch (IllegalArgumentException e) {
-			if (!ERROR_MESSAGE_WRONG_PARENT.equals(e.getMessage())) {
-				fail();
-			}
+			assertEquals(ERROR_MESSAGE_EMPTY_PARENT, e.getMessage());
 		}
 		/*
 		 * === assert remove wrong child ===
@@ -376,18 +343,14 @@ public class FigureTest extends Draw2dFigureTestCase {
 			parentFigure.remove(wrongChildFigure);
 			fail();
 		} catch (IllegalArgumentException e) {
-			if (!ERROR_MESSAGE_WRONG_PARENT.equals(e.getMessage())) {
-				fail();
-			}
+			assertEquals(ERROR_MESSAGE_EMPTY_PARENT, e.getMessage());
 		}
 		// assert remove itself
 		try {
 			parentFigure.remove(parentFigure);
 			fail();
 		} catch (IllegalArgumentException e) {
-			if (!ERROR_MESSAGE_WRONG_PARENT.equals(e.getMessage())) {
-				fail();
-			}
+			assertEquals(ERROR_MESSAGE_EMPTY_PARENT, e.getMessage());
 		}
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/RootFigureTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/RootFigureTest.java
@@ -256,8 +256,8 @@ public class RootFigureTest extends Draw2dFigureTestCase {
 		// check work removeLayer(Layer)
 		testRoot.removeLayer(layer0);
 		//
-		expectedLogger.log("invalidate");
 		expectedLogger.log("repaint(0, 0, 0, 0)");
+		expectedLogger.log("invalidate");
 		actualLogger.assertEquals(expectedLogger);
 		//
 		assertNull(layer0.getParent());
@@ -267,8 +267,8 @@ public class RootFigureTest extends Draw2dFigureTestCase {
 		// check work removeLayer(String)
 		testRoot.removeLayer("feedback");
 		//
-		expectedLogger.log("invalidate");
 		expectedLogger.log("repaint(0, 0, 0, 0)");
+		expectedLogger.log("invalidate");
 		actualLogger.assertEquals(expectedLogger);
 		//
 		assertNull(layer0.getParent());
@@ -297,8 +297,10 @@ public class RootFigureTest extends Draw2dFigureTestCase {
 		// check reset state during removeAll()
 		testRoot.removeAll();
 		//
+		expectedLogger.log("repaint(0, 0, 0, 0)");
 		expectedLogger.log("invalidate");
 		expectedLogger.log("repaint(0, 0, 0, 0)");
+		expectedLogger.log("invalidate");
 		actualLogger.assertEquals(expectedLogger);
 		//
 		assertNull(layer0.getParent());


### PR DESCRIPTION
This makes it so that the add(), remove() and setParent() methods of our Figure class match the ones defined by the GEF figure. Doing so avoids any ambiguity regarding which list a child is added to.