### PR TITLE
[Draw2D] Add support for layout managers to figures

### DIFF
--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
@@ -156,8 +156,8 @@ public class Figure extends org.eclipse.draw2d.Figure {
 		// notify child of change
 		childFigure.addNotify();
 		// set bounds
-		if (bounds != null) {
-			childFigure.setBounds(bounds);
+		if (getLayoutManager() != null) {
+			getLayoutManager().setConstraint(childFigure, bounds);
 		}
 		// notify of change
 		resetState(childFigure);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/JustifyPaletteTooltipProvider.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/JustifyPaletteTooltipProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -74,16 +74,18 @@ public final class JustifyPaletteTooltipProvider extends CustomTooltipProvider {
 				detailsSize.width = headerSize.width + 10;
 			}
 		}
-		// create container figure
-		Figure tooltipFigure = new Figure();
-		tooltipFigure.add(headerFigure, new Rectangle(detailsSize.width / 2 - headerSize.width / 2,
+		headerFigure.setBounds(new Rectangle(detailsSize.width / 2 - headerSize.width / 2,
 				0,
 				headerSize.width,
 				headerSize.height));
-		tooltipFigure.add(detailsFigure, new Rectangle(0,
+		detailsFigure.setBounds(new Rectangle(0,
 				headerSize.height,
 				detailsSize.width,
 				detailsSize.height));
+		// create container figure
+		Figure tooltipFigure = new Figure();
+		tooltipFigure.add(headerFigure);
+		tooltipFigure.add(detailsFigure);
 		tooltipFigure.setBounds(new Rectangle(0, 0, detailsSize.width, headerSize.height
 				+ detailsSize.height));
 		//

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/figure/OutlineImageFigure.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/figure/OutlineImageFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ import org.eclipse.wb.draw2d.Figure;
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Image;
 
@@ -40,8 +41,15 @@ public final class OutlineImageFigure extends Figure {
 	}
 
 	public OutlineImageFigure(Image image, Color borderColor) {
+		this(image, borderColor, null);
+	}
+
+	public OutlineImageFigure(Image image, Color borderColor, Rectangle bounds) {
 		m_image = image;
 		setForegroundColor(borderColor);
+		if (bounds != null) {
+			setBounds(bounds);
+		}
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/AbsoluteBasedLayoutEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/AbsoluteBasedLayoutEditPolicy.java
@@ -395,7 +395,7 @@ IPreferenceConstants {
 				modelList.add(model);
 				//
 				m_moveFeedback.add(new OutlineImageFigure(model.getImage(),
-						AbsolutePolicyUtils.COLOR_OUTLINE), bounds);
+						AbsolutePolicyUtils.COLOR_OUTLINE, bounds));
 			}
 			//
 			List<Figure> moveFeedbackFigures = m_moveFeedback.getChildren();
@@ -500,7 +500,7 @@ IPreferenceConstants {
 				modelList.add(model);
 				//
 				m_resizeFeedback.add(new OutlineImageFigure(model.getImage(),
-						AbsolutePolicyUtils.COLOR_OUTLINE), bounds);
+						AbsolutePolicyUtils.COLOR_OUTLINE, bounds));
 			}
 			//
 			List<Figure> moveFeedbackFigures = m_resizeFeedback.getChildren();
@@ -749,7 +749,7 @@ IPreferenceConstants {
 							new Rectangle(bounds.x - offsetX, bounds.y - offsetY, bounds.width, bounds.height);
 					widgetBounds.union(relativeBounds[i]);
 					m_createFeedback.add(new OutlineImageFigure(pastedComponent.getComponent().getImage(),
-							AbsolutePolicyUtils.COLOR_OUTLINE), relativeBounds[i]);
+							AbsolutePolicyUtils.COLOR_OUTLINE, relativeBounds[i]));
 					pastedComponent.setBounds(relativeBounds[i]);
 					i++;
 				}

--- a/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/gef/GroupLayoutEditPolicy2.java
+++ b/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/gef/GroupLayoutEditPolicy2.java
@@ -260,8 +260,8 @@ public abstract class GroupLayoutEditPolicy2 extends LayoutEditPolicy implements
 				for (EditPart editPart : editParts) {
 					AbstractComponentInfo model = (AbstractComponentInfo) editPart.getModel();
 					Rectangle bounds = ((GraphicalEditPart) editPart).getFigure().getBounds();
-					m_dragFeedback.add(new OutlineImageFigure(model.getImage(), AbsolutePolicyUtils.COLOR_OUTLINE),
-							bounds);
+					m_dragFeedback.add(new OutlineImageFigure(model.getImage(), AbsolutePolicyUtils.COLOR_OUTLINE,
+							bounds));
 				}
 				// set bounds of nested figures
 				List<Figure> moveFeedbackFigures = m_dragFeedback.getChildren();
@@ -329,8 +329,8 @@ public abstract class GroupLayoutEditPolicy2 extends LayoutEditPolicy implements
 				for (EditPart editPart : editParts) {
 					AbstractComponentInfo model = (AbstractComponentInfo) editPart.getModel();
 					Rectangle bounds = ((GraphicalEditPart) editPart).getFigure().getBounds();
-					m_dragFeedback.add(new OutlineImageFigure(model.getImage(), AbsolutePolicyUtils.COLOR_OUTLINE),
-							bounds);
+					m_dragFeedback.add(new OutlineImageFigure(model.getImage(), AbsolutePolicyUtils.COLOR_OUTLINE,
+							bounds));
 				}
 				//
 				List<Figure> moveFeedbackFigures = m_dragFeedback.getChildren();
@@ -406,8 +406,8 @@ public abstract class GroupLayoutEditPolicy2 extends LayoutEditPolicy implements
 					java.awt.Rectangle bounds = GroupLayoutUtils.getBoundsInLayout(m_layout, model);
 					movingBounds[i] = new java.awt.Rectangle(bounds.x - offsetX, bounds.y - offsetY, bounds.width,
 							bounds.height);
-					m_dragFeedback.add(new OutlineImageFigure(model.getImage(), AbsolutePolicyUtils.COLOR_OUTLINE),
-							GroupLayoutUtils.get(movingBounds[i]));
+					m_dragFeedback.add(new OutlineImageFigure(model.getImage(), AbsolutePolicyUtils.COLOR_OUTLINE,
+							GroupLayoutUtils.get(movingBounds[i])));
 					// prepare bounds for dragging
 					movedBounds[i] = new java.awt.Rectangle();
 					movedBounds[i].width = movingBounds[i].width;

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormLayoutEditPolicy2.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormLayoutEditPolicy2.java
@@ -270,7 +270,7 @@ IHeadersProvider {
 				modelList.add(model);
 				//
 				m_moveFeedback.add(new OutlineImageFigure(model.getImage(),
-						AbsolutePolicyUtils.COLOR_OUTLINE), bounds);
+						AbsolutePolicyUtils.COLOR_OUTLINE, bounds));
 			}
 			//
 			List<Figure> moveFeedbackFigures = m_moveFeedback.getChildren();

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormLayoutEditPolicyClassic.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormLayoutEditPolicyClassic.java
@@ -511,8 +511,8 @@ implements IHeadersProvider {
 				relativeBounds[i] = new Rectangle(modelBounds.x - offsetX, modelBounds.y - offsetY, modelBounds.width,
 						modelBounds.height);
 				bounds.union(relativeBounds[i]);
-				moveFeedback.add(new OutlineImageFigure(control.getImage(), AbsolutePolicyUtils.COLOR_OUTLINE),
-						relativeBounds[i]);
+				moveFeedback.add(new OutlineImageFigure(control.getImage(), AbsolutePolicyUtils.COLOR_OUTLINE,
+						relativeBounds[i]));
 			}
 		} else {
 			C model = getControlFromList(pastingComponents, 0);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigureEventTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigureEventTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -73,14 +73,16 @@ public class FigureEventTest extends Draw2dFigureTestCase {
 				return "figure11";
 			}
 		};
-		layer1.add(figure11, new Rectangle(10, 10, 200, 150));
+		figure11.setBounds(new Rectangle(10, 10, 200, 150));
+		layer1.add(figure11);
 		Figure figure12 = new Figure() {
 			@Override
 			public String toString() {
 				return "figure12";
 			}
 		};
-		layer1.add(figure12, new Rectangle(400, 300, 50, 70));
+		figure12.setBounds(new Rectangle(400, 300, 50, 70));
+		layer1.add(figure12);
 		//
 		Layer layer2 = new Layer("2");
 		Figure figure21 = new Figure() {
@@ -89,14 +91,16 @@ public class FigureEventTest extends Draw2dFigureTestCase {
 				return "figure21";
 			}
 		};
-		layer2.add(figure21, new Rectangle(50, 50, 90, 60));
+		figure21.setBounds(new Rectangle(50, 50, 90, 60));
+		layer2.add(figure21);
 		Figure figure22 = new Figure() {
 			@Override
 			public String toString() {
 				return "figure22";
 			}
 		};
-		layer2.add(figure22, new Rectangle(150, 250, 190, 120));
+		figure22.setBounds(new Rectangle(150, 250, 190, 120));
+		layer2.add(figure22);
 		//
 		TestLogger actualLogger = new TestLogger();
 		//

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigurePaintingTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigurePaintingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ import org.eclipse.wb.draw2d.border.LineBorder;
 import org.eclipse.wb.tests.gef.TestLogger;
 
 import org.eclipse.draw2d.Cursors;
+import org.eclipse.draw2d.XYLayout;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -55,7 +56,9 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 
 	private Figure addFigure(int x, int y, int width, int height) {
 		Figure figure = new Figure();
-		m_root.add(figure, new Rectangle(x, y, width, height));
+		figure.setBounds(new Rectangle(x, y, width, height));
+		figure.setLayoutManager(new XYLayout());
+		m_root.add(figure);
 		m_actualLogger.clear();
 		return figure;
 	}
@@ -105,18 +108,22 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		//
 		// check reset state during add(Figure, Rectangle) child figure with not empty bounds
 		testFigure.add(new Figure(), new Rectangle(1, 2, 3, 4));
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(10, 11, 0, 0)"); // erase
+		m_actualLogger.assertEquals(expectedLogger);
+		testFigure.getLayoutManager().layout(testFigure);
 		expectedLogger.log("repaint(10, 11, 0, 0)"); // erase
 		expectedLogger.log("repaint(1, 2, 3, 4)");
-		expectedLogger.log("invalidate");
-		expectedLogger.log("repaint(11, 13, 3, 4)");
 		m_actualLogger.assertEquals(expectedLogger);
 		//
 		// check reset state during add(Figure, Rectangle, int) child figure with not empty bounds
 		testFigure.add(new Figure(), new Rectangle(1, 2, 3, 4), -1);
+		expectedLogger.log("invalidate");
+		expectedLogger.log("repaint(10, 11, 0, 0)"); // erase
+		m_actualLogger.assertEquals(expectedLogger);
+		testFigure.getLayoutManager().layout(testFigure);
 		expectedLogger.log("repaint(10, 11, 0, 0)"); // erase
 		expectedLogger.log("repaint(1, 2, 3, 4)");
-		expectedLogger.log("invalidate");
-		expectedLogger.log("repaint(11, 13, 3, 4)");
 		m_actualLogger.assertEquals(expectedLogger);
 	}
 
@@ -128,6 +135,7 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 		Figure testChildFigure = new Figure();
 		testFigure.add(testChildFigure, new Rectangle(21, 17, 25, 24));
 		testFigure.add(new Figure());
+		testFigure.getLayoutManager().layout(testFigure);
 		m_actualLogger.clear();
 		//
 		// check reset state during remove child figure

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigureTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigureTest.java
@@ -23,6 +23,7 @@ import org.eclipse.draw2d.FigureListener;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.MouseListener;
 import org.eclipse.draw2d.MouseMotionListener;
+import org.eclipse.draw2d.XYLayout;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Point;
@@ -173,6 +174,7 @@ public class FigureTest extends Draw2dFigureTestCase {
 	@Test
 	public void test_add_Figure_Rectangle() throws Exception {
 		Figure parentFigure = new Figure();
+		parentFigure.setLayoutManager(new XYLayout());
 		/*
 		 * === assert add figure's ===
 		 */
@@ -225,12 +227,13 @@ public class FigureTest extends Draw2dFigureTestCase {
 		// assert set bounds during add(...)
 		Figure childFigure3 = new Figure();
 		parentFigure.add(childFigure3, bounds);
-		assertEquals(bounds, childFigure3.getBounds());
+		assertEquals(bounds, parentFigure.getLayoutManager().getConstraint(childFigure3));
 	}
 
 	@Test
 	public void test_add_Figure_Rectangle_int() throws Exception {
 		Figure parentFigure = new Figure();
+		parentFigure.setLayoutManager(new XYLayout());
 		/*
 		 * === assert add figure's ===
 		 */
@@ -308,7 +311,7 @@ public class FigureTest extends Draw2dFigureTestCase {
 		// assert set bounds during add(...)
 		Figure childFigure4 = new Figure();
 		parentFigure.add(childFigure4, bounds, 0);
-		assertEquals(bounds, childFigure4.getBounds());
+		assertEquals(bounds, parentFigure.getLayoutManager().getConstraint(childFigure4));
 	}
 
 	@Test

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/LayerTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/LayerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -106,7 +106,8 @@ public class LayerTest extends Draw2dFigureTestCase {
 	public void test_containsPoint() throws Exception {
 		Layer layer = new Layer("test");
 		Figure figure = new Figure();
-		layer.add(figure, new Rectangle(10, 10, 100, 100));
+		figure.setBounds(new Rectangle(10, 10, 100, 100));
+		layer.add(figure);
 		layer.setBounds(new Rectangle(0, 0, 200, 200));
 		//
 		// check contains point (0, 0)

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/RootFigureTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/RootFigureTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -56,12 +56,14 @@ public class RootFigureTest extends Draw2dFigureTestCase {
 		//
 		Layer layer0 = new Layer("Main");
 		Figure figure0 = new Figure();
-		layer0.add(figure0, new Rectangle(10, 10, 100, 200));
+		figure0.setBounds(new Rectangle(10, 10, 100, 200));
+		layer0.add(figure0);
 		testRoot.addLayer(layer0);
 		//
 		Layer layer1 = new Layer("Feedback");
 		Figure figure1 = new Figure();
-		layer1.add(figure1, new Rectangle(50, 70, 120, 90));
+		figure1.setBounds(new Rectangle(50, 70, 120, 90));
+		layer1.add(figure1);
 		testRoot.addLayer(layer1);
 		//
 		actualLogger.clear();


### PR DESCRIPTION
When adding a figure, one can currently only specify its bounds as additional argument. Normally, this constraints may be arbitrary (e.g. GridData for the GridLayout or a Rectangle for the XYLayout).

This argument is therefore simply passed to the layout manager (if present) instead being treated as the figure bounds. As a result, all references (which luckily only includes instances there the OutlineImageFigure is used) have been updated so that the bounds are explicitly set by calling setBounds(), rather than implicitly via add().

One could've achieved a similar effect by using the XYLayout. However, this would then only update the bounds during the re-layout and has been avoided to remain as close to the previous behavior as possible.