### PR TITLE
Set version for builder-helper-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,11 @@
             </dependency>
           </dependencies>
         </plugin>
+        <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <version>3.6.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>


### PR DESCRIPTION
This plugin is referenced via the Tycho pomless build. If the version isn't set, a warning is created at the start of the build.