### PR TITLE
Cleanup and decouple SWTBot from other JUnit tests

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/swtbot/designer/AbstractWizardTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/swtbot/designer/AbstractWizardTest.java
@@ -12,10 +12,10 @@ package org.eclipse.wb.tests.swtbot.designer;
 
 import org.eclipse.swtbot.swt.finder.SWTBot;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
-import org.eclipse.ui.PlatformUI;
+
+import static org.junit.Assert.assertTrue;
 
 import org.junit.After;
-import org.junit.Before;
 
 import java.util.Arrays;
 
@@ -27,44 +27,18 @@ public abstract class AbstractWizardTest extends AbstractSWTBotTest {
 	private SWTBotShell shell;
 	protected SWTBot editor;
 
-	@Before
-	@Override
-	public void setUp() throws Exception {
-		super.setUp();
-		// Initialize "Resource" perspective
-		bot.perspectiveByLabel("Resource").activate();
-	}
-
 	@After
-	@Override
-	public void tearDown() throws Exception {
-		// Clear "Resource" perspective and close all open editors
-		bot.perspectiveByLabel("Resource").close();
-		if (shell != null) {
-			PlatformUI.getWorkbench().getDisplay().syncExec(shell.widget::dispose);
-		}
-		super.tearDown();
-	}
-
-	protected final SWTBotShell openNewWizardViaProjectExplorer() {
-		String project = m_javaProject.getElementName();
-		SWTBot packageExplorer = bot.viewByPartName("Project Explorer").bot();
-		packageExplorer.tree().getTreeItem(project).contextMenu().menu("New", "Other...").click();
-		return bot.shell("Select a wizard");
-	}
-
-	protected final SWTBotShell openNewWizardViaMenu() {
-		bot.menu("File").menu("New", "Other...").click();
-		return bot.shell("Select a wizard");
+	public void tearDown() {
+		bot.resetWorkbench();
 	}
 
 	protected final void testTemplateViaProjectExplorer(String... fullPath) {
-		shell = openNewWizardViaProjectExplorer();
+		shell = bot.getProjectExplorer().openNewWizard();
 		createTemplate(fullPath);
 	}
 
 	protected final void testTemplateViaMenu(String... fullPath) {
-		shell = openNewWizardViaMenu();
+		shell = bot.openNewWizard();
 		createTemplate(fullPath);
 	}
 
@@ -81,6 +55,8 @@ public abstract class AbstractWizardTest extends AbstractSWTBotTest {
 		newWizard.text(2).setText(fileName);
 		newWizard.button("Finish").click();
 
+		// The created Java file needs to be deleted after the test concluded
+		bot.addFile("test", fileName + ".java");
 		editor = bot.editorByTitle(fileName + ".java").bot();
 		editor.cTabItem("Design").activate();
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/swtbot/designer/bot/UIUtil.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/swtbot/designer/bot/UIUtil.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Patrick Ziegler and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.tests.swtbot.designer.bot;
+
+import org.eclipse.swt.SwtCallable;
+import org.eclipse.swt.SwtRunnable;
+import org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable;
+import org.eclipse.ui.PlatformUI;
+
+/**
+ * Inspired by {@link UIThreadRunnable} to support the execution of tasks within
+ * the UI thread. Unlike the SWTBot class however, we need to also support the
+ * case where those tasks throw an exception.
+ */
+public final class UIUtil {
+	private UIUtil() {
+		// This utility class should never be instantiated
+	}
+
+	/**
+	 * Executes the given {@code runnable} within the UI thread. Any exception
+	 * thrown by this task is converted into a {@link RuntimeException}.
+	 *
+	 * @param <E>      The type of exception thrown by this runnable.
+	 * @param runnable The task to be executed in the UI thread.
+	 */
+	public static <E extends Exception> void syncExec(SwtRunnable<E> runnable) {
+		syncCall(() -> {
+			runnable.run();
+			return null;
+		});
+	}
+
+	/**
+	 * Executes the given {@code callable} within the UI thread and returns the
+	 * result. Any exception thrown by this task is converted into a
+	 * {@link RuntimeException}.
+	 *
+	 * @param <E>      The type of exception thrown by this runnable.
+	 * @param callable The task to be executed in the UI thread.
+	 */
+	public static <U, E extends Exception> U syncCall(SwtCallable<U, E> callable) {
+		try {
+			return PlatformUI.getWorkbench().getDisplay().syncCall(callable);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/swtbot/designer/bot/WindowBuilderProjectExplorerBot.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/swtbot/designer/bot/WindowBuilderProjectExplorerBot.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Patrick Ziegler and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.tests.swtbot.designer.bot;
+
+import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
+import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
+import org.eclipse.ui.IViewReference;
+
+import java.util.logging.Logger;
+
+/**
+ * The SWTBot instance over the {@code Project Explorer}.
+ */
+public class WindowBuilderProjectExplorerBot extends SWTBotView {
+	private static final Logger LOGGER = Logger.getLogger(WindowBuilderProjectExplorerBot.class.getSimpleName());
+
+	public WindowBuilderProjectExplorerBot(IViewReference partReference, SWTWorkbenchBot bot) {
+		super(partReference, bot);
+	}
+
+	/**
+	 * Opens the "New" wizard via the context menu of the test project.
+	 */
+	public SWTBotShell openNewWizard() {
+		LOGGER.fine("Open New wizard");
+		bot().tree().getTreeItem("TestProject").contextMenu().menu("New", "Other...").click();
+		LOGGER.fine("Opened New wizard");
+		return bot.shell("Select a wizard");
+	}
+}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/swtbot/designer/bot/WindowBuilderWorkbenchBot.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/swtbot/designer/bot/WindowBuilderWorkbenchBot.java
@@ -1,0 +1,235 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Patrick Ziegler and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.tests.swtbot.designer.bot;
+
+import org.eclipse.wb.tests.designer.core.TestProject;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
+import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
+import org.eclipse.swtbot.swt.finder.SWTBot;
+import org.eclipse.swtbot.swt.finder.waits.Conditions;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.intro.IIntroManager;
+import org.eclipse.ui.intro.IIntroPart;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * The SWTBot instance over the entire {@code Eclipse} workbench.
+ */
+public class WindowBuilderWorkbenchBot extends SWTWorkbenchBot {
+	private static final String TEST_PROJECT_NAME = "TestProject";
+	private static final Logger LOGGER = Logger.getLogger(WindowBuilderWorkbenchBot.class.getSimpleName());
+	private TestProject testProject;
+	private List<IFile> createdFiles;
+	private boolean init;
+
+	public WindowBuilderWorkbenchBot() {
+		testProject = new TestProject(createProject());
+		createdFiles = new ArrayList<>();
+
+		if (!init) {
+			init = true;
+			UIUtil.syncExec(() -> {
+				// Close "Welcome" page
+				IWorkbench wb = PlatformUI.getWorkbench();
+				IIntroManager im = wb.getIntroManager();
+				IIntroPart intro = wb.getIntroManager().getIntro();
+				if (intro != null) {
+					im.closeIntro(intro);
+				}
+				// Initialize "Resource" perspective
+				IWorkbenchWindow ww = wb.getActiveWorkbenchWindow();
+				wb.getPerspectiveRegistry().setDefaultPerspective("org.eclipse.ui.resourcePerspective");
+				wb.showPerspective("org.eclipse.ui.resourcePerspective", ww);
+			});
+		}
+	}
+
+	private IProject createProject() {
+		IProject project = getTestProject();
+
+		if (project.exists()) {
+			return project;
+		}
+
+		SWTBot wizard = openNewWizard().bot();
+		wizard.tree().expandNode("WindowBuilder", "SWT Designer", "SWT/JFace Java Project").click();
+		wizard.button("Next >").click();
+		wizard.text().setText("TestProject");
+		wizard.checkBox("Create module-info.java file").deselect();
+		wizard.button("Next >").click();
+		wizard.button("Finish").click();
+		waitWhile(Conditions.shellIsActive("New SWT/JFace Java Project"));
+
+		return getTestProject();
+	}
+
+	private static IProject getTestProject() {
+		return UIUtil.syncCall(() -> ResourcesPlugin.getWorkspace().getRoot().getProject(TEST_PROJECT_NAME));
+	}
+
+	@Override
+	public void resetWorkbench() {
+		Iterator<IFile> iterator = createdFiles.iterator();
+		while (iterator.hasNext()) {
+			UIUtil.syncExec(() -> iterator.next().delete(true, null));
+			iterator.remove();
+		}
+		super.resetWorkbench();
+	}
+
+	/**
+	 * @return The SWTBot instance over the {@code Project Explorer}.
+	 */
+	public WindowBuilderProjectExplorerBot getProjectExplorer() {
+		LOGGER.fine("Open Project Explorer");
+		SWTBotView projectExplorer = viewByPartName("Project Explorer");
+		LOGGER.fine("Opened Project Explorer");
+		return new WindowBuilderProjectExplorerBot(projectExplorer.getViewReference(), this);
+	}
+
+	/**
+	 * Opens the {@code New} wizard from the main menu.
+	 *
+	 * @return the {@code New} wizard shell.
+	 */
+	public SWTBotShell openNewWizard() {
+		LOGGER.fine("Open New wizard");
+		shell().menu().menu("File").menu("New", "Other...").click();
+		LOGGER.fine("Opened New wizard");
+		return shell("Select a wizard");
+	}
+
+	// I/O
+	private IFile getFile(String packageName, String fileName) {
+		return UIUtil.syncCall(() -> {
+			IFolder packageFolder = (IFolder) testProject.getPackage(packageName).getResource();
+			return packageFolder.getFile(fileName);
+		});
+	}
+
+	/**
+	 * Registers the given source file to be deleted after the current test has
+	 * concluded. The file is located in the root of the source directory.
+	 *
+	 * <pre>
+	 * Example: src/module-info.java
+	 * </pre>
+	 *
+	 * @param fileName The file name (e.g. {@code module-info.java}).
+	 */
+	public void addFile(String fileName) {
+		addFile("", fileName);
+	}
+
+	/**
+	 * Registers the given source file to be deleted after the current test has
+	 * concluded. The file is located in the source directory.
+	 *
+	 * <pre>
+	 * Example: src/test/Test.java
+	 * </pre>
+	 *
+	 * @param packageName The package name (e.g. {@code test}).
+	 * @param fileName    The file name (e.g. {@code Test.java}.
+	 */
+	public void addFile(String packageName, String fileName) {
+		IFile sourceFile = getFile(packageName, fileName);
+		createdFiles.add(sourceFile);
+	}
+
+	/**
+	 * Updates the content of the given source file. The file is located in the root
+	 * of the source directory and deleted after the test concludes. A new file is
+	 * created if necessary.
+	 *
+	 * <pre>
+	 * Example: src/module-info.java
+	 * </pre>
+	 *
+	 * @param fileName The file name (e.g. {@code module-info.java}).
+	 * @param content  The file content.
+	 */
+	public void setFileContent(String fileName, String content) {
+		setFileContent("", fileName, content);
+	}
+
+	/**
+	 * Updates the content of the given source file. The file is deleted after the
+	 * test concludes. A new file is created if necessary.
+	 *
+	 * <pre>
+	 * Example: src/test/Test.java
+	 * </pre>
+	 *
+	 * @param packageName The package name (e.g. {@code test})
+	 * @param fileName    The file name (e.g. {@code Test.java}).
+	 * @param content     The file content.
+	 */
+	public void setFileContent(String packageName, String fileName, String content) {
+		UIUtil.syncExec(() -> {
+			IFile sourceFile = getFile(packageName, fileName);
+			sourceFile.setContents(content.getBytes(StandardCharsets.UTF_8), true, false, null);
+			createdFiles.add(sourceFile);
+		});
+	}
+
+	/**
+	 * Returns the content of the given source file. The file is located in the root
+	 * of the source directory.
+	 *
+	 * <pre>
+	 * Example: src/module-info.java
+	 * </pre>
+	 *
+	 * @param fileName The file name (e.g. {@code module-info.java}).
+	 * @return The file content.
+	 */
+	public String getFileContent(String fileName) {
+		return getFileContent("", fileName);
+	}
+
+	/**
+	 * Returns the content of the given source file.
+	 *
+	 * <pre>
+	 * Example: src/test/Test.java
+	 * </pre>
+	 *
+	 * @param packageName The package name (e.g. {@code test})
+	 * @param fileName    The file name (e.g. {@code Test.java}).
+	 * @return The file content.
+	 */
+	public String getFileContent(String packageName, String fileName) {
+		return UIUtil.syncCall(() -> {
+			IFile sourceFile = getFile(packageName, fileName);
+			ByteArrayOutputStream os = new ByteArrayOutputStream();
+			try (InputStream is = sourceFile.getContents()) {
+				is.transferTo(os);
+			}
+			return new String(os.toByteArray(), StandardCharsets.UTF_8);
+		});
+	}
+}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/swtbot/designer/rcp/wizard/JFaceWizardTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/swtbot/designer/rcp/wizard/JFaceWizardTest.java
@@ -14,6 +14,8 @@ import org.eclipse.wb.tests.swtbot.designer.AbstractWizardTest;
 
 import static org.eclipse.swtbot.swt.finder.matchers.WithText.withText;
 
+import static org.junit.Assert.assertNotNull;
+
 import org.junit.Test;
 
 public class JFaceWizardTest extends AbstractWizardTest {

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/swtbot/designer/rcp/wizard/RcpWizardTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/swtbot/designer/rcp/wizard/RcpWizardTest.java
@@ -14,6 +14,8 @@ import org.eclipse.wb.tests.swtbot.designer.AbstractWizardTest;
 
 import static org.eclipse.swtbot.swt.finder.matchers.WithText.withText;
 
+import static org.junit.Assert.assertNotNull;
+
 import org.junit.Test;
 
 public class RcpWizardTest extends AbstractWizardTest {

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/swtbot/designer/swing/wizard/SwingNewWizardTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/swtbot/designer/swing/wizard/SwingNewWizardTest.java
@@ -12,6 +12,8 @@ package org.eclipse.wb.tests.swtbot.designer.swing.wizard;
 
 import org.eclipse.wb.tests.swtbot.designer.AbstractWizardTest;
 
+import static org.junit.Assert.assertArrayEquals;
+
 import org.junit.Test;
 
 public class SwingNewWizardTest extends AbstractWizardTest {
@@ -48,13 +50,13 @@ public class SwingNewWizardTest extends AbstractWizardTest {
 
 	@Test
 	public void testCreateWithJavaModules() throws Exception {
-		setFileContentSrc("module-info.java", """
+		bot.setFileContent("module-info.java", """
 				module test {
 				}""");
 		//
 		testTemplateViaProjectExplorer("WindowBuilder", "Swing Designer", "JFrame");
 		// We can't use code blocks as they don't consider carriage-returns
-		assertArrayEquals(getFileContentSrc("module-info.java").split(System.lineSeparator()),
+		assertArrayEquals(bot.getFileContent("module-info.java").split(System.lineSeparator()),
 				new String[] {
 						"module test {",
 						"	requires java.desktop;",
@@ -94,13 +96,13 @@ public class SwingNewWizardTest extends AbstractWizardTest {
 
 	@Test
 	public void testCreateWithJavaModulesNoSelection() throws Exception {
-		setFileContentSrc("module-info.java", """
+		bot.setFileContent("module-info.java", """
 				module test {
 				}""");
 		//
 		testTemplateViaMenu("WindowBuilder", "Swing Designer", "JFrame");
 		// We can't use code blocks as they don't consider carriage-returns
-		assertArrayEquals(getFileContentSrc("module-info.java").split(System.lineSeparator()),
+		assertArrayEquals(bot.getFileContent("module-info.java").split(System.lineSeparator()),
 				new String[] {
 						"module test {",
 						"	requires java.desktop;",


### PR DESCRIPTION
This removes the dependency from the AbstractSWTBotTest class to the AbstractJavaProjectTest class and therefore makes the SWTBot tests independent from the "old" tests.

This dependency was used to perform I/O operations, which is problematic due to its dependency on the UI thread. Instead, helper methods have been added to our custom SWTBot instance, which take over this task.