### PR TITLE
[1.8] Improve support for outdated JDK versions

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/Messages.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/Messages.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Google, Inc. - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.wb.internal.core.editor;
 
 import org.eclipse.osgi.util.NLS;
@@ -60,6 +70,7 @@ public class Messages extends NLS {
 	public static String ComponentsTreePage_expandAllAction;
 	public static String DesignComponentsComposite_componentsTitle;
 	public static String DesignComponentsComposite_propertiesTitle;
+	public static String DesignerMethodBinding_unknownArgumentNames;
 	public static String DesignerPalettePopupActions_addCategoryAction;
 	public static String DesignerPalettePopupActions_addComponentAction;
 	public static String DesignerPalettePopupActions_addInstanceFactoryAction;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/messages.properties
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/messages.properties
@@ -61,6 +61,7 @@ ComponentsTreePage_collapseAllAction=Collapse All
 ComponentsTreePage_expandAllAction=Expand All
 DesignComponentsComposite_componentsTitle=Components
 DesignComponentsComposite_propertiesTitle=Properties
+DesignerMethodBinding_unknownArgumentNames=The argument names for the method "{0}" could not be determined. Possible reasons are an old JDK or a bug within JDT.
 DesignerPalettePopupActions_addCategoryAction=Add category...
 DesignerPalettePopupActions_addComponentAction=Add component...
 DesignerPalettePopupActions_addInstanceFactoryAction=Add instance factory


### PR DESCRIPTION
The JDT compiler is unable to calculate the argument names of a method binding when a JDK 8 is used and simply returns an empty array. This then leads to an out-of-bounds exception, as the number of parameter types no longer matches the number of parameter names.

Note that this issue only happens with a proper JDK 8, but not an e.g. JDK 17 with compiler compliance set to Java 8.

The parameter names themselves only seem to be relevant for cosmetic reason, so they are now simply ignored (together with a warning), rather than causing the editor to crash.

From a technical perspective, the problem can be isolated to one of the internal classes of the JDT compiler:

org.eclipse.jdt.internal.compiler.classfmt.MethodInfo
 -> getArgumentNames()
 -> readCodeAttribute()
 -> decodeCodeAttribute()

The offset that is supposed to point to the "LocalVariableTable" is instead pointing to the "LineNumberTable" and as a result, the compiler is unable to extract the attribute names.