### PR TITLE
Use new high-DPI icons for anchor actions

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/AbsoluteComplexSelectionEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/AbsoluteComplexSelectionEditPolicy.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.gef.policy.layout.absolute;
 
+import org.eclipse.wb.core.editor.constants.CoreImages;
 import org.eclipse.wb.core.gef.policy.PolicyUtils;
 import org.eclipse.wb.core.gef.policy.layout.LayoutPolicyUtils;
 import org.eclipse.wb.core.gef.policy.layout.generic.AbstractPopupFigure;
@@ -359,17 +360,17 @@ AbsoluteBasedSelectionEditPolicy<C> implements IActionImageProvider {
 			boolean isLeftAttached = isAttached(m_widget, PositionConstants.LEFT);
 			boolean isRightAttached = isAttached(m_widget, PositionConstants.RIGHT);
 			if (isLeftAttached && isRightAttached) {
-				return getActionImageDescriptor("h/both.gif");
+				return CoreImages.ALIGNMENT_H_SMALL_FILL;
 			} else if (isRightAttached) {
-				return getActionImageDescriptor("h/right.gif");
+				return CoreImages.ALIGNMENT_H_SMALL_RIGHT;
 			} else {
-				return getActionImageDescriptor("h/left.gif");
+				return CoreImages.ALIGNMENT_H_SMALL_LEFT;
 			}
 		}
 
 		@Override
 		protected void fillMenu(IMenuManager manager) {
-			new AnchorsActionsSupport(getPlacementsSupport(), AbsoluteComplexSelectionEditPolicy.this).fillAnchorsActions(
+			new AnchorsActionsSupport(getPlacementsSupport()).fillAnchorsActions(
 					manager,
 					m_widget,
 					true);
@@ -388,17 +389,17 @@ AbsoluteBasedSelectionEditPolicy<C> implements IActionImageProvider {
 			boolean isTopAttached = isAttached(m_widget, PositionConstants.TOP);
 			boolean isBottomAttached = isAttached(m_widget, PositionConstants.BOTTOM);
 			if (isTopAttached && isBottomAttached) {
-				return getActionImageDescriptor("v/both.gif");
+				return CoreImages.ALIGNMENT_V_SMALL_FILL;
 			} else if (isBottomAttached) {
-				return getActionImageDescriptor("v/bottom.gif");
+				return CoreImages.ALIGNMENT_V_SMALL_BOTTOM;
 			} else {
-				return getActionImageDescriptor("v/top.gif");
+				return CoreImages.ALIGNMENT_V_SMALL_TOP;
 			}
 		}
 
 		@Override
 		protected void fillMenu(IMenuManager manager) {
-			new AnchorsActionsSupport(getPlacementsSupport(), AbsoluteComplexSelectionEditPolicy.this).fillAnchorsActions(
+			new AnchorsActionsSupport(getPlacementsSupport()).fillAnchorsActions(
 					manager,
 					m_widget,
 					false);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/actions/AnchorsActionsSupport.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/actions/AnchorsActionsSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.gef.policy.layout.absolute.actions;
 
+import org.eclipse.wb.core.editor.constants.CoreImages;
 import org.eclipse.wb.core.model.IAbstractComponentInfo;
 import org.eclipse.wb.internal.core.gef.GefMessages;
 import org.eclipse.wb.internal.core.gef.policy.snapping.PlacementsSupport;
@@ -17,15 +18,13 @@ import org.eclipse.wb.internal.core.model.util.ObjectInfoAction;
 
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.jface.action.IContributionManager;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 public class AnchorsActionsSupport {
 	private final PlacementsSupport m_placementsSupport;
-	private final IActionImageProvider m_imageProvider;
 
-	public AnchorsActionsSupport(PlacementsSupport placementsSupport,
-			IActionImageProvider imageProvider) {
+	public AnchorsActionsSupport(PlacementsSupport placementsSupport) {
 		m_placementsSupport = placementsSupport;
-		m_imageProvider = imageProvider;
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -39,28 +38,28 @@ public class AnchorsActionsSupport {
 		if (isHorizontal) {
 			manager.add(new SetAlignmentAction(widget,
 					GefMessages.AnchorsActionsSupport_leftAlignment,
-					"h/menu/left.gif",
+					CoreImages.ALIGNMENT_H_MENU_LEFT,
 					PositionConstants.LEFT));
 			manager.add(new SetAlignmentAction(widget,
 					GefMessages.AnchorsActionsSupport_rightAlignment,
-					"h/menu/right.gif",
+					CoreImages.ALIGNMENT_H_MENU_RIGHT,
 					PositionConstants.RIGHT));
 			manager.add(new MakeResizeableAction(widget,
 					GefMessages.AnchorsActionsSupport_makeResizableHorizontal,
-					"h/menu/both.gif",
+					CoreImages.ALIGNMENT_H_MENU_FILL,
 					isHorizontal));
 		} else {
 			manager.add(new SetAlignmentAction(widget,
 					GefMessages.AnchorsActionsSupport_topAlignment,
-					"v/menu/top.gif",
+					CoreImages.ALIGNMENT_V_MENU_TOP,
 					PositionConstants.TOP));
 			manager.add(new SetAlignmentAction(widget,
 					GefMessages.AnchorsActionsSupport_bottomAlignment,
-					"v/menu/bottom.gif",
+					CoreImages.ALIGNMENT_V_MENU_BOTTOM,
 					PositionConstants.BOTTOM));
 			manager.add(new MakeResizeableAction(widget,
 					GefMessages.AnchorsActionsSupport_makeResizableVertical,
-					"v/menu/both.gif",
+					CoreImages.ALIGNMENT_V_MENU_FILL,
 					isHorizontal));
 		}
 	}
@@ -71,9 +70,9 @@ public class AnchorsActionsSupport {
 
 		private SetAlignmentAction(IAbstractComponentInfo widget,
 				String text,
-				String imageName,
+				ImageDescriptor icon,
 				int alignment) {
-			super(widget.getUnderlyingModel(), text, m_imageProvider.getActionImageDescriptor(imageName));
+			super(widget.getUnderlyingModel(), text, icon);
 			m_widget = widget;
 			m_alignment = alignment;
 		}
@@ -89,9 +88,9 @@ public class AnchorsActionsSupport {
 
 		private MakeResizeableAction(IAbstractComponentInfo widget,
 				String text,
-				String imageName,
+				ImageDescriptor icon,
 				boolean isHorizontal) {
-			super(widget.getUnderlyingModel(), text, m_imageProvider.getActionImageDescriptor(imageName));
+			super(widget.getUnderlyingModel(), text, icon);
 			m_widget = widget;
 			m_isHorizontal = isHorizontal;
 		}

--- a/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/gef/GroupSelectionEditPolicy2.java
+++ b/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/gef/GroupSelectionEditPolicy2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.layout.group.gef;
 
+import org.eclipse.wb.core.editor.constants.CoreImages;
 import org.eclipse.wb.core.gef.command.EditCommand;
 import org.eclipse.wb.core.gef.policy.PolicyUtils;
 import org.eclipse.wb.core.gef.policy.layout.LayoutPolicyUtils;
@@ -29,7 +30,6 @@ import org.eclipse.wb.gef.graphical.policies.SelectionEditPolicy;
 import org.eclipse.wb.gef.graphical.tools.ResizeTracker;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.gef.policy.layout.absolute.AbsolutePolicyUtils;
-import org.eclipse.wb.internal.core.model.layout.absolute.IImageProvider;
 import org.eclipse.wb.internal.layout.group.model.AnchorsSupport;
 import org.eclipse.wb.internal.layout.group.model.GroupLayoutUtils;
 import org.eclipse.wb.internal.layout.group.model.IGroupLayoutInfo;
@@ -413,16 +413,15 @@ LayoutConstants {
 		@Override
 		protected ImageDescriptor getImageDescriptor() {
 			int anchors = m_anchorsSupport.getCurrentAnchors(m_component, true);
-			IImageProvider imageProvider = getImageProvider();
 			switch (anchors) {
 			case AnchorsSupport.RESIZABLE :
-				return imageProvider.getImageDescriptor("info/layout/groupLayout/h/both.gif");
+				return CoreImages.ALIGNMENT_H_SMALL_FILL;
 			case LEADING :
-				return imageProvider.getImageDescriptor("info/layout/groupLayout/h/left.gif");
+				return CoreImages.ALIGNMENT_H_SMALL_LEFT;
 			case TRAILING :
-				return imageProvider.getImageDescriptor("info/layout/groupLayout/h/right.gif");
+				return CoreImages.ALIGNMENT_H_SMALL_RIGHT;
 			default :
-				return imageProvider.getImageDescriptor("info/layout/groupLayout/h/default.gif");
+				return CoreImages.ALIGNMENT_H_SMALL_DEFAULT;
 			}
 		}
 
@@ -442,16 +441,15 @@ LayoutConstants {
 		@Override
 		protected ImageDescriptor getImageDescriptor() {
 			int anchors = m_anchorsSupport.getCurrentAnchors(m_component, false);
-			IImageProvider imageProvider = getImageProvider();
 			switch (anchors) {
 			case AnchorsSupport.RESIZABLE :
-				return imageProvider.getImageDescriptor("info/layout/groupLayout/v/both.gif");
+				return CoreImages.ALIGNMENT_V_SMALL_FILL;
 			case LEADING :
-				return imageProvider.getImageDescriptor("info/layout/groupLayout/v/top.gif");
+				return CoreImages.ALIGNMENT_V_SMALL_TOP;
 			case TRAILING :
-				return imageProvider.getImageDescriptor("info/layout/groupLayout/v/bottom.gif");
+				return CoreImages.ALIGNMENT_V_SMALL_BOTTOM;
 			default :
-				return imageProvider.getImageDescriptor("info/layout/groupLayout/v/default.gif");
+				return CoreImages.ALIGNMENT_V_SMALL_DEFAULT;
 			}
 		}
 
@@ -459,14 +457,5 @@ LayoutConstants {
 		protected void fillMenu(IMenuManager manager) {
 			m_anchorsSupport.fillContributionManager(m_component, manager, false);
 		}
-	}
-
-	////////////////////////////////////////////////////////////////////////////
-	//
-	// Misc
-	//
-	////////////////////////////////////////////////////////////////////////////
-	private IImageProvider getImageProvider() {
-		return m_layout.getAdapter(IImageProvider.class);
 	}
 }

--- a/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/model/AnchorsSupport.java
+++ b/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/model/AnchorsSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,14 +11,15 @@
 package org.eclipse.wb.internal.layout.group.model;
 
 import org.eclipse.wb.core.editor.IContextMenuConstants;
+import org.eclipse.wb.core.editor.constants.CoreImages;
 import org.eclipse.wb.core.model.AbstractComponentInfo;
-import org.eclipse.wb.internal.core.model.layout.absolute.IImageProvider;
 import org.eclipse.wb.internal.core.model.util.ObjectInfoAction;
 import org.eclipse.wb.internal.layout.group.Messages;
 
 import org.eclipse.jface.action.IContributionManager;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
+import org.eclipse.jface.resource.ImageDescriptor;
 
 import org.netbeans.modules.form.layoutdesign.LayoutComponent;
 import org.netbeans.modules.form.layoutdesign.LayoutConstants;
@@ -54,33 +55,33 @@ public final class AnchorsSupport implements LayoutConstants {
 			anchorsManager.add(
 					new SetAnchorAction(component,
 							Messages.AnchorsSupport_anchorLeft,
-							"h/menu/left.gif",
+							CoreImages.ALIGNMENT_H_MENU_LEFT,
 							true,
 							LEADING));
 			anchorsManager.add(
 					new SetAnchorAction(component,
 							Messages.AnchorsSupport_anchorRight,
-							"h/menu/right.gif",
+							CoreImages.ALIGNMENT_H_MENU_RIGHT,
 							true,
 							TRAILING));
 			anchorsManager.add(
 					new SetAnchorAction(component,
 							Messages.AnchorsSupport_anchorTop,
-							"v/menu/top.gif",
+							CoreImages.ALIGNMENT_V_MENU_TOP,
 							false,
 							LEADING));
 			anchorsManager.add(
 					new SetAnchorAction(component,
 							Messages.AnchorsSupport_anchorBottom,
-							"v/menu/bottom.gif",
+							CoreImages.ALIGNMENT_V_MENU_BOTTOM,
 							false,
 							TRAILING));
 		}
 		{
 			IMenuManager autoResigingManager = new MenuManager(Messages.AnchorsSupport_autoResizeMenu);
 			manager.appendToGroup(IContextMenuConstants.GROUP_CONSTRAINTS, autoResigingManager);
-			autoResigingManager.add(new ToggleResizeableAction(component, "h/menu/both.gif", true));
-			autoResigingManager.add(new ToggleResizeableAction(component, "v/menu/both.gif", false));
+			autoResigingManager.add(new ToggleResizeableAction(component, CoreImages.ALIGNMENT_H_MENU_FILL, true));
+			autoResigingManager.add(new ToggleResizeableAction(component, CoreImages.ALIGNMENT_V_MENU_FILL, false));
 		}
 	}
 
@@ -91,30 +92,30 @@ public final class AnchorsSupport implements LayoutConstants {
 			manager.add(
 					new SetAnchorAction(component,
 							Messages.AnchorsSupport_anchoredLeft,
-							"h/menu/left.gif",
+							CoreImages.ALIGNMENT_H_MENU_LEFT,
 							true,
 							LEADING));
 			manager.add(
 					new SetAnchorAction(component,
 							Messages.AnchorsSupport_anchoredRight,
-							"h/menu/right.gif",
+							CoreImages.ALIGNMENT_H_MENU_RIGHT,
 							true,
 							TRAILING));
-			manager.add(new MakeResizeableAction(component, "h/menu/both.gif", isHorizontal));
+			manager.add(new MakeResizeableAction(component, CoreImages.ALIGNMENT_H_MENU_FILL, isHorizontal));
 		} else {
 			manager.add(
 					new SetAnchorAction(component,
 							Messages.AnchorsSupport_anchoredTop,
-							"v/menu/top.gif",
+							CoreImages.ALIGNMENT_V_MENU_TOP,
 							false,
 							LEADING));
 			manager.add(
 					new SetAnchorAction(component,
 							Messages.AnchorsSupport_anchoredBottom,
-							"v/menu/bottom.gif",
+							CoreImages.ALIGNMENT_V_MENU_BOTTOM,
 							false,
 							TRAILING));
-			manager.add(new MakeResizeableAction(component, "v/menu/both.gif", isHorizontal));
+			manager.add(new MakeResizeableAction(component, CoreImages.ALIGNMENT_V_MENU_FILL, isHorizontal));
 		}
 	}
 
@@ -255,12 +256,12 @@ public final class AnchorsSupport implements LayoutConstants {
 
 		private SetAnchorAction(AbstractComponentInfo component,
 				String text,
-				String imageName,
+				ImageDescriptor icon,
 				boolean isHorizontal,
 				int alignment) {
 			super(component,
 					text,
-					getImageProvider().getImageDescriptor("info/layout/groupLayout/" + imageName),
+					icon,
 					AS_CHECK_BOX);
 			m_isHorizontal = isHorizontal;
 			m_component = component;
@@ -287,11 +288,11 @@ public final class AnchorsSupport implements LayoutConstants {
 		private final boolean m_alreadySet;
 
 		private MakeResizeableAction(AbstractComponentInfo component,
-				String imageName,
+				ImageDescriptor icon,
 				boolean isHorizontal) {
 			super(component,
 					Messages.AnchorsSupport_autoResizable,
-					getImageProvider().getImageDescriptor("info/layout/groupLayout/" + imageName),
+					icon,
 					AS_CHECK_BOX);
 			m_component = component;
 			m_isHorizontal = isHorizontal;
@@ -316,13 +317,13 @@ public final class AnchorsSupport implements LayoutConstants {
 		private final AbstractComponentInfo m_component;
 
 		private ToggleResizeableAction(AbstractComponentInfo component,
-				String imageName,
+				ImageDescriptor icon,
 				boolean isHorizontal) {
 			super(component,
 					isHorizontal
 					? Messages.AnchorsSupport_resizableHorizontal
 							: Messages.AnchorsSupport_resizableVertical,
-							getImageProvider().getImageDescriptor("info/layout/groupLayout/" + imageName),
+							icon,
 							AS_CHECK_BOX);
 			m_component = component;
 			m_isHorizontal = isHorizontal;
@@ -337,14 +338,5 @@ public final class AnchorsSupport implements LayoutConstants {
 					m_isHorizontal,
 					!isComponentResizable(m_component, m_isHorizontal));
 		}
-	}
-
-	////////////////////////////////////////////////////////////////////////////
-	//
-	// Misc
-	//
-	////////////////////////////////////////////////////////////////////////////
-	private IImageProvider getImageProvider() {
-		return m_layout.getAdapter(IImageProvider.class);
 	}
 }

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/LayoutAssistantPage.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/LayoutAssistantPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -127,11 +127,11 @@ ILayoutAssistantPage {
 	////////////////////////////////////////////////////////////////////////////
 	private void fillAnchorsActions(IContributionManager manager) {
 		C widget = m_selection.size() == 1 ? (C) m_selection.get(0) : null;
-		new AnchorsActionsSupport(m_placementsSupport, m_imageProvider).fillAnchorsActions(
+		new AnchorsActionsSupport(m_placementsSupport).fillAnchorsActions(
 				manager,
 				widget,
 				false);
-		new AnchorsActionsSupport(m_placementsSupport, m_imageProvider).fillAnchorsActions(
+		new AnchorsActionsSupport(m_placementsSupport).fillAnchorsActions(
 				manager,
 				widget,
 				true);


### PR DESCRIPTION
With this, bundles no longer need to contribute the actions icon on their own and instead, the images contributed via the CoreImages are used.