### PR TITLE
[eRCP] Typify IToolkitSupport interface

### DIFF
--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/support/ToolkitSupportImpl.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/support/ToolkitSupportImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,15 +23,11 @@ import org.eclipse.swt.events.ShellEvent;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.graphics.ImageData;
-import org.eclipse.swt.graphics.ImageLoader;
+import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.swt.widgets.Widget;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -59,19 +55,17 @@ public final class ToolkitSupportImpl implements IToolkitSupport {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public void makeShots(Object controlObject) throws Exception {
+	public void makeShots(Control controlObject) throws Exception {
 		OSSupport.get().makeShots(controlObject);
 	}
 
 	@Override
-	public Image getShotImage(Object controlObject) throws Exception {
-		Widget widget = (Widget) controlObject;
-		return (Image) widget.getData(OSSupport.WBP_IMAGE);
+	public Image getShotImage(Control controlObject) throws Exception {
+		return (Image) controlObject.getData(OSSupport.WBP_IMAGE);
 	}
 
 	@Override
-	public MenuVisualData fetchMenuVisualData(Object menuObject) throws Exception {
-		Menu menu = (Menu) menuObject;
+	public MenuVisualData fetchMenuVisualData(Menu menu) throws Exception {
 		MenuVisualData menuInfo = new MenuVisualData();
 		if ((menu.getStyle() & SWT.BAR) != 0) {
 			// menu bar
@@ -111,35 +105,13 @@ public final class ToolkitSupportImpl implements IToolkitSupport {
 	}
 
 	@Override
-	public void beginShot(Object controlObject) {
+	public void beginShot(Control controlObject) {
 		OSSupport.get().beginShot(controlObject);
 	}
 
 	@Override
-	public void endShot(Object controlObject) {
+	public void endShot(Control controlObject) {
 		OSSupport.get().endShot(controlObject);
-	}
-
-	////////////////////////////////////////////////////////////////////////////
-	//
-	// Images
-	//
-	////////////////////////////////////////////////////////////////////////////
-	@Override
-	public Object createToolkitImage(Image image) throws Exception {
-		return image;
-	}
-
-	@Override
-	public Image createSWTImage(Object image) throws Exception {
-		// save image to byte stream
-		ImageLoader loader = new ImageLoader();
-		loader.data = new ImageData[]{((Image) image).getImageData()};
-		ByteArrayOutputStream outStream = new ByteArrayOutputStream();
-		loader.save(outStream, SWT.IMAGE_PNG);
-		// load image from byte stream
-		ByteArrayInputStream inStream = new ByteArrayInputStream(outStream.toByteArray());
-		return new Image(null, inStream);
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -148,8 +120,7 @@ public final class ToolkitSupportImpl implements IToolkitSupport {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public void showShell(Object shellObject) throws Exception {
-		final Shell shell = (Shell) shellObject;
+	public void showShell(Shell shell) throws Exception {
 		final Shell mainShell = DesignerPlugin.getShell();
 		// [Linux] feature in SWT/GTK: since we cannot use Test/Preview shell as modal
 		// and if the 'main' shell of the application is disabled, switching to other
@@ -215,8 +186,8 @@ public final class ToolkitSupportImpl implements IToolkitSupport {
 	}
 
 	@Override
-	public Image getFontPreview(Object font) throws Exception {
-		m_fontPreviewShell.updateFont((Font) font);
+	public Image getFontPreview(Font font) throws Exception {
+		m_fontPreviewShell.updateFont(font);
 		return OSSupport.get().makeShot(m_fontPreviewShell);
 	}
 

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/widgets/menu/MenuInfo.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/widgets/menu/MenuInfo.java
@@ -173,7 +173,7 @@ public final class MenuInfo extends WidgetInfo implements IAdaptable {
 			displayListener.beforeMessagesLoop();
 			// On windows, when one creates a new entry the image for the menu is not displayed correctly
 			Display.getDefault().readAndDispatch();
-			visualData = ToolkitSupport.fetchMenuVisualData(getObject());//
+			visualData = ToolkitSupport.fetchMenuVisualData(getWidget());//
 		} finally {
 			displayListener.afterMessagesLoop();
 		}

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/support/IToolkitSupport.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/support/IToolkitSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ import org.eclipse.wb.internal.core.model.menu.MenuVisualData;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.Shell;
 
 /**
@@ -36,47 +37,32 @@ public interface IToolkitSupport {
 	 * Prepares shots for all {@link Control}'s in hierarchy that have flag {@link #WBP_NEED_IMAGE}.
 	 * Created image can be requested using {@link #getShotImage(Object)}.
 	 */
-	void makeShots(Object control) throws Exception;
+	void makeShots(Control control) throws Exception;
 
 	/**
 	 * @return the SWT shot {@link Image} created by {@link #makeShots(Object)}.
 	 */
-	Image getShotImage(Object control) throws Exception;
+	Image getShotImage(Control control) throws Exception;
 
 	/**
 	 * Prepares the process of taking screen shot.
 	 */
-	void beginShot(Object control);
+	void beginShot(Control control);
 
 	/**
 	 * Finalizes the process of taking screen shot.
 	 */
-	void endShot(Object control);
+	void endShot(Control control);
 
 	/**
 	 * @return the menu visual data (image, bounds, item bounds) for given menu object.
 	 */
-	MenuVisualData fetchMenuVisualData(Object menu) throws Exception;
+	MenuVisualData fetchMenuVisualData(Menu menu) throws Exception;
 
 	/**
 	 * @return the default height of single-line menu bar according to system metrics (if available).
 	 */
 	int getDefaultMenuBarHeight() throws Exception;
-
-	////////////////////////////////////////////////////////////////////////////
-	//
-	// Images
-	//
-	////////////////////////////////////////////////////////////////////////////
-	/**
-	 * @return the new toolkit {@link Image} for given SWT {@link Image}.
-	 */
-	Object createToolkitImage(Image image) throws Exception;
-
-	/**
-	 * @return the new SWT {@link Image} for given toolkit {@link Image}.
-	 */
-	Image createSWTImage(Object image) throws Exception;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -86,7 +72,7 @@ public interface IToolkitSupport {
 	/**
 	 * Shows given {@link Shell} object to user. On close {@link Shell} will be hidden, not disposed.
 	 */
-	void showShell(Object shell) throws Exception;
+	void showShell(Shell shell) throws Exception;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -101,5 +87,5 @@ public interface IToolkitSupport {
 	/**
 	 * @return {@link Image} with preview for given {@link Font}.
 	 */
-	Image getFontPreview(Object font) throws Exception;
+	Image getFontPreview(Font font) throws Exception;
 }

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/support/ToolkitSupport.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/support/ToolkitSupport.java
@@ -18,6 +18,7 @@ import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.Shell;
 
 import org.apache.commons.lang3.StringUtils;
@@ -81,21 +82,21 @@ public class ToolkitSupport extends AbstractSupport {
 	/**
 	 * Prepares the process of taking screen shot.
 	 */
-	public static void beginShot(Object control) throws Exception {
+	public static void beginShot(Control control) throws Exception {
 		getImpl().beginShot(control);
 	}
 
 	/**
 	 * Finalizes the process of taking screen shot.
 	 */
-	public static void endShot(Object control) throws Exception {
+	public static void endShot(Control control) throws Exception {
 		getImpl().endShot(control);
 	}
 
 	/**
 	 * @return {@link MenuVisualData} for given menu.
 	 */
-	public static MenuVisualData fetchMenuVisualData(Object menu) throws Exception {
+	public static MenuVisualData fetchMenuVisualData(Menu menu) throws Exception {
 		return getImpl().fetchMenuVisualData(menu);
 	}
 
@@ -108,32 +109,13 @@ public class ToolkitSupport extends AbstractSupport {
 
 	////////////////////////////////////////////////////////////////////////////
 	//
-	// Images
-	//
-	////////////////////////////////////////////////////////////////////////////
-	/**
-	 * @return the new toolkit {@link Image} for given SWT {@link Image}.
-	 */
-	public static Object createToolkitImage(Image image) throws Exception {
-		return getImpl().createToolkitImage(image);
-	}
-
-	/**
-	 * @return the new SWT {@link Image} for given toolkit {@link Image}.
-	 */
-	public static Image createSWTImage(Object image) throws Exception {
-		return getImpl().createSWTImage(image);
-	}
-
-	////////////////////////////////////////////////////////////////////////////
-	//
 	// Shell
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
 	 * Shows given {@link Shell} object to user. On close {@link Shell} will be hidden, not disposed.
 	 */
-	public static void showShell(Object shell) throws Exception {
+	public static void showShell(Shell shell) throws Exception {
 		getImpl().showShell(shell);
 	}
 
@@ -152,7 +134,7 @@ public class ToolkitSupport extends AbstractSupport {
 	/**
 	 * @return {@link Image} with preview for given {@link Font}.
 	 */
-	public static Image getFontPreview(Object font) throws Exception {
+	public static Image getFontPreview(Font font) throws Exception {
 		return getImpl().getFontPreview(font);
 	}
 


### PR DESCRIPTION
Also removes the unused "Image" utility methods.

Contributes to
https://github.com/eclipse-windowbuilder/windowbuilder/issues/942