### PR TITLE
Avoid jumping if property table is refreshed by a change

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/table/PropertyTable.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/table/PropertyTable.java
@@ -403,6 +403,8 @@ public class PropertyTable extends ScrollingGraphicalViewer {
 				DesignerPlugin.log(e);
 			}
 		}
+		setContents(m_properties);
+		getControl().getViewport().validate();
 		// update active property
 		if (m_activePropertyId != null) {
 			PropertyInfo newActivePropertyInfo = null;
@@ -418,7 +420,6 @@ public class PropertyTable extends ScrollingGraphicalViewer {
 			// set new PropertyInfo
 			setActivePropertyInfo(newActivePropertyInfo);
 		}
-		setContents(m_properties);
 	}
 
 	/**


### PR DESCRIPTION
If the table is refreshed due to editing a property, it may happen that the table is scrolled to the very top and thus hiding the selection. This is because the active property is set before the new input. Thus the selection is done on an outdated edit-part.

Instead the input should be set before the selection. Furthermore, the input needs to be validated, to ensure that the bounds of the figures are correct.