### PR TITLE
Adapt FigureTest to handle new GEF behavior

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigureTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigureTest.java
@@ -300,7 +300,12 @@ public class FigureTest extends Draw2dFigureTestCase {
 		/*
 		 * === assert remove from empty parent ===
 		 */
-		assertThrows(NullPointerException.class, () -> parentFigure.remove(null));
+		try {
+			parentFigure.remove(null);
+			fail();
+		} catch (IllegalArgumentException e) {
+			assertEquals(ERROR_MESSAGE_EMPTY_PARENT, e.getMessage());
+		}
 		//
 		try {
 			parentFigure.remove(new Figure());


### PR DESCRIPTION
When trying to remove a "null" figure, an IllegalArgumentException is thrown instead of a NullPointerException.