### PR TITLE
Set version attribute for maven-clean-plugin

### DIFF
--- a/org.eclipse.wb.core.databinding.xsd/pom.xml
+++ b/org.eclipse.wb.core.databinding.xsd/pom.xml
@@ -30,7 +30,8 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-clean-plugin</artifactId>
-					<configuration>
+				<version>3.4.0</version>
+				<configuration>
 						<filesets>
 							<fileset>
 								<directory>${basedir}/src-gen</directory>


### PR DESCRIPTION
This version isn't set anywhere, resulting in an illegal POM that produces a warning at the start of the build.