### PR TITLE
[Draw2D] Remove explicit type cast in Figure.getChildren()

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/part/DesignRootEditPart.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/part/DesignRootEditPart.java
@@ -169,7 +169,7 @@ public final class DesignRootEditPart extends GraphicalEditPart {
 		@Override
 		public Dimension getPreferredSize(Dimension originalPreferredSize) {
 			Rectangle preferred = new Rectangle();
-			for (Figure figure : getChildren()) {
+			for (IFigure figure : getChildren()) {
 				if (figure.isVisible()) {
 					preferred.union(figure.getBounds());
 				}

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
@@ -15,6 +15,7 @@ import org.eclipse.wb.internal.draw2d.FigureVisitor;
 import org.eclipse.wb.internal.draw2d.ICustomTooltipProvider;
 
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Rectangle;
 
@@ -55,7 +56,8 @@ public class Figure extends org.eclipse.draw2d.Figure {
 	 */
 	public final void accept(FigureVisitor visitor, boolean forward) {
 		if (visitor.visit(this)) {
-			List<Figure> children = getChildren();
+			@SuppressWarnings("unchecked")
+			List<Figure> children = (List<Figure>) getChildren();
 			int size = children.size();
 			//
 			if (forward) {
@@ -78,15 +80,6 @@ public class Figure extends org.eclipse.draw2d.Figure {
 	// Parent/Children
 	//
 	////////////////////////////////////////////////////////////////////////////
-
-	/**
-	 * @return the {@link List} of children {@link Figure}'s.
-	 */
-	@Override
-	@SuppressWarnings("unchecked")
-	public List<Figure> getChildren() {
-		return (List<Figure>) super.getChildren();
-	}
 
 	/**
 	 * @return the {@link FigureCanvas} that contains this {@link Figure}.
@@ -149,7 +142,7 @@ public class Figure extends org.eclipse.draw2d.Figure {
 
 	@Override
 	protected void paintChildren(Graphics graphics) {
-		List<Figure> children = getChildren();
+		List<? extends IFigure> children = getChildren();
 		if (children.isEmpty()) {
 			return;
 		}
@@ -158,7 +151,7 @@ public class Figure extends org.eclipse.draw2d.Figure {
 		graphics.translate(insets.left, insets.top);
 		graphics.pushState();
 		// paint all
-		for (Figure childFigure : children) {
+		for (IFigure childFigure : children) {
 			if (childFigure.isVisible() && childFigure.intersects(graphics.getClip(new Rectangle()))) {
 				Rectangle childBounds = childFigure.getBounds();
 				graphics.clipRect(childBounds);

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Layer.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Layer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@ package org.eclipse.wb.draw2d;
 
 import org.eclipse.wb.internal.draw2d.IRootFigure;
 
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Rectangle;
 
 /**
@@ -51,7 +52,7 @@ public class Layer extends Figure {
 	 */
 	@Override
 	public boolean containsPoint(int x, int y) {
-		for (Figure childFigure : getChildren()) {
+		for (IFigure childFigure : getChildren()) {
 			if (childFigure.containsPoint(x, y)) {
 				return true;
 			}

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/RootFigure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/RootFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ import org.eclipse.wb.draw2d.Layer;
 
 import org.eclipse.draw2d.DeferredUpdateManager;
 import org.eclipse.draw2d.EventDispatcher;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.UpdateListener;
 import org.eclipse.draw2d.UpdateManager;
 import org.eclipse.draw2d.geometry.Dimension;
@@ -120,7 +121,7 @@ public class RootFigure extends Figure implements IRootFigure {
 			// layer's loop
 			for (Layer layer : getLayers()) {
 				// figure's loop
-				for (Figure figure : layer.getChildren()) {
+				for (IFigure figure : layer.getChildren()) {
 					if (figure.isVisible()) {
 						if (figure instanceof IPreferredSizeProvider provider) {
 							Dimension figurePreferredSize = provider.getPreferredSize(null);
@@ -207,7 +208,7 @@ public class RootFigure extends Figure implements IRootFigure {
 	@Override
 	public List<Layer> getLayers() {
 		List<Layer> layers = new ArrayList<>();
-		for (Figure childFigure : getChildren()) {
+		for (IFigure childFigure : getChildren()) {
 			layers.add((Layer) childFigure);
 		}
 		return layers;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
@@ -316,7 +316,7 @@ public final class PaletteComposite extends Composite {
 		 * This method is invoked when {@link IPalettePreferences} changes.
 		 */
 		private void onPreferencesUpdate() {
-			for (Iterator<Figure> I = getChildren().iterator(); I.hasNext();) {
+			for (Iterator<? extends IFigure> I = getChildren().iterator(); I.hasNext();) {
 				CategoryFigure categoryFigure = (CategoryFigure) I.next();
 				categoryFigure.onPreferencesUpdate();
 			}
@@ -333,7 +333,7 @@ public final class PaletteComposite extends Composite {
 			width -= getInsets().getWidth();
 			//
 			int y = 0;
-			for (Iterator<Figure> I = getChildren().iterator(); I.hasNext();) {
+			for (Iterator<? extends IFigure> I = getChildren().iterator(); I.hasNext();) {
 				CategoryFigure categoryFigure = (CategoryFigure) I.next();
 				y += categoryFigure.layout(y, width);
 			}
@@ -394,7 +394,7 @@ public final class PaletteComposite extends Composite {
 		public void onPreferencesUpdate() {
 			FontDescriptor fontDescriptor = m_preferences.getCategoryFontDescriptor();
 			setFont(fontDescriptor == null ? null : m_resourceManager.createFont(fontDescriptor));
-			for (Iterator<Figure> I = getChildren().iterator(); I.hasNext();) {
+			for (Iterator<? extends IFigure> I = getChildren().iterator(); I.hasNext();) {
 				EntryFigure entryFigure = (EntryFigure) I.next();
 				entryFigure.onPreferencesUpdate();
 			}
@@ -568,7 +568,7 @@ public final class PaletteComposite extends Composite {
 				int maxWidth = 0;
 				int maxHeight = 0;
 				boolean onlyIcons = m_preferences.getLayoutType() == ONLY_ICONS_TYPE;
-				for (Figure child : getChildren()) {
+				for (IFigure child : getChildren()) {
 					EntryFigure entryFigure = (EntryFigure) child;
 					// update size
 					Dimension entrySize =
@@ -592,7 +592,7 @@ public final class PaletteComposite extends Composite {
 				{
 					int column = 0;
 					int entryY = height;
-					for (Figure child : getChildren()) {
+					for (IFigure child : getChildren()) {
 						EntryFigure entryFigure = (EntryFigure) child;
 						// relocate entry
 						if (onlyIcons) {

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/AbsoluteBasedLayoutEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/AbsoluteBasedLayoutEditPolicy.java
@@ -42,6 +42,7 @@ import org.eclipse.wb.internal.core.model.description.ToolkitDescription;
 import org.eclipse.wb.internal.core.model.layout.absolute.IPreferenceConstants;
 import org.eclipse.wb.internal.core.utils.state.GlobalState;
 
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
@@ -398,9 +399,9 @@ IPreferenceConstants {
 						AbsolutePolicyUtils.COLOR_OUTLINE, bounds));
 			}
 			//
-			List<Figure> moveFeedbackFigures = m_moveFeedback.getChildren();
+			List<? extends IFigure> moveFeedbackFigures = m_moveFeedback.getChildren();
 			for (int i = 0; i < moveFeedbackFigures.size(); ++i) {
-				Figure figure = moveFeedbackFigures.get(i);
+				IFigure figure = moveFeedbackFigures.get(i);
 				figure.getBounds().performTranslate(-widgetBounds.x, -widgetBounds.y);
 				relativeBounds[i] = figure.getBounds().getCopy();
 			}
@@ -503,9 +504,9 @@ IPreferenceConstants {
 						AbsolutePolicyUtils.COLOR_OUTLINE, bounds));
 			}
 			//
-			List<Figure> moveFeedbackFigures = m_resizeFeedback.getChildren();
+			List<? extends IFigure> moveFeedbackFigures = m_resizeFeedback.getChildren();
 			for (int i = 0; i < moveFeedbackFigures.size(); ++i) {
-				Figure figure = moveFeedbackFigures.get(i);
+				IFigure figure = moveFeedbackFigures.get(i);
 				figure.getBounds().performTranslate(-widgetBounds.x, -widgetBounds.y);
 				relativeBounds[i] = figure.getBounds().getCopy();
 			}

--- a/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/gef/GroupLayoutEditPolicy2.java
+++ b/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/gef/GroupLayoutEditPolicy2.java
@@ -31,6 +31,7 @@ import org.eclipse.wb.internal.core.model.clipboard.JavaInfoMemento;
 import org.eclipse.wb.internal.layout.group.model.GroupLayoutUtils;
 import org.eclipse.wb.internal.layout.group.model.IGroupLayoutInfo;
 
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Point;
@@ -264,9 +265,9 @@ public abstract class GroupLayoutEditPolicy2 extends LayoutEditPolicy implements
 							bounds));
 				}
 				// set bounds of nested figures
-				List<Figure> moveFeedbackFigures = m_dragFeedback.getChildren();
+				List<? extends IFigure> moveFeedbackFigures = m_dragFeedback.getChildren();
 				for (j = 0; j < moveFeedbackFigures.size(); ++j) {
-					Figure figure = moveFeedbackFigures.get(j);
+					IFigure figure = moveFeedbackFigures.get(j);
 					figure.getBounds().performTranslate(-firstPartBounds.x, -firstPartBounds.y);
 				}
 			} else {
@@ -333,9 +334,9 @@ public abstract class GroupLayoutEditPolicy2 extends LayoutEditPolicy implements
 							bounds));
 				}
 				//
-				List<Figure> moveFeedbackFigures = m_dragFeedback.getChildren();
+				List<? extends IFigure> moveFeedbackFigures = m_dragFeedback.getChildren();
 				for (int j = 0; j < moveFeedbackFigures.size(); ++j) {
-					Figure figure = moveFeedbackFigures.get(j);
+					IFigure figure = moveFeedbackFigures.get(j);
 					figure.getBounds().performTranslate(-firstPartBounds.x, -firstPartBounds.y);
 				}
 			} else {

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormLayoutEditPolicy2.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormLayoutEditPolicy2.java
@@ -42,6 +42,7 @@ import org.eclipse.wb.internal.swt.model.layout.form.FormLayoutInfo;
 import org.eclipse.wb.internal.swt.model.layout.form.FormLayoutPreferences;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.draw2d.geometry.Translatable;
@@ -273,9 +274,9 @@ IHeadersProvider {
 						AbsolutePolicyUtils.COLOR_OUTLINE, bounds));
 			}
 			//
-			List<Figure> moveFeedbackFigures = m_moveFeedback.getChildren();
+			List<? extends IFigure> moveFeedbackFigures = m_moveFeedback.getChildren();
 			for (int i = 0; i < moveFeedbackFigures.size(); ++i) {
-				Figure figure = moveFeedbackFigures.get(i);
+				IFigure figure = moveFeedbackFigures.get(i);
 				figure.getBounds().performTranslate(-widgetBounds.x, -widgetBounds.y);
 				relativeBounds[i] = figure.getBounds().getCopy();
 			}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuFeedbackTester.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuFeedbackTester.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,13 +10,13 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.swt.model.menu;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.core.gef.policy.menu.MenuSelectionEditPolicy;
 import org.eclipse.wb.tests.gef.GraphicalRobot;
 
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Rectangle;
 
 import java.util.function.Predicate;
@@ -46,7 +46,7 @@ public final class MenuFeedbackTester {
 	/**
 	 * @return the {@link Predicate} that checks if feedback is {@link MenuSelectionEditPolicy}.
 	 */
-	private static Predicate<Figure> getSelectionPredicate(GraphicalEditPart part) {
+	private static Predicate<IFigure> getSelectionPredicate(GraphicalEditPart part) {
 		// prepare "part" Figure bounds in absolute
 		final Rectangle partBounds;
 		{
@@ -57,7 +57,7 @@ public final class MenuFeedbackTester {
 		return feedback -> partBounds.equals(feedback.getBounds());
 	}
 
-	private Predicate<Figure> getSelectionPredicate(Object object) {
+	private Predicate<IFigure> getSelectionPredicate(Object object) {
 		return getSelectionPredicate(canvas.getEditPart(object));
 	}
 
@@ -69,20 +69,20 @@ public final class MenuFeedbackTester {
 	}
 
 	@SuppressWarnings("unchecked")
-	public void assertMenuFeedbacks(Predicate<Figure> p) {
+	public void assertMenuFeedbacks(Predicate<IFigure> p) {
 		assertMenuFeedbacks(new Predicate[]{p});
 	}
 
 	@SuppressWarnings("unchecked")
-	public void assertMenuFeedbacks(Predicate<Figure> p1, Predicate<Figure> p2) {
+	public void assertMenuFeedbacks(Predicate<IFigure> p1, Predicate<IFigure> p2) {
 		assertMenuFeedbacks(new Predicate[]{p1, p2});
 	}
 
 	/**
-	 * Asserts that {@link IEditPartViewer#MENU_FEEDBACK_LAYER} has feedback {@link Figure}'s that
+	 * Asserts that {@link IEditPartViewer#MENU_FEEDBACK_LAYER} has feedback {@link IFigure}'s that
 	 * satisfy to given {@link Predicate}'s.
 	 */
-	public void assertMenuFeedbacks(Predicate<Figure>... predicates) {
+	public void assertMenuFeedbacks(Predicate<IFigure>... predicates) {
 		canvas.assertFigures(IEditPartViewer.MENU_FEEDBACK_LAYER, predicates);
 	}
 
@@ -91,23 +91,23 @@ public final class MenuFeedbackTester {
 	}
 
 	public void assertFeedback_selection_line(Object selection, Object lineObject, int location) {
-		Predicate<Figure> linePredicate = canvas.getLinePredicate(lineObject, location);
-		Predicate<Figure> selectionPredicate = getSelectionPredicate(selection);
+		Predicate<IFigure> linePredicate = canvas.getLinePredicate(lineObject, location);
+		Predicate<IFigure> selectionPredicate = getSelectionPredicate(selection);
 		assertMenuFeedbacks(selectionPredicate, linePredicate);
 	}
 
 	public void assertFeedback_selection_target(Object selection, Object targetObject) {
-		Predicate<Figure> targetPredicate = canvas.getTargetPredicate(targetObject);
-		Predicate<Figure> selectionPredicate = getSelectionPredicate(selection);
+		Predicate<IFigure> targetPredicate = canvas.getTargetPredicate(targetObject);
+		Predicate<IFigure> selectionPredicate = getSelectionPredicate(selection);
 		assertMenuFeedbacks(selectionPredicate, targetPredicate);
 	}
 
 	public void assertFeedback_selection_emptyFlow(Object selection,
 			Object hostObject,
 			boolean horizontal) {
-		Predicate<Figure> targetPredicate =
+		Predicate<IFigure> targetPredicate =
 				canvas.getEmptyFlowContainerPredicate(hostObject, horizontal);
-		Predicate<Figure> flowPredicate = getSelectionPredicate(selection);
+		Predicate<IFigure> flowPredicate = getSelectionPredicate(selection);
 		assertMenuFeedbacks(flowPredicate, targetPredicate);
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/GraphicalRobot.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/GraphicalRobot.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.gef;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.draw2d.Layer;
 import org.eclipse.wb.draw2d.Polyline;
@@ -25,6 +24,7 @@ import org.eclipse.wb.gef.graphical.tools.SelectionTool;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.gef.graphical.GraphicalViewer;
 
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
@@ -766,7 +766,7 @@ public final class GraphicalRobot {
 	 * @return bounds of {@link GraphicalEditPart}'s figure in absolute coordinates.
 	 */
 	public static Rectangle getAbsoluteBounds(GraphicalEditPart editPart) {
-		Figure figure = editPart.getFigure();
+		IFigure figure = editPart.getFigure();
 		Rectangle bounds = figure.getBounds().getCopy();
 		FigureUtils.translateFigureToAbsolute(figure, bounds);
 		return bounds;
@@ -821,7 +821,7 @@ public final class GraphicalRobot {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * Description of {@link Figure}.
+	 * Description of {@link IFigure}.
 	 */
 	public static final class FigureDescription {
 		private final Class<?> m_class;
@@ -853,9 +853,9 @@ public final class GraphicalRobot {
 		//
 		////////////////////////////////////////////////////////////////////////////
 		/**
-		 * @return <code>true</code> if given {@link Figure} matches this {@link FigureDescription}.
+		 * @return <code>true</code> if given {@link IFigure} matches this {@link FigureDescription}.
 		 */
-		public boolean match(Figure figure) {
+		public boolean match(IFigure figure) {
 			boolean match = true;
 			match &= m_class.isAssignableFrom(figure.getClass());
 			if (m_absoluteBounds != null) {
@@ -866,9 +866,9 @@ public final class GraphicalRobot {
 	}
 
 	/**
-	 * @return the list of {@link Figure}'s on feedback {@link Layer}.
+	 * @return the list of {@link IFigure}'s on feedback {@link Layer}.
 	 */
-	public List<Figure> getFeedbackFigures() {
+	public List<? extends IFigure> getFeedbackFigures() {
 		return m_viewer.getLayer(IEditPartViewer.FEEDBACK_LAYER).getChildren();
 	}
 
@@ -931,19 +931,19 @@ public final class GraphicalRobot {
 	}
 
 	/**
-	 * Asserts that {@link Layer} has {@link Figure}'s that satisfy to given {@link Predicate} .
+	 * Asserts that {@link Layer} has {@link IFigure}'s that satisfy to given {@link Predicate} .
 	 */
 	@SuppressWarnings("unchecked")
-	public void assertFigures(String layerName, Predicate<Figure> predicate) {
+	public void assertFigures(String layerName, Predicate<IFigure> predicate) {
 		assertFigures(layerName, new Predicate[]{predicate});
 	}
 
 	/**
-	 * Asserts that {@link Layer} has {@link Figure}'s that satisfy to given {@link Predicate} 's.
+	 * Asserts that {@link Layer} has {@link IFigure}'s that satisfy to given {@link Predicate} 's.
 	 */
-	public void assertFigures(String layerName, Predicate<Figure>... predicates) {
+	public void assertFigures(String layerName, Predicate<IFigure>... predicates) {
 		// prepare feedback's
-		List<Figure> feedbacks;
+		List<? extends IFigure> feedbacks;
 		{
 			Layer feedbackLayer = m_viewer.getLayer(layerName);
 			feedbacks = feedbackLayer.getChildren();
@@ -952,8 +952,8 @@ public final class GraphicalRobot {
 		}
 		// check all feedback's
 		for (int i = 0; i < predicates.length; i++) {
-			Predicate<Figure> predicate = predicates[i];
-			Figure feedback = feedbacks.get(i);
+			Predicate<IFigure> predicate = predicates[i];
+			IFigure feedback = feedbacks.get(i);
 			Assertions.assertThat(predicate.test(feedback)).describedAs("Predicate [" + i + "] failed.").isTrue();
 		}
 	}
@@ -970,39 +970,39 @@ public final class GraphicalRobot {
 	 * {@link IEditPartViewer#FEEDBACK_LAYER}.
 	 */
 	public void assertEmptyFlowContainerFeedback(Object host, boolean horizontal) {
-		Predicate<Figure> predicate = getEmptyFlowContainerPredicate(host, horizontal);
+		Predicate<IFigure> predicate = getEmptyFlowContainerPredicate(host, horizontal);
 		assertFeedbacks(predicate);
 	}
 
 	/**
-	 * Asserts that {@link IEditPartViewer#FEEDBACK_LAYER} has feedback {@link Figure}'s that satisfy
+	 * Asserts that {@link IEditPartViewer#FEEDBACK_LAYER} has feedback {@link IFigure}'s that satisfy
 	 * to given {@link Predicate}'s.
 	 */
 	@SuppressWarnings("unchecked")
-	public void assertFeedbacks(Predicate<Figure> predicate_1) {
+	public void assertFeedbacks(Predicate<IFigure> predicate_1) {
 		assertFeedbacks0(predicate_1);
 	}
 
 	/**
-	 * Asserts that {@link IEditPartViewer#FEEDBACK_LAYER} has feedback {@link Figure}'s that satisfy
+	 * Asserts that {@link IEditPartViewer#FEEDBACK_LAYER} has feedback {@link IFigure}'s that satisfy
 	 * to given {@link Predicate}'s.
 	 */
-	private void assertFeedbacks0(Predicate<Figure>... predicates) {
+	private void assertFeedbacks0(Predicate<IFigure>... predicates) {
 		assertFigures(IEditPartViewer.FEEDBACK_LAYER, predicates);
 	}
 
 	/**
-	 * Asserts that feedback layer contains exactly same {@link Figure}'s as described.
+	 * Asserts that feedback layer contains exactly same {@link IFigure}'s as described.
 	 */
 	public void assertFeedbackFigures(FigureDescription... descriptions) {
-		HashSet<Figure> feedbackFigures = new HashSet<>(getFeedbackFigures());
+		HashSet<IFigure> feedbackFigures = new HashSet<>(getFeedbackFigures());
 		//
 		for (int i = 0; i < descriptions.length; i++) {
 			FigureDescription description = descriptions[i];
 			// try to find figure for current description
 			boolean figureFound = false;
-			for (Iterator<Figure> I = feedbackFigures.iterator(); I.hasNext();) {
-				Figure figure = I.next();
+			for (Iterator<IFigure> I = feedbackFigures.iterator(); I.hasNext();) {
+				IFigure figure = I.next();
 				if (description.match(figure)) {
 					I.remove();
 					figureFound = true;
@@ -1015,7 +1015,7 @@ public final class GraphicalRobot {
 		// all figure should be matched
 		if (!feedbackFigures.isEmpty()) {
 			String message = "Following figures are not matched:";
-			for (Figure figure : feedbackFigures) {
+			for (IFigure figure : feedbackFigures) {
 				message +=
 						"\n\t"
 								+ figure.getClass().getName()
@@ -1029,14 +1029,14 @@ public final class GraphicalRobot {
 	}
 
 	/**
-	 * Asserts that there are no {@link Figure}'s on feedback {@link Layer}.
+	 * Asserts that there are no {@link IFigure}'s on feedback {@link Layer}.
 	 */
 	public void assertNoFeedbackFigures() {
 		Assertions.assertThat(getFeedbackFigures().isEmpty()).describedAs("Feedback layer should be empty.").isTrue();
 	}
 
 	/**
-	 * Asserts that there are exactly given count of {@link Figure}'s on feedback {@link Layer}.
+	 * Asserts that there are exactly given count of {@link IFigure}'s on feedback {@link Layer}.
 	 */
 	public void assertFeedbackFigures(int count) {
 		Assertions.assertThat(getFeedbackFigures()).hasSize(count);
@@ -1073,7 +1073,7 @@ public final class GraphicalRobot {
 	/**
 	 * @return the {@link Predicate} that checks if feedback is line used for empty flow container.
 	 */
-	public final Predicate<Figure> getEmptyFlowContainerPredicate(Object hostModel, boolean horizontal) {
+	public final Predicate<IFigure> getEmptyFlowContainerPredicate(Object hostModel, boolean horizontal) {
 		GraphicalEditPart host = getEditPart(hostModel);
 		// prepare "host" Figure bounds in absolute
 		Rectangle bounds;
@@ -1144,7 +1144,7 @@ public final class GraphicalRobot {
 	 *          {@link PositionConstants#BOTTOM} , {@link PositionConstants#LEFT},
 	 *          {@link PositionConstants#RIGHT}.
 	 */
-	public static final Predicate<Figure> getLinePredicate(GraphicalEditPart part, final int location) {
+	public static final Predicate<IFigure> getLinePredicate(GraphicalEditPart part, final int location) {
 		// prepare "part" Figure bounds in absolute
 		final Rectangle partBounds;
 		{
@@ -1199,7 +1199,7 @@ public final class GraphicalRobot {
 		};
 	}
 
-	public final Predicate<Figure> getLinePredicate(Object object, final int location) {
+	public final Predicate<IFigure> getLinePredicate(Object object, final int location) {
 		return getLinePredicate(getEditPart(object), location);
 	}
 
@@ -1207,7 +1207,7 @@ public final class GraphicalRobot {
 	 * @return the {@link Predicate} that checks if feedback is "border target" around given
 	 *         {@link GraphicalEditPart}.
 	 */
-	public static final Predicate<Figure> getTargetPredicate(GraphicalEditPart part) {
+	public static final Predicate<IFigure> getTargetPredicate(GraphicalEditPart part) {
 		// prepare "part" Figure bounds in absolute
 		final Rectangle partBounds;
 		{
@@ -1219,7 +1219,7 @@ public final class GraphicalRobot {
 		return feedback -> partBounds.equals(feedback.getBounds());
 	}
 
-	public final Predicate<Figure> getTargetPredicate(Object object) {
+	public final Predicate<IFigure> getTargetPredicate(Object object) {
 		return getTargetPredicate(getEditPart(object));
 	}
 }


### PR DESCRIPTION
The type cast is only necessary when using the visitor. For all other instances, we can work directly on the IFigure interface. Meaning there is no need to overwrite this method anymore.