### PR TITLE
[Draw2D] Fix potential deadlock in palette when using layout manager

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -308,17 +308,6 @@ public final class PaletteComposite extends Composite {
 
 		////////////////////////////////////////////////////////////////////////////
 		//
-		// Figure
-		//
-		////////////////////////////////////////////////////////////////////////////
-		@Override
-		public void setBounds(Rectangle bounds) {
-			super.setBounds(bounds);
-			layout();
-		}
-
-		////////////////////////////////////////////////////////////////////////////
-		//
 		// Internal
 		//
 		////////////////////////////////////////////////////////////////////////////
@@ -330,6 +319,7 @@ public final class PaletteComposite extends Composite {
 				CategoryFigure categoryFigure = (CategoryFigure) I.next();
 				categoryFigure.onPreferencesUpdate();
 			}
+			revalidate();
 			layout();
 		}
 
@@ -346,7 +336,6 @@ public final class PaletteComposite extends Composite {
 				CategoryFigure categoryFigure = (CategoryFigure) I.next();
 				y += categoryFigure.layout(y, width);
 			}
-			revalidate();
 		}
 	}
 	////////////////////////////////////////////////////////////////////////////
@@ -453,6 +442,7 @@ public final class PaletteComposite extends Composite {
 							}
 						} else if (m_mouseOnTitle) {
 							m_category.setOpen(!m_category.isOpen());
+							m_paletteFigure.revalidate();
 							m_paletteFigure.layout();
 						}
 					}


### PR DESCRIPTION
In order to respond to size-changes in the palette when e.g. a container has been opened, we perform a re-layout whenever setBounds() is called. When a layout manager is set within a figure, this setBounds() method may also be called while performing the re-layout, leading to an infinite, recursive loop.

To avoid this, a revalidation is only done, after a category has been expanded/collapsed, or if the palette preferences have been updated.