### PR TITLE
Avoid asynchronous task when calculating relative locations

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingUtils.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingUtils.java
@@ -314,8 +314,8 @@ public final class SwingUtils {
 			throws Exception {
 		try {
 			return runObjectLaterAndWait(() -> {
-				Point parentLocation = getScreenLocation(parentComponent);
-				Point childLocation = getScreenLocation(childComponent);
+				Point parentLocation = parentComponent.getLocationOnScreen();
+				Point childLocation = childComponent.getLocationOnScreen();
 				int relX = childLocation.x - parentLocation.x;
 				int relY = childLocation.y - parentLocation.y;
 				return new Point(relX, relY);


### PR DESCRIPTION
The getRelativeLocation() asynchronously calculates the screen location of the parent and child component. To calls should instead be done synchronously, to avoid any race conditions caused by window changes between those calls.

Amends bee6c0d65382e283c3e337f6f373a715fa6c0914