### PR TITLE
Synchronize IPalettePreferences with PaletteViewerPreferences

### DIFF
--- a/org.eclipse.wb.core.java/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core.java/META-INF/MANIFEST.MF
@@ -149,6 +149,7 @@ Export-Package: org.eclipse.wb.core.editor,
 Automatic-Module-Name: org.eclipse.wb.core.java
 Import-Package: jakarta.xml.bind;version="[4.0.1,5.0.0)",
  org.apache.commons.collections4;version="[4.4.0,5.0.0)",
+ org.apache.commons.collections4.bidimap;version="[4.4.0,5.0.0)",
  org.apache.commons.collections4.keyvalue;version="[4.4.0,5.0.0]",
  org.apache.commons.collections4.map;version="[4.4.0,5.0.0)",
  org.apache.commons.collections4.multimap;version="[4.4.0,5.0.0)",

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPalette.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPalette.java
@@ -29,7 +29,6 @@ import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.broadcast.ObjectEventListener;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.graphical.tools.SelectionTool;
-import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.editor.DesignPage;
 import org.eclipse.wb.internal.core.editor.palette.command.CategoryMoveCommand;
 import org.eclipse.wb.internal.core.editor.palette.command.CategoryRemoveCommand;
@@ -82,10 +81,6 @@ import java.util.Set;
  */
 public class DesignerPalette {
 	public static final String FLAG_NO_PALETTE = "FLAG_NO_PALETTE"; // Don't load palette during testing
-	public static final int COLUMN_ICONS_TYPE = 0;
-	public static final int LIST_ICONS_TYPE = 1;
-	public static final int ONLY_ICONS_TYPE = 2;
-	public static final int DETAIL_ICONS_TYPE = 3;
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Instance fields
@@ -109,7 +104,7 @@ public class DesignerPalette {
 	public DesignerPalette(Composite parent, int style, boolean isMainPalette) {
 		m_isMainPalette = isMainPalette;
 		m_operations = new DesignerPaletteOperations();
-		m_preferences = new PluginPalettePreferences(DesignerPlugin.getPreferences());
+		m_preferences = new PluginPalettePreferences();
 		m_paletteComposite = new PaletteComposite(parent, SWT.NONE);
 	}
 
@@ -519,7 +514,7 @@ public class DesignerPalette {
 
 		public void setIconsType(int iconsType) {
 			m_paletteComposite.setLayoutType(iconsType);
-			m_preferences.setLayoutType(iconsType);
+			m_preferences.setLayoutSetting(iconsType);
 			m_paletteComposite.setPreferences(m_preferences);
 			m_paletteComposite.refreshComposite();
 		}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPalettePopupActions.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPalettePopupActions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc and Others.
+ * Copyright (c) 2011, 2024 Google, Inc and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,6 +25,7 @@ import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 
 import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.gef.ui.palette.PaletteViewerPreferences;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.IMenuManager;
@@ -59,8 +60,6 @@ final class DesignerPalettePopupActions {
 	private static final ImageDescriptor ID_SELECTED = getImageDescription("selected.gif");
 	// field
 	private final DesignerPaletteOperations m_operations;
-	private final PluginPalettePreferences m_preferences =
-			new PluginPalettePreferences(DesignerPlugin.getPreferences());
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -122,46 +121,46 @@ final class DesignerPalettePopupActions {
 			// single
 			{
 				ImageDescriptor image = null;
-				if (type == DesignerPalette.COLUMN_ICONS_TYPE) {
+				if (type == PaletteViewerPreferences.LAYOUT_COLUMNS) {
 					image = ID_SELECTED;
 				}
 				Action columnAction = new Action("Columns", image) {
 					@Override
 					public void run() {
-						m_operations.setIconsType(DesignerPalette.COLUMN_ICONS_TYPE);
+						m_operations.setIconsType(PaletteViewerPreferences.LAYOUT_COLUMNS);
 					}
 				};
 				layoutMenuManager.add(columnAction);
 				image = null;
-				if (type == DesignerPalette.LIST_ICONS_TYPE) {
+				if (type == PaletteViewerPreferences.LAYOUT_LIST) {
 					image = ID_SELECTED;
 				}
 				Action listAction = new Action("List", image) {
 					@Override
 					public void run() {
-						m_operations.setIconsType(DesignerPalette.LIST_ICONS_TYPE);
+						m_operations.setIconsType(PaletteViewerPreferences.LAYOUT_LIST);
 					}
 				};
 				layoutMenuManager.add(listAction);
 				image = null;
-				if (type == DesignerPalette.ONLY_ICONS_TYPE) {
+				if (type == PaletteViewerPreferences.LAYOUT_ICONS) {
 					image = ID_SELECTED;
 				}
 				Action onlyIconAction = new Action("Icons Only", image) {
 					@Override
 					public void run() {
-						m_operations.setIconsType(DesignerPalette.ONLY_ICONS_TYPE);
+						m_operations.setIconsType(PaletteViewerPreferences.LAYOUT_ICONS);
 					}
 				};
 				layoutMenuManager.add(onlyIconAction);
 				image = null;
-				if (type == DesignerPalette.DETAIL_ICONS_TYPE) {
+				if (type == PaletteViewerPreferences.LAYOUT_DETAILS) {
 					image = ID_SELECTED;
 				}
 				Action detailAction = new Action("Detail", image) {
 					@Override
 					public void run() {
-						m_operations.setIconsType(DesignerPalette.DETAIL_ICONS_TYPE);
+						m_operations.setIconsType(PaletteViewerPreferences.LAYOUT_DETAILS);
 					}
 				};
 				layoutMenuManager.add(detailAction);

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/dialogs/PalettePreferencesDialog.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/dialogs/PalettePreferencesDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,9 +19,13 @@ import org.eclipse.wb.internal.core.utils.dialogfields.LayoutDialogFieldGroup;
 import org.eclipse.wb.internal.core.utils.dialogfields.SelectionButtonDialogFieldGroup;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
 
+import org.eclipse.gef.ui.palette.PaletteViewerPreferences;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Shell;
+
+import org.apache.commons.collections4.BidiMap;
+import org.apache.commons.collections4.bidimap.DualHashBidiMap;
 
 /**
  * Dialog for modifying palette settings.
@@ -31,6 +35,7 @@ import org.eclipse.swt.widgets.Shell;
  */
 public final class PalettePreferencesDialog extends AbstractPaletteDialog {
 	private final PluginPalettePreferences m_preferences;
+	private final BidiMap<Integer, Integer> m_index2layout;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -44,6 +49,11 @@ public final class PalettePreferencesDialog extends AbstractPaletteDialog {
 				null,
 				Messages.PalettePreferencesDialog_message);
 		m_preferences = preferences;
+		m_index2layout = new DualHashBidiMap<>();
+		m_index2layout.put(0, PaletteViewerPreferences.LAYOUT_COLUMNS);
+		m_index2layout.put(1, PaletteViewerPreferences.LAYOUT_LIST);
+		m_index2layout.put(2, PaletteViewerPreferences.LAYOUT_ICONS);
+		m_index2layout.put(3, PaletteViewerPreferences.LAYOUT_DETAILS);
 		setShellStyle(SWT.APPLICATION_MODAL | SWT.DIALOG_TRIM);
 	}
 
@@ -59,7 +69,7 @@ public final class PalettePreferencesDialog extends AbstractPaletteDialog {
 		m_preferences.setMinColumns(1 + m_minColumnsField.getSelection()[0]);
 		m_preferences.setCategoryFont(m_categoryFontField.getFontDataArray());
 		m_preferences.setEntryFont(m_entryFontField.getFontDataArray());
-		m_preferences.setLayoutType(m_layoutDialogField.getSelection()[0]);
+		m_preferences.setLayoutSetting(m_index2layout.get(m_layoutDialogField.getSelection()[0]));
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -117,7 +127,7 @@ public final class PalettePreferencesDialog extends AbstractPaletteDialog {
 		m_minColumnsField.setSelection(new int[]{m_preferences.getMinColumns() - 1});
 		m_categoryFontField.setFontDataArray(m_preferences.getCategoryFontDescriptor().getFontData());
 		m_entryFontField.setFontDataArray(m_preferences.getEntryFontDescriptor().getFontData());
-		m_layoutDialogField.setSelection(new int[]{m_preferences.getLayoutType()});
+		m_layoutDialogField.setSelection(new int[] { m_index2layout.getKey(m_preferences.getLayoutType()) });
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/DesignerPaletteViewerPreferences.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/DesignerPaletteViewerPreferences.java
@@ -1,27 +1,37 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2024 Patrick Ziegler and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *    Google, Inc. - initial API and implementation
- *    DSA - layout type added
+ *    Patrick Ziegler - initial API and implementation
  *******************************************************************************/
 package org.eclipse.wb.core.controls.palette;
 
+import org.eclipse.wb.internal.core.DesignerPlugin;
+
+import org.eclipse.gef.ui.palette.DefaultPaletteViewerPreferences;
+import org.eclipse.gef.ui.palette.PaletteViewerPreferences;
+import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.resource.FontDescriptor;
 
 /**
  * The default implementation of {@link IPalettePreferences}.
- *
- * @author scheglov_ke
- * @coverage core.control.palette
- * @deprecated Replaced by {@link DesignPaletteViewerPreferences}.
  */
-@Deprecated(forRemoval = true, since = "1.18.0")
-public final class DefaultPalettePreferences implements IPalettePreferences {
+@SuppressWarnings("removal")
+public class DesignerPaletteViewerPreferences extends DefaultPaletteViewerPreferences implements IPalettePreferences {
+
+	public DesignerPaletteViewerPreferences() {
+		this(DesignerPlugin.getPreferences());
+	}
+
+	public DesignerPaletteViewerPreferences(IPreferenceStore store) {
+		super(store);
+		super.setAutoCollapseSetting(COLLAPSE_NEVER);
+	}
+
 	@Override
 	public FontDescriptor getCategoryFontDescriptor() {
 		return null;
@@ -34,7 +44,7 @@ public final class DefaultPalettePreferences implements IPalettePreferences {
 
 	@Override
 	public boolean isOnlyIcons() {
-		return false;
+		return getLayoutSetting() == PaletteViewerPreferences.LAYOUT_ICONS;
 	}
 
 	@Override
@@ -44,6 +54,6 @@ public final class DefaultPalettePreferences implements IPalettePreferences {
 
 	@Override
 	public int getLayoutType() {
-		return 0;
+		return getLayoutSetting();
 	}
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/IPalettePreferences.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/IPalettePreferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.wb.core.controls.palette;
 
+import org.eclipse.gef.ui.palette.PaletteViewerPreferences;
 import org.eclipse.jface.resource.FontDescriptor;
 
 /**
@@ -18,7 +19,9 @@ import org.eclipse.jface.resource.FontDescriptor;
  *
  * @author scheglov_ke
  * @coverage core.control.palette
+ * @deprecated Replaced by {@link DesignPaletteViewerPreferences}.
  */
+@Deprecated(forRemoval = true, since = "1.18.0")
 public interface IPalettePreferences {
 	/**
 	 * @return the {@link FontDescriptor} for {@link ICategory}.
@@ -31,8 +34,11 @@ public interface IPalettePreferences {
 	FontDescriptor getEntryFontDescriptor();
 
 	/**
-	 * @return <code>true</code> if only icons should be displayed for {@link IEntry}'s.
+	 * @return {@code true} if only icons should be displayed for {@link IEntry}'s.
+	 * @deprecated Use {@link PaletteViewerPreferences#getLayoutSetting} instead and
+	 *             compare with {@link PaletteViewerPreferences#LAYOUT_ICONS}.
 	 */
+	@Deprecated(forRemoval = true, since = "1.18.0")
 	boolean isOnlyIcons();
 
 	/**
@@ -40,5 +46,9 @@ public interface IPalettePreferences {
 	 */
 	int getMinColumns();
 
+	/**
+	 * @deprecated Use {@link PaletteViewerPreferences#getLayoutSetting} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.18.0")
 	int getLayoutType();
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
@@ -33,6 +33,7 @@ import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.commands.Command;
+import org.eclipse.gef.ui.palette.PaletteViewerPreferences;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
@@ -60,10 +61,26 @@ import java.util.Map;
  * @coverage core.control.palette
  */
 public final class PaletteComposite extends Composite {
-	public static int COLUMN_ICONS_TYPE = 0;
-	public static int LIST_ICONS_TYPE = 1;
-	public static int ONLY_ICONS_TYPE = 2;
-	public static int DETAIL_ICONS_TYPE = 3;
+	/**
+	 * @deprecated Use {@link PaletteViewerPreferences#LAYOUT_COLUMNS} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.18.0")
+	public static int COLUMN_ICONS_TYPE = PaletteViewerPreferences.LAYOUT_COLUMNS;
+	/**
+	 * @deprecated Use {@link PaletteViewerPreferences#LAYOUT_LIST} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.18.0")
+	public static int LIST_ICONS_TYPE = PaletteViewerPreferences.LAYOUT_LIST;
+	/**
+	 * @deprecated Use {@link PaletteViewerPreferences#LAYOUT_ICONS} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.18.0")
+	public static int ONLY_ICONS_TYPE = PaletteViewerPreferences.LAYOUT_ICONS;
+	/**
+	 * @deprecated Use {@link PaletteViewerPreferences#LAYOUT_DETAILS} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.18.0")
+	public static int DETAIL_ICONS_TYPE = PaletteViewerPreferences.LAYOUT_DETAILS;
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Colors
@@ -128,7 +145,7 @@ public final class PaletteComposite extends Composite {
 	////////////////////////////////////////////////////////////////////////////
 	public PaletteComposite(Composite parent, int style) {
 		super(parent, style);
-		m_preferences = new DefaultPalettePreferences();
+		m_preferences = new DesignerPaletteViewerPreferences();
 		//
 		setLayout(new FillLayout());
 		// prepare draw2d FigureCanvas


### PR DESCRIPTION
This marks the IPalettePreferences and DefaultPalettePreferences as "forRemoval", and replaces them with PaletteViewerPreferences class. The constants for the different palette layouts are also replaced with what is declared by GEF.

Preferences are now tracked by the DesignerPaletteViewerPreferences class, which is also used to define our own preferences.