### PR TITLE
Manage lifecycle of preview in LAF preference page via AWT even thread

### DIFF
--- a/org.eclipse.wb.swing/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swing;singleton:=true
-Bundle-Version: 1.10.0.qualifier
+Bundle-Version: 1.10.100.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.swing.Activator
 Bundle-Vendor: %providerName

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingUtils.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingUtils.java
@@ -61,6 +61,29 @@ public final class SwingUtils {
 	////////////////////////////////////////////////////////////////////////////
 	/**
 	 * Runs the {@link RunnableEx} in the AWT event dispatching thread using
+	 * {@link SwingUtilities#invokeLater(Runnable)} and waits for it to get done
+	 * with SWT message pumping. Due to SWT principles this means pumping system
+	 * message loop. Using {@link SwingUtilities#invokeAndWait(Runnable)} is not
+	 * acceptable because it could produce deadlocks between SWT and AWT dispatch
+	 * threads. Any exceptions that are thrown are logged using
+	 * {@link DesignerPlugin#log(Throwable)}.
+	 *
+	 * Note: must be invoked from SWT UI thread.
+	 *
+	 * @return {@code true} if execution was finished without exception.
+	 */
+	public static boolean runLog(final RunnableEx runnable) {
+		try {
+			runLaterAndWait(runnable);
+			return true;
+		} catch (Throwable e) {
+			DesignerPlugin.log(e);
+			return false;
+		}
+	}
+
+	/**
+	 * Runs the {@link RunnableEx} in the AWT event dispatching thread using
 	 * {@link SwingUtilities#invokeLater(Runnable)} and waits for it to get done with SWT message
 	 * pumping. Due to SWT principles this means pumping system message loop. Using
 	 * {@link SwingUtilities#invokeAndWait(Runnable)} is not acceptable because it could produce

--- a/org.eclipse.wb.swing/src/swingintegration/example/EmbeddedSwingComposite.java
+++ b/org.eclipse.wb.swing/src/swingintegration/example/EmbeddedSwingComposite.java
@@ -8,6 +8,7 @@
 package swingintegration.example;
 
 import org.eclipse.wb.internal.swing.utils.SwingImageUtils;
+import org.eclipse.wb.internal.swing.utils.SwingUtils;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTException;
@@ -504,8 +505,10 @@ public abstract class EmbeddedSwingComposite extends Composite {
 		getDisplay().removeFilter(SWT.Show, menuListener);
 		// dispose frame to avoid lock down in EventQueue.invokeAndWait() later
 		if (awtContext != null) {
-			Frame oldFrame = awtContext.getFrame();
-			oldFrame.dispose();
+			SwingUtils.runLog(() -> {
+				Frame oldFrame = awtContext.getFrame();
+				oldFrame.dispose();
+			});
 		}
 	}
 }

--- a/org.eclipse.wb.swing/src/swingintegration/example/EmbeddedSwingComposite2.java
+++ b/org.eclipse.wb.swing/src/swingintegration/example/EmbeddedSwingComposite2.java
@@ -9,6 +9,7 @@ package swingintegration.example;
 
 import org.eclipse.wb.internal.core.EnvironmentUtils;
 import org.eclipse.wb.internal.swing.utils.SwingImageUtils;
+import org.eclipse.wb.internal.swing.utils.SwingUtils;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTException;
@@ -427,9 +428,13 @@ public abstract class EmbeddedSwingComposite2 extends Composite {
 		// remove listeners
 		getDisplay().removeFilter(SWT.Show, menuListener);
 		// dispose frame to avoid lock down in EventQueue.invokeAndWait() later
+		// must be done in the AWT even thread. See:
+		// https://github.com/eclipse-windowbuilder/windowbuilder/discussions/937
 		if (awtContext != null) {
-			Frame oldFrame = awtContext.getFrame();
-			oldFrame.dispose();
+			SwingUtils.runLog(() -> {
+				Frame oldFrame = awtContext.getFrame();
+				oldFrame.dispose();
+			});
 		}
 	}
 


### PR DESCRIPTION
The applet that is created as part of the preview needs to be created and disposed from within the AWT even thread, to avoid deadlocks when called from within the SWT UI thread.

See https://github.com/eclipse-windowbuilder/windowbuilder/discussions/937