### PR TITLE
Fix several AsciiDoc errors/warnings/debug problems

### DIFF
--- a/org.eclipse.wb.doc.user/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.doc.user/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Automatic-Module-Name: org.eclipse.wb.doc.user
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.doc.user; singleton:=true
-Bundle-Version: 1.10.100.qualifier
+Bundle-Version: 1.10.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.wb.doc.user/html-src/faq.asciidoc
+++ b/org.eclipse.wb.doc.user/html-src/faq.asciidoc
@@ -583,5 +583,3 @@ Here are the steps to follow:
 . Save your work and close any application you are working with.
 . End your session (or press Ctrl-Alt-Delete to restart the x-server) and log in again.
 . You are done!
-
-|===

--- a/org.eclipse.wb.doc.user/html-src/layoutmanagers/index.asciidoc
+++ b/org.eclipse.wb.doc.user/html-src/layoutmanagers/index.asciidoc
@@ -10,11 +10,9 @@ for the layout of your UI in a way that will be portable.
 
 [cols="34%,33%,33%"]
 |===
-image:../userinterface/images/feedback_drag_grid1.png[image,width=229,height=124] 
-|
-image:../userinterface/images/feedback_drag_xy.png[image,width=229,height=124] 
-|
-image:../userinterface/images/feedback_size_xy.png[image,width=229,height=124]
+|image:../userinterface/images/feedback_drag_grid1.png[image,width=229,height=124] 
+|image:../userinterface/images/feedback_drag_xy.png[image,width=229,height=124] 
+|image:../userinterface/images/feedback_size_xy.png[image,width=229,height=124]
 |===
 
 Layout managers can provide the following advantages:

--- a/org.eclipse.wb.doc.user/html-src/userinterface/palette.asciidoc
+++ b/org.eclipse.wb.doc.user/html-src/userinterface/palette.asciidoc
@@ -38,7 +38,7 @@ The following commands are common to every palette:
 
 image:images/palette_context_menu.png[image]
 
-=== Common Palette Commands
+== Common Palette Commands
 
 [width="100%",cols="10%,20%,70%"]
 |===

--- a/org.eclipse.wb.doc.user/html-src/userinterface/property_editor_image.asciidoc
+++ b/org.eclipse.wb.doc.user/html-src/userinterface/property_editor_image.asciidoc
@@ -45,7 +45,7 @@ the path that was selected in the image editor to valid Java code. The class
 (SwingImageIcon in the following example) must be in the classpath of the
 current project.
 
-[java]
+[source,java]
 ---- 
 public class SwingImageProcessor extends AbstractClasspathImageProcessor {
 	@Override

--- a/org.eclipse.wb.doc.user/pom.xml
+++ b/org.eclipse.wb.doc.user/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>org.eclipse.wb.doc.user</artifactId>
-	<version>1.10.100-SNAPSHOT</version>
+	<version>1.10.200-SNAPSHOT</version>
 	<parent>
 		<groupId>org.eclipse.wb</groupId>
 		<artifactId>org.eclipse.wb.root</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -125,12 +125,13 @@
             <dependency>
               <groupId>org.jruby</groupId>
               <artifactId>jruby</artifactId>
-              <version>9.4.7.0</version>
+              <version>9.4.8.0</version>
             </dependency>
           </dependencies>
           <configuration>
             <doctype>book</doctype>
             <attributes>
+              <source-highlighter>rouge</source-highlighter>
               <stylesheet>${project.basedir}/book.css</stylesheet>
               <nofooter/>
             </attributes>


### PR DESCRIPTION
layoutmanagers/index.asciidoc
 - table missing leading separator

faq.asciidoc
 - unterminated table block

userinterface/palette.asciidoc
 - section title out of sequence: expected levels 0 or 1, got level 2

userinterface/property_editor_image.asciidoc
 - unknown style for listing block: java