### PR TITLE
Fix NPE when opening palette settings dialog

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPalette.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPalette.java
@@ -686,7 +686,10 @@ public class DesignerPalette {
 		}
 
 		public Shell getShell() {
-			return m_paletteComposite.getShell();
+			if (EnvironmentUtils.isGefPalette()) {
+				return m_paletteComposite.getShell();
+			}
+			return m_legacyPaletteComposite.getShell();
 		}
 	}
 }


### PR DESCRIPTION
Follow-up to dfb85a9419c0e55991e8cfdbb9efaacd8e01bed0 due to which the m_paletteComposite field is only initialized when the GEF palette is enabled.