### PR TITLE
Cleanup usage of old BeanObservables in list/set factories

### DIFF
--- a/org.eclipse.wb.rcp.databinding/resources/1.8/org/eclipse/wb/rcp/databinding/BeansListObservableFactory.java
+++ b/org.eclipse.wb.rcp.databinding/resources/1.8/org/eclipse/wb/rcp/databinding/BeansListObservableFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.wb.rcp.databinding;
 
-import org.eclipse.core.databinding.beans.BeansObservables;
+import org.eclipse.core.databinding.beans.typed.BeanProperties;
 import org.eclipse.core.databinding.observable.IObservable;
 import org.eclipse.core.databinding.observable.Realm;
 
@@ -37,6 +37,6 @@ public class BeansListObservableFactory extends BeansObservableFactory {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	protected IObservable createBeanObservable(Object target) {
-		return BeansObservables.observeList(Realm.getDefault(), target, m_propertyName);
+		return BeanProperties.list(m_propertyName).observe(Realm.getDefault());
 	}
 }

--- a/org.eclipse.wb.rcp.databinding/resources/1.8/org/eclipse/wb/rcp/databinding/BeansSetObservableFactory.java
+++ b/org.eclipse.wb.rcp.databinding/resources/1.8/org/eclipse/wb/rcp/databinding/BeansSetObservableFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.wb.rcp.databinding;
 
-import org.eclipse.core.databinding.beans.BeansObservables;
+import org.eclipse.core.databinding.beans.typed.BeanProperties;
 import org.eclipse.core.databinding.observable.IObservable;
 import org.eclipse.core.databinding.observable.Realm;
 
@@ -37,6 +37,6 @@ public class BeansSetObservableFactory extends BeansObservableFactory {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	protected IObservable createBeanObservable(Object target) {
-		return BeansObservables.observeSet(Realm.getDefault(), target, m_propertyName);
+		return BeanProperties.set(m_propertyName).observe(Realm.getDefault(), target);
 	}
 }

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/ControllerSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/ControllerSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -315,15 +315,14 @@ public class ControllerSupport {
 		//
 		String observeMethod = null;
 		if (automaticWizardStub == null) {
+			String className;
 			if (ObservableInfo.isPojoBean(beanClass)) {
-				String pojoClassName = DataBindingsCodeUtils.getPojoObservablesClass();
-				observeMethod =
-						"ObserveValue = " + ClassUtils.getShortClassName(pojoClassName) + ".observeValue(";
-				controllerImportList.add(pojoClassName);
+				className = DataBindingsCodeUtils.getPojoObservablesClass();
 			} else {
-				observeMethod = "ObserveValue = BeansObservables.observeValue(";
-				controllerImportList.add("org.eclipse.core.databinding.beans.BeansObservables");
+				className = DataBindingsCodeUtils.getBeanObservablesClass();
 			}
+			observeMethod = "ObserveValue = " + ClassUtils.getShortClassName(className) + ".value(";
+			controllerImportList.add(className);
 		} else {
 			automaticWizardStub.addImports(controllerImportList);
 		}

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/DetailBeanObservableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/DetailBeanObservableInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,7 +26,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.List;
 
 /**
- * Abstract model for observable objects <code>BeansObservables.observeDetailXXX(...)</code>.
+ * Abstract model for observable objects <code>BeansProperties.detail(...)</code>.
  *
  * @author lobas_av
  * @coverage bindings.rcp.model.beans

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/input/AbstractFactoryInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/input/AbstractFactoryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@ import org.apache.commons.lang3.ClassUtils;
 import java.util.List;
 
 /**
- * Abstract model for factory observable object <code>BeansObservables.XXXFactory(...)</code>.
+ * Abstract model for factory observable object <code>BeanProperties.XXX(...).XXXFactory()</code>.
  *
  * @author lobas_av
  * @coverage bindings.rcp.model.widgets
@@ -122,18 +122,22 @@ public abstract class AbstractFactoryInfo extends BeansObservableFactoryInfo {
 		String beansClassName =
 				m_isPojoBindable
 				? DataBindingsCodeUtils.getPojoObservablesClass()
-						: "org.eclipse.core.databinding.beans.BeansObservables";
+						: DataBindingsCodeUtils.getBeanObservablesClass();
 		lines.add("org.eclipse.core.databinding.observable.masterdetail.IObservableFactory "
 				+ getVariableIdentifier()
 				+ " = "
 				+ beansClassName
 				+ "."
 				+ m_method
-				+ "(org.eclipse.core.databinding.observable.Realm.getDefault(), "
+				+ "("
 				+ m_propertyName
 				+ ", "
 				+ CoreUtils.getClassName(m_elementType)
 				+ ".class"
-				+ ");");
+				+ ")"
+				+ "."
+				+ m_method
+				+ "Factory(org.eclipse.core.databinding.observable.Realm.getDefault())"
+				+ ";");
 	}
 }

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/input/BeansObservableListFactoryInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/input/BeansObservableListFactoryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,7 @@
 package org.eclipse.wb.internal.rcp.databinding.model.widgets.input;
 
 /**
+ * Model for observable object <code>BeanProperties.list(...).listFactory(...)</code>.
  *
  * @author lobas_av
  *
@@ -22,6 +23,6 @@ public class BeansObservableListFactoryInfo extends AbstractFactoryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	public BeansObservableListFactoryInfo() {
-		super("listFactory");
+		super("list");
 	}
 }

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/input/BeansObservableSetFactoryInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/input/BeansObservableSetFactoryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,7 @@
 package org.eclipse.wb.internal.rcp.databinding.model.widgets.input;
 
 /**
- * Model for observable object <code>BeansObservables.setFactory(...)</code>.
+ * Model for observable object <code>BeanProperties.set(...).setFactory(...)</code>.
  *
  * @author lobas_av
  * @coverage bindings.rcp.model.widgets
@@ -23,6 +23,6 @@ public class BeansObservableSetFactoryInfo extends AbstractFactoryInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	public BeansObservableSetFactoryInfo() {
-		super("setFactory");
+		super("set");
 	}
 }

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/wizards/autobindings/SwtDatabindingProvider.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/wizards/autobindings/SwtDatabindingProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -225,15 +225,14 @@ public class SwtDatabindingProvider extends DefaultAutomaticDatabindingProvider 
 		//
 		String observeMethod = null;
 		if (automaticWizardStub == null) {
+			String className;
 			if (ObservableInfo.isPojoBean(m_beanClass)) {
-				String pojoClass = DataBindingsCodeUtils.getPojoObservablesClass();
-				observeMethod =
-						"ObserveValue = " + ClassUtils.getShortClassName(pojoClass) + ".observeValue(";
-				importList.add(pojoClass);
+				className = DataBindingsCodeUtils.getPojoObservablesClass();
 			} else {
-				observeMethod = "ObserveValue = BeansObservables.observeValue(";
-				importList.add("org.eclipse.core.databinding.beans.BeansObservables");
+				className = DataBindingsCodeUtils.getBeanObservablesClass();
 			}
+			observeMethod = "ObserveValue = " + ClassUtils.getShortClassName(className) + ".value(";
+			importList.add(className);
 		} else {
 			automaticWizardStub.addImports(importList);
 		}


### PR DESCRIPTION
Move to Bean-/MojoProperties instead.
- Also updates the factory templates

See https://github.com/eclipse-windowbuilder/windowbuilder/issues/492