### PR TITLE
Build and test WindowBuilder against Java 21 only

### DIFF
--- a/.github/workflows/license-review.yml
+++ b/.github/workflows/license-review.yml
@@ -8,7 +8,7 @@ jobs:
   call-license-check:
     permissions:
       pull-requests: write
-    uses: eclipse-dash/dash-licenses/.github/workflows/mavenLicenseCheck.yml@90ebdf14dff066293b65b9d3ca99c8fb90d5222b # 1.1.0
+    uses: eclipse-dash/dash-licenses/.github/workflows/mavenLicenseCheck.yml@ebc42f4ad28dffa380c6db7685431065b414daab # 1.1.0
     with:
       projectId: tools.windowbuilder
     secrets:

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -9,7 +9,7 @@ on:
       - master
 jobs:
   check-dash-licenses:
-    uses: eclipse-dash/dash-licenses/.github/workflows/mavenLicenseCheck.yml@90ebdf14dff066293b65b9d3ca99c8fb90d5222b # 1.1.0
+    uses: eclipse-dash/dash-licenses/.github/workflows/mavenLicenseCheck.yml@ebc42f4ad28dffa380c6db7685431065b414daab # 1.1.0
     with:
       projectId: tools.windowbuilder
   build:
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: [ 17, 21 ]
+        java: [ 21 ]
     runs-on: ${{ matrix.os }}   
     name: OS ${{ matrix.os }} Java ${{ matrix.java }} compile
     timeout-minutes: 90

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
 
   tools {
     maven 'apache-maven-latest'
-    jdk 'temurin-jdk17-latest'
+    jdk 'temurin-jdk21-latest'
   }
 
   environment {


### PR DESCRIPTION
The Eclipse Platform SDK now requires at least Java 21 due to Lucene 10.x and we therefore can no longer build against older versions.