### PR TITLE
Harmonize property selection with edit-part selection

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/structure/property/ComponentsPropertiesPage.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/structure/property/ComponentsPropertiesPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -31,6 +31,7 @@ import org.eclipse.wb.internal.core.model.property.category.PropertyCategoryProv
 import org.eclipse.wb.internal.core.model.property.editor.PropertyEditor;
 import org.eclipse.wb.internal.core.model.property.table.IPropertyExceptionHandler;
 import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
+import org.eclipse.wb.internal.core.model.property.table.PropertyTable.PropertyEditPart;
 import org.eclipse.wb.internal.core.model.util.PropertyUtils;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.external.ExternalFactoriesHelper;
@@ -47,7 +48,6 @@ import org.eclipse.jface.action.ToolBarManager;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.IStructuredSelection;
-import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StackLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -245,12 +245,14 @@ public final class ComponentsPropertiesPage implements IPage {
 	 */
 	private void trackPropertySelection() {
 		ISelectionChangedListener listener = event -> {
-			StructuredSelection selection = (StructuredSelection) event.getSelection();
-			m_activeProperty = (Property) selection.getFirstElement();
-			ExecutionUtils.runLog(() -> {
-				update_defaultValueAction();
-				update_categoryAction();
-			});
+			IStructuredSelection selection = event.getStructuredSelection();
+			if (selection.getFirstElement() instanceof PropertyEditPart editPart) {
+				m_activeProperty = editPart.getProperty();
+				ExecutionUtils.runLog(() -> {
+					update_defaultValueAction();
+					update_categoryAction();
+				});
+			}
 		};
 		m_propertyTable.addSelectionChangedListener(listener);
 		m_eventsTable.addSelectionChangedListener(listener);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/ModelMessages.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/ModelMessages.java
@@ -125,6 +125,7 @@ public class ModelMessages extends NLS {
 	public static String OrderingSupport_sendBackward;
 	public static String OrderingSupport_sendToBack;
 	public static String PropertyTable_noProperties;
+	public static String PropertyTable_unknownEditPart;
 	public static String RenameConvertSupport_beField;
 	public static String RenameConvertSupport_message;
 	public static String RenameConvertSupport_shellTitle;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/ModelMessages.properties
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/ModelMessages.properties
@@ -119,6 +119,7 @@ OrderingSupport_orderManager=Order
 OrderingSupport_sendBackward=Send Backward
 OrderingSupport_sendToBack=Send to Back
 PropertyTable_noProperties=<No Properties>
+PropertyTable_unknownEditPart=Unable to find edit part for property "{0}"
 RenameConvertSupport_beField=Be field
 RenameConvertSupport_message=Enter a new name and/or convert to field/local variable.
 RenameConvertSupport_shellTitle=Rename/convert


### PR DESCRIPTION
When a property is selected, this now also selects the corresponding edit part. Doing so allows us to check whether an edit part is selected by simply checking the getSelected() flag, rather than having to compare against the local variable of the property table.

To do so, the setActivePropertyInfo(PropertyInfo) now delegates its call to select(EditPart), which not only updates the local variable but also notifies the underlying viewer about this change. This can then be utilized in the isActiveProperty() method of the PropertyFigure.