### PR TITLE
Harmonize call to palette entries in DesignerContainer

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPalette.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPalette.java
@@ -310,7 +310,7 @@ public class DesignerPalette {
 				private boolean m_open;
 
 				@Override
-				public List<DesignerEntry> getEntries() {
+				public List<DesignerEntry> getChildren() {
 					final List<EntryInfo> entryInfoList = new ArrayList<>(categoryInfo.getEntries());
 					// add new EntryInfo's using broadcast
 					ExecutionUtils.runIgnore(new RunnableEx() {

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/DesignerContainer.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/DesignerContainer.java
@@ -75,7 +75,7 @@ public abstract class DesignerContainer extends PaletteDrawer implements ICatego
 	@Override
 	@SuppressWarnings("unchecked")
 	public List<DesignerEntry> getEntries() {
-		return (List<DesignerEntry>) super.getChildren();
+		return (List<DesignerEntry>) getChildren();
 	}
 
 }


### PR DESCRIPTION
By overwriting the deprecated getEntries() method (which internally delegates to getChildren()), we may return a different list of palette entries, depending on which method is called.