### PR TITLE
Set the "Dictionary" preference as part of the Oomph setup

### DIFF
--- a/setups/WindowBuilder.setup
+++ b/setups/WindowBuilder.setup
@@ -63,6 +63,14 @@
     </annotation>
     <setupTask
         xsi:type="setup:CompoundTask"
+        name="org.eclipse.jdt.ui">
+      <setupTask
+          xsi:type="setup:PreferenceTask"
+          key="/instance/org.eclipse.jdt.ui/spelling_user_dictionary"
+          value="${git.clone.windowbuilder.location/org.eclipse.wb.core/dictionary.txt}"/>
+    </setupTask>
+    <setupTask
+        xsi:type="setup:CompoundTask"
         name="org.eclipse.oomph.setup.ui">
       <setupTask
           xsi:type="setup:PreferenceTask"


### PR DESCRIPTION
The dictionary for spell-checking is located in org.eclipse.wb.core. When the workspace is created by the Oomph installer, this file should be used to avoid warnings caused by unknown technical terms.