### PR TITLE
Adjust lower bound of GEF dependency in SWT_AWT.

### DIFF
--- a/org.eclipse.wb.rcp.SWT_AWT/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp.SWT_AWT/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.wb.rcp.SWT_AWT;singleton:=true
 Bundle-Version: 1.9.600.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,
- org.eclipse.gef;bundle-version="3.20.0",
+ org.eclipse.gef;bundle-version="3.18.0",
  org.eclipse.wb.core;bundle-version="1.12.0",
  org.eclipse.wb.rcp,
  org.eclipse.wb.swing,


### PR DESCRIPTION
The 3.20 version won't be available before the 2024-12 release. Given that we only need this dependency to resolve "org.eclipse.gef.Tool", we can safely pick any recent version. The 3.18 version has only be chosen because that's what's used everywhere else as lower bound.

Amends 5562ca79b8be01aea8092a69ceda9eb1230392e7