### PR TITLE
Refactor unnecessary usage of RectangleSupport class

### DIFF
--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/forms/DetailsPageTopBoundsSupport.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/forms/DetailsPageTopBoundsSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,6 @@ package org.eclipse.wb.internal.rcp.model.forms;
 import org.eclipse.wb.internal.core.model.TopBoundsSupport;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeTopBoundsSupport;
 import org.eclipse.wb.internal.swt.support.ControlSupport;
-import org.eclipse.wb.internal.swt.support.RectangleSupport;
 
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -52,8 +51,7 @@ public final class DetailsPageTopBoundsSupport extends TopBoundsSupport {
 			Dimension size = getResourceSize();
 			Shell shell = m_page.getShell();
 			// "size" is size of _content_ for "shell", so calculate trim
-			Rectangle trim =
-					RectangleSupport.getRectangle(shell.computeTrim(0, 0, size.width, size.height));
+			Rectangle trim = new Rectangle(shell.computeTrim(0, 0, size.width, size.height));
 			// OK, set size from trim
 			ControlSupport.setSize(shell, trim.width, trim.height);
 		}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/forms/MasterDetailsBlockTopBoundsSupport.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/forms/MasterDetailsBlockTopBoundsSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,6 @@ package org.eclipse.wb.internal.rcp.model.forms;
 import org.eclipse.wb.internal.core.model.TopBoundsSupport;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeTopBoundsSupport;
 import org.eclipse.wb.internal.swt.support.ControlSupport;
-import org.eclipse.wb.internal.swt.support.RectangleSupport;
 
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -52,8 +51,7 @@ public final class MasterDetailsBlockTopBoundsSupport extends TopBoundsSupport {
 			Dimension size = getResourceSize();
 			Shell shell = m_block.getShell();
 			// "size" is size of _content_ for "shell", so calculate trim
-			Rectangle trim =
-					RectangleSupport.getRectangle(shell.computeTrim(0, 0, size.width, size.height));
+			Rectangle trim = new Rectangle(shell.computeTrim(0, 0, size.width, size.height));
 			// OK, set size from trim
 			ControlSupport.setSize(shell, trim.width, trim.height);
 		}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/forms/SectionPartTopBoundsSupport.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/forms/SectionPartTopBoundsSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,6 @@ package org.eclipse.wb.internal.rcp.model.forms;
 import org.eclipse.wb.internal.core.model.TopBoundsSupport;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeTopBoundsSupport;
 import org.eclipse.wb.internal.swt.support.ControlSupport;
-import org.eclipse.wb.internal.swt.support.RectangleSupport;
 
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -50,8 +49,7 @@ public final class SectionPartTopBoundsSupport extends TopBoundsSupport {
 			Dimension size = getResourceSize();
 			Shell shell = m_part.getShell();
 			// "size" is size of _content_ for "shell", so calculate trim
-			Rectangle trim =
-					RectangleSupport.getRectangle(shell.computeTrim(0, 0, size.width, size.height));
+			Rectangle trim = new Rectangle(shell.computeTrim(0, 0, size.width, size.height));
 			// OK, set size from trim
 			ControlSupport.setSize(shell, trim.width, trim.height);
 		}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/CoolBarManagerInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/CoolBarManagerInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,6 @@ import org.eclipse.wb.internal.core.model.description.ComponentDescription;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
-import org.eclipse.wb.internal.swt.support.RectangleSupport;
 
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.jface.action.ICoolBarManager;
@@ -113,7 +112,7 @@ public final class CoolBarManagerInfo extends ContributionManagerInfo {
 					(ToolBar) ReflectionUtils.invokeMethod(toolBarManager.getObject(), "getControl()");
 			for (CoolItem coolItem : coolItems) {
 				if (coolItem.getControl() == toolBar) {
-					Rectangle newBounds = RectangleSupport.getRectangle(coolItem.getBounds());
+					Rectangle newBounds = new Rectangle(coolItem.getBounds());
 					Rectangle oldBounds = toolBarManager.getBounds();
 					final int deltaX = oldBounds.x - newBounds.x;
 					final int deltaY = oldBounds.y - newBounds.y;

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/ToolBarManagerInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/action/ToolBarManagerInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,6 @@ import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
-import org.eclipse.wb.internal.swt.support.RectangleSupport;
 
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.jface.action.Action;
@@ -75,8 +74,7 @@ public final class ToolBarManagerInfo extends ContributionManagerInfo {
 			Object contributionItemObject = contributionItem.getObject();
 			for (ToolItem toolItem : toolItems) {
 				if (toolItem.getData() == contributionItemObject) {
-					Object itemBoundsObject = ReflectionUtils.invokeMethod2(toolItem, "getBounds");
-					Rectangle itemBounds = RectangleSupport.getRectangle(itemBoundsObject);
+					Rectangle itemBounds = new Rectangle(toolItem.getBounds());
 					contributionItem.setModelBounds(itemBounds);
 					break;
 				}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/ViewPartLikeInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/ViewPartLikeInfo.java
@@ -23,7 +23,6 @@ import org.eclipse.wb.internal.rcp.Activator;
 import org.eclipse.wb.internal.rcp.model.jface.action.MenuManagerInfo;
 import org.eclipse.wb.internal.rcp.model.jface.action.MenuManagerPopupInfo;
 import org.eclipse.wb.internal.swt.support.CoordinateUtils;
-import org.eclipse.wb.internal.swt.support.RectangleSupport;
 
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -184,7 +183,7 @@ public abstract class ViewPartLikeInfo extends WorkbenchPartLikeInfo {
 		super.refresh_fetch();
 		// fetch bounds of menu drop-down
 		{
-			m_menuToolItemBounds = RectangleSupport.getRectangle(m_menuToolItem.getBounds());
+			m_menuToolItemBounds = new Rectangle(m_menuToolItem.getBounds());
 			Point menuToolItemDisplayLocation =
 					new Point(m_menuToolItem.getParent().toDisplay(
 							m_menuToolItemBounds.x,

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/WorkbenchPartTopBoundsSupport.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/WorkbenchPartTopBoundsSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,6 @@ package org.eclipse.wb.internal.rcp.model.rcp;
 import org.eclipse.wb.internal.core.model.TopBoundsSupport;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeTopBoundsSupport;
 import org.eclipse.wb.internal.swt.support.ControlSupport;
-import org.eclipse.wb.internal.swt.support.RectangleSupport;
 
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -50,8 +49,7 @@ public final class WorkbenchPartTopBoundsSupport extends TopBoundsSupport {
 			Dimension size = getResourceSize();
 			Shell shell = m_part.getShell();
 			// "size" is size of _content_ for "shell", so calculate trim
-			Rectangle trim =
-					RectangleSupport.getRectangle(shell.computeTrim(0, 0, size.width, size.height));
+			Rectangle trim = new Rectangle(shell.computeTrim(0, 0, size.width, size.height));
 			// OK, set size from trim
 			ControlSupport.setSize(shell, trim.width, trim.height);
 		}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/PageLayoutTopBoundsSupport.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/PageLayoutTopBoundsSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,6 @@ package org.eclipse.wb.internal.rcp.model.rcp.perspective;
 import org.eclipse.wb.internal.core.model.TopBoundsSupport;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeTopBoundsSupport;
 import org.eclipse.wb.internal.swt.support.ControlSupport;
-import org.eclipse.wb.internal.swt.support.RectangleSupport;
 
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -52,8 +51,7 @@ public final class PageLayoutTopBoundsSupport extends TopBoundsSupport {
 			Dimension size = getResourceSize();
 			Shell shell = m_page.getShell();
 			// "size" is size of _content_ for "shell", so calculate trim
-			Rectangle trim =
-					RectangleSupport.getRectangle(shell.computeTrim(0, 0, size.width, size.height));
+			Rectangle trim = new Rectangle(shell.computeTrim(0, 0, size.width, size.height));
 			// OK, set size from trim
 			ControlSupport.setSize(shell, trim.width, trim.height);
 		}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/shortcuts/AbstractShortcutInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/perspective/shortcuts/AbstractShortcutInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,6 @@ import org.eclipse.wb.internal.rcp.model.rcp.perspective.IRenderableInfo;
 import org.eclipse.wb.internal.rcp.model.rcp.perspective.PageLayoutAddCreationSupport;
 import org.eclipse.wb.internal.rcp.model.rcp.perspective.PageLayoutInfo;
 import org.eclipse.wb.internal.swt.support.CoordinateUtils;
-import org.eclipse.wb.internal.swt.support.RectangleSupport;
 
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.jdt.core.dom.Expression;
@@ -157,7 +156,7 @@ public abstract class AbstractShortcutInfo extends AbstractComponentInfo impleme
 		{
 			Composite composite = m_container.getComposite();
 			Rectangle toolBarBounds = CoordinateUtils.getBounds(composite, m_container.getToolBar());
-			Rectangle itemBounds = RectangleSupport.getRectangle(m_item.getBounds());
+			Rectangle itemBounds = new Rectangle(m_item.getBounds());
 			itemBounds.performTranslate(toolBarBounds.x, toolBarBounds.y);
 			setModelBounds(itemBounds);
 		}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/CTabItemInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/CTabItemInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,8 +13,8 @@ package org.eclipse.wb.internal.rcp.model.widgets;
 import org.eclipse.wb.internal.core.model.creation.CreationSupport;
 import org.eclipse.wb.internal.core.model.description.ComponentDescription;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
-import org.eclipse.wb.internal.swt.support.RectangleSupport;
 
+import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.swt.custom.CTabItem;
 
 /**
@@ -46,7 +46,7 @@ public final class CTabItemInfo extends AbstractTabItemInfo {
 		// set bounds
 		{
 			CTabItem item = (CTabItem) getObject();
-			setModelBounds(RectangleSupport.getRectangle(item.getBounds()));
+			setModelBounds(new Rectangle(item.getBounds()));
 		}
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ConvertersTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ConvertersTest.java
@@ -14,9 +14,9 @@ import org.eclipse.wb.internal.core.model.property.converter.ExpressionConverter
 import org.eclipse.wb.internal.swt.model.property.converter.PointConverter;
 import org.eclipse.wb.internal.swt.model.property.converter.RectangleConverter;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
-import org.eclipse.wb.internal.swt.support.RectangleSupport;
 import org.eclipse.wb.tests.designer.rcp.RcpModelTest;
 
+import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.swt.graphics.Point;
 
 import org.junit.After;
@@ -67,7 +67,7 @@ public class ConvertersTest extends RcpModelTest {
 		assertEquals("(org.eclipse.swt.graphics.Rectangle) null", converter.toJavaSource(shell, null));
 		assertEquals(
 				"new org.eclipse.swt.graphics.Rectangle(1, 2, 3, 4)",
-				converter.toJavaSource(shell, RectangleSupport.newRectangle(1, 2, 3, 4)));
+				converter.toJavaSource(shell, new Rectangle(1, 2, 3, 4)));
 	}
 
 	@Test


### PR DESCRIPTION
In cases where an SWT widget has already been loaded, we can avoid the reflective calls by constructing the Draw2D rectangle directly.