### PR TITLE
Fix: Wrong coordinates when calculating location of Swing components

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/ComponentInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/ComponentInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -165,10 +165,9 @@ public class ComponentInfo extends AbstractComponentInfo {
 					AbstractComponentInfo parentModel = (AbstractComponentInfo) model.getParent();
 					Object parentObject = parentModel.getComponentObject();
 					if (parentObject instanceof Component parentComponent) {
-						java.awt.Point p_component = SwingUtils.getScreenLocation(component);
-						java.awt.Point p_parent = SwingUtils.getScreenLocation(parentComponent);
-						bounds.x = p_component.x - p_parent.x;
-						bounds.y = p_component.y - p_parent.y;
+						java.awt.Point relativeLocation = SwingUtils.getRelativeLocation(parentComponent, component);
+						bounds.x = relativeLocation.x;
+						bounds.y = relativeLocation.y;
 					}
 				}
 				// remember bounds

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingUtils.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingUtils.java
@@ -307,6 +307,25 @@ public final class SwingUtils {
 	}
 
 	/**
+	 * @return location of given {@code child} {@link Component} relative to the
+	 *         {@code parent} {@link Component}.
+	 */
+	public static Point getRelativeLocation(final Component parentComponent, final Component childComponent)
+			throws Exception {
+		try {
+			return runObjectLaterAndWait(() -> {
+				Point parentLocation = getScreenLocation(parentComponent);
+				Point childLocation = getScreenLocation(childComponent);
+				int relX = childLocation.x - parentLocation.x;
+				int relY = childLocation.y - parentLocation.y;
+				return new Point(relX, relY);
+			});
+		} catch (IllegalComponentStateException e) {
+			return new Point();
+		}
+	}
+
+	/**
 	 * Convert SWT color to AWT color.
 	 */
 	public static java.awt.Color getAWTColor(org.eclipse.swt.graphics.Color color) {


### PR DESCRIPTION
A race condition may occur when calculating the relative location of a Swing component relative to its parent component. The way we calculate this value is by subtracting the screen location of the child from the screen location of the parent. Because those locations are fetched independent from one another, it may happen that the window is moved between those requests, introducing a ficticious offset.

To avoid this issue, both locations have to be fetched at the same time, for which a new method getRelativeLocation() has been added to the SwingUtils class.