### PR TITLE
Make scroll-bar invisible for horizontal/vertical header

### DIFF
--- a/org.eclipse.wb.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.core;singleton:=true
-Bundle-Version: 1.17.0.qualifier
+Bundle-Version: 1.18.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.core.DesignerPlugin

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/graphical/HeaderGraphicalViewer.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/graphical/HeaderGraphicalViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@ package org.eclipse.wb.internal.gef.graphical;
 
 import org.eclipse.wb.internal.draw2d.IPreferredSizeProvider;
 
+import org.eclipse.draw2d.FigureCanvas;
 import org.eclipse.draw2d.RangeModel;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.swt.SWT;
@@ -35,20 +36,9 @@ public class HeaderGraphicalViewer extends GraphicalViewer {
 	}
 
 	public HeaderGraphicalViewer(Composite parent, int style, boolean horizontal) {
-		super(parent, checkStyles(style));
+		super(parent, style);
+		getControl().setScrollBarVisibility(FigureCanvas.NEVER);
 		m_horizontal = horizontal;
-	}
-
-	private static final int checkStyles(int styles) {
-		// ignore horizontal scroll style
-		if ((styles & SWT.H_SCROLL) != 0) {
-			styles |= ~SWT.H_SCROLL;
-		}
-		// ignore vertical scroll style
-		if ((styles & SWT.V_SCROLL) != 0) {
-			styles |= ~SWT.V_SCROLL;
-		}
-		return styles;
 	}
 
 	////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
GEF automatically adds the H_SCROLL/V_SCROLL styles when creating a new FigureCanvas instance, leading to scroll-bars being shown in the headers and thus obscuring the entries.

Set the visibility of the scroll-bars to never be shown, to get around this problem. Note that those headers scroll together with the main viewer and the scroll-bars are therefore not needed.

Relates to:
https://github.com/eclipse-windowbuilder/windowbuilder/discussions/894