### PR TITLE
Update URL to WindowBuilder Website repo in Oomph script

### DIFF
--- a/setups/WindowBuilder.setup
+++ b/setups/WindowBuilder.setup
@@ -236,7 +236,7 @@
     <setupTask
         xsi:type="git:GitCloneTask"
         id="github.clone.www.eclipse.org.wb"
-        remoteURI="eclipse-windowbuilder/windowbuilder-website">
+        remoteURI="eclipse-windowbuilder/windowbuilder-website-source">
       <annotation
           source="http://www.eclipse.org/oomph/setup/InducedChoices">
         <detail


### PR DESCRIPTION
The windowbuilder-website repository now contains the static HTML generated by Hugo. Users should never need to edit them directly, but rather modify the source files located in windowbuilder-website-source.