### PR TITLE
Remove eclipse-jarsigner-plugin from pluginManagement block

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
           <plugin>
             <groupId>org.eclipse.cbi.maven.plugins</groupId>
             <artifactId>eclipse-jarsigner-plugin</artifactId>
+            <version>1.5.0</version>
             <executions>
               <execution>
                 <id>sign</id>
@@ -104,11 +105,6 @@
   <build>
     <pluginManagement>
       <plugins>
-        <plugin>
-          <groupId>org.eclipse.cbi.maven.plugins</groupId>
-          <artifactId>eclipse-jarsigner-plugin</artifactId>
-          <version>1.5.0</version>
-        </plugin>
         <plugin>
           <groupId>org.eclipse.tycho</groupId>
           <artifactId>tycho-gpg-plugin</artifactId>


### PR DESCRIPTION
The repository containing this plugin is only available when the "sign" profile is used, leading to several warnings during the normal build. This entry is only used to specify the version, which has simply been moved to the declaration.