### PR TITLE
[GEF] Make IPalette compatible with PaletteRoot

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/DesignerRoot.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/DesignerRoot.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Patrick Ziegler and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.core.controls.palette;
+
+import org.eclipse.gef.palette.PaletteRoot;
+import org.eclipse.gef.ui.palette.PaletteContextMenuProvider;
+import org.eclipse.gef.ui.palette.PaletteCustomizer;
+import org.eclipse.jface.action.IMenuManager;
+
+import java.util.List;
+
+/**
+ * Serves as the root {@link org.eclipse.gef.palette.PaletteEntry} for the
+ * palette model. It provides access to the {@link DesignerContainer}'s,
+ * {@link DesignerEntry}'s and operations on them.
+ */
+@SuppressWarnings("removal")
+public abstract class DesignerRoot extends PaletteRoot implements IPalette {
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public final List<DesignerContainer> getChildren() {
+		return (List<DesignerContainer>) super.getChildren();
+	}
+
+	/**
+	 * @noreference This method is not intended to be referenced by clients.
+	 * @nooverride This method is not intended to be re-implemented or extended by
+	 *             clients.
+	 * @deprecated Use {@link PaletteContextMenuProvider} instead.
+	 */
+	@Override
+	@Deprecated(since = "1.17.0", forRemoval = true)
+	public abstract void addPopupActions(IMenuManager menuManager, Object target, int iconsType);
+
+	/**
+	 * @noreference This method is not intended to be referenced by clients.
+	 * @nooverride This method is not intended to be re-implemented or extended by
+	 *             clients.
+	 * @deprecated Use {@link EditDomain#loadDefaultTool()}.
+	 */
+	@Override
+	@Deprecated(since = "1.17.0", forRemoval = true)
+	public abstract void selectDefault();
+
+	/**
+	 * @noreference This method is not intended to be referenced by clients.
+	 * @nooverride This method is not intended to be re-implemented or extended by
+	 *             clients.
+	 * @deprecated Use {@link #getChildren()} instead.
+	 */
+	@Override
+	@Deprecated(since = "1.17.0", forRemoval = true)
+	public final List<DesignerContainer> getCategories() {
+		return getChildren();
+	}
+
+	/**
+	 * @noreference This method is not intended to be referenced by clients.
+	 * @nooverride This method is not intended to be re-implemented or extended by
+	 *             clients.
+	 * @deprecated Use {@link PaletteCustomizer} instead.
+	 */
+	@Override
+	@Deprecated(since = "1.17.0", forRemoval = true)
+	public abstract void moveCategory(ICategory category, ICategory nextCategory);
+
+	/**
+	 * @noreference This method is not intended to be referenced by clients.
+	 * @nooverride This method is not intended to be re-implemented or extended by
+	 *             clients.
+	 * @deprecated Use {@link PaletteCustomizer} instead.
+	 */
+	@Override
+	@Deprecated(since = "1.17.0", forRemoval = true)
+	public abstract void moveEntry(IEntry entry, ICategory targetCategory, IEntry nextEntry);
+}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/IPalette.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/IPalette.java
@@ -23,6 +23,8 @@ import java.util.List;
  * @author scheglov_ke
  * @coverage core.control.palette
  */
+//TODO GEF
+@Deprecated(since = "1.17.0", forRemoval = true)
 public interface IPalette {
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -32,7 +34,7 @@ public interface IPalette {
 	/**
 	 * @return the {@link List} of {@link ICategory}'s to display as roots of palette.
 	 */
-	List<ICategory> getCategories();
+	List<? extends ICategory> getCategories();
 
 	/**
 	 * Adds {@link Action}'s to the popup menu.

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/test/PaletteTest.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/test/PaletteTest.java
@@ -16,9 +16,9 @@ import org.eclipse.wb.core.controls.flyout.IFlyoutPreferences;
 import org.eclipse.wb.core.controls.flyout.MemoryFlyoutPreferences;
 import org.eclipse.wb.core.controls.palette.DesignerContainer;
 import org.eclipse.wb.core.controls.palette.DesignerEntry;
+import org.eclipse.wb.core.controls.palette.DesignerRoot;
 import org.eclipse.wb.core.controls.palette.ICategory;
 import org.eclipse.wb.core.controls.palette.IEntry;
-import org.eclipse.wb.core.controls.palette.IPalette;
 import org.eclipse.wb.core.controls.palette.PaletteComposite;
 import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 
@@ -33,9 +33,6 @@ import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Application for testing {@link PaletteComposite}.
@@ -108,7 +105,7 @@ public class PaletteTest implements ColorConstants {
 			palette = new PaletteImpl();
 			{
 				CategoryImpl category = new CategoryImpl("First category", true);
-				palette.addCategory(category);
+				palette.add(category);
 				category.add(new EntryImpl(true, createIcon(red), "AAAAAAAAAAA"));
 				category.add(new EntryImpl(false, createIcon(green), "BBBBB"));
 				category.add(new EntryImpl(true, createIcon(blue), "CCCCCCCCCCCCCCC"));
@@ -118,14 +115,14 @@ public class PaletteTest implements ColorConstants {
 			}
 			{
 				CategoryImpl category = new CategoryImpl("Second category", false);
-				palette.addCategory(category);
+				palette.add(category);
 				category.add(new EntryImpl(true, createIcon(red), "0123456789"));
 				category.add(new EntryImpl(true, createIcon(green), "012345"));
 				category.add(new EntryImpl(true, createIcon(blue), "0123456789123"));
 			}
 			{
 				CategoryImpl category = new CategoryImpl("Third category", true);
-				palette.addCategory(category);
+				palette.add(category);
 				category.add(new EntryImpl(true, createIcon(red), "0123456789"));
 				category.add(new EntryImpl(true, createIcon(green), "012345"));
 				category.add(new EntryImpl(true, createIcon(blue), "0123456789123"));
@@ -153,22 +150,7 @@ public class PaletteTest implements ColorConstants {
 	// Palette implementation
 	//
 	////////////////////////////////////////////////////////////////////////////
-	private static final class PaletteImpl implements IPalette {
-		private final List<ICategory> m_categories = new ArrayList<>();
-
-		////////////////////////////////////////////////////////////////////////////
-		//
-		// Access
-		//
-		////////////////////////////////////////////////////////////////////////////
-		public void addCategory(ICategory category) {
-			m_categories.add(category);
-		}
-
-		@Override
-		public List<ICategory> getCategories() {
-			return m_categories;
-		}
+	private static final class PaletteImpl extends DesignerRoot {
 
 		/** {@inheritDoc} */
 		@Override


### PR DESCRIPTION
Because the IPalette interface is API, we can't simply rename the methods to match the ones that are used by GEF. Instead, a new DesignerRoot class is created, which serves as an adapter between the IPalette interface and the PaletteRoot class.

The IPalette interface has been marked as deprecated and "for removal", meaning that they can be removed after a two-year grace period, without breaking API.