### PR TITLE
Explicitly set required permissions for "Publish Test Results" action

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,6 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion != 'skipped'
 
+    permissions:
+      checks: write
+      pull-requests: write
+
     steps:
       - name: Download and Extract Artifacts
         env:


### PR DESCRIPTION
The workflow action no longer creates a comment containing the test results on a given pull requests. Based on the log, it seems to be unable to find the PR...

This is an attempt to solve this issue by giving write-access to pull requests, as listed by the minimal workflow job permissions.

See:
https://github.com/EnricoMi/publish-unit-test-result-action/blob/master/README.md#permissions