### PR TITLE
Migrate Swing-based GEF test to text blocks

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/generic/DblClickRunScriptEditPolicyTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/generic/DblClickRunScriptEditPolicyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -39,10 +39,10 @@ public class DblClickRunScriptEditPolicyTest extends SwingGefTest {
 	public void test_doFlip() throws Exception {
 		setFileContentSrc(
 				"test/MyPanel.java",
-				getTestSource(
-						"// filler filler filler filler filler",
-						"public class MyPanel extends JPanel {",
-						"}"));
+				getTestSource("""
+						// filler filler filler filler filler
+						public class MyPanel extends JPanel {
+						}"""));
 		setFileContentSrc(
 				"test/MyPanel.wbp-component.xml",
 				getSourceDQ(
@@ -54,23 +54,22 @@ public class DblClickRunScriptEditPolicyTest extends SwingGefTest {
 						"</component>"));
 		waitForAutoBuild();
 		// open editor
-		ContainerInfo panel =
-				openContainer(
-						"// filler filler filler filler filler",
-						"// filler filler filler filler filler",
-						"public class Test extends MyPanel {",
-						"  public Test() {",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends MyPanel {
+					public Test() {
+					}
+				}""");
 		// double click
 		canvas.doubleClick(panel);
-		assertEditor(
-				"// filler filler filler filler filler",
-				"// filler filler filler filler filler",
-				"public class Test extends MyPanel {",
-				"  public Test() {",
-				"    setEnabled(false);",
-				"  }",
-				"}");
+		assertEditor("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends MyPanel {
+					public Test() {
+						setEnabled(false);
+					}
+				}""");
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/generic/FlipBooleanPropertyGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/generic/FlipBooleanPropertyGefTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -52,29 +52,29 @@ public class FlipBooleanPropertyGefTest extends SwingGefTest {
 		ContainerInfo panel = openMyPanel();
 		// flip: false -> true
 		canvas.doubleClick(panel);
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      MyPanel panel = new MyPanel();",
-				"      panel.setMyExpanded(true);",
-				"      add(panel);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							MyPanel panel = new MyPanel();
+							panel.setMyExpanded(true);
+							add(panel);
+						}
+					}
+				}""");
 		// flip: true -> false
 		canvas.doubleClick(panel);
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      MyPanel panel = new MyPanel();",
-				"      add(panel);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							MyPanel panel = new MyPanel();
+							add(panel);
+						}
+					}
+				}""");
 	}
 
 	/**
@@ -96,16 +96,16 @@ public class FlipBooleanPropertyGefTest extends SwingGefTest {
 		ContainerInfo panel = openMyPanel();
 		// do double click, but property to flip does not exist, so ignore
 		canvas.doubleClick(panel);
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      MyPanel panel = new MyPanel();",
-				"      add(panel);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							MyPanel panel = new MyPanel();
+							add(panel);
+						}
+					}
+				}""");
 	}
 
 	/**
@@ -127,16 +127,16 @@ public class FlipBooleanPropertyGefTest extends SwingGefTest {
 		ContainerInfo panel = openMyPanel();
 		// do double click, but property to flip is not boolean, so ignore
 		canvas.doubleClick(panel);
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      MyPanel panel = new MyPanel();",
-				"      add(panel);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							MyPanel panel = new MyPanel();
+							add(panel);
+						}
+					}
+				}""");
 	}
 
 	@Test
@@ -146,16 +146,16 @@ public class FlipBooleanPropertyGefTest extends SwingGefTest {
 		ContainerInfo panel = openMyPanel();
 		// do double click, but no flip parameter, so ignore
 		canvas.doubleClick(panel);
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      MyPanel panel = new MyPanel();",
-				"      add(panel);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							MyPanel panel = new MyPanel();
+							add(panel);
+						}
+					}
+				}""");
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -166,30 +166,29 @@ public class FlipBooleanPropertyGefTest extends SwingGefTest {
 	private void prepareMyPanel() throws Exception {
 		setFileContentSrc(
 				"test/MyPanel.java",
-				getTestSource(
-						"public class MyPanel extends Container {",
-						"  private boolean m_expanded;",
-						"  public boolean getMyExpanded() {",
-						"    return m_expanded;",
-						"  }",
-						"  public void setMyExpanded(boolean expanded) {",
-						"    m_expanded = expanded;",
-						"  }",
-						"}"));
+				getTestSource("""
+						public class MyPanel extends Container {
+							private boolean m_expanded;
+							public boolean getMyExpanded() {
+								return m_expanded;
+							}
+							public void setMyExpanded(boolean expanded) {
+								m_expanded = expanded;
+							}
+						}"""));
 	}
 
 	private ContainerInfo openMyPanel() throws Exception {
-		ContainerInfo mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      MyPanel panel = new MyPanel();",
-						"      add(panel);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							MyPanel panel = new MyPanel();
+							add(panel);
+						}
+					}
+				}""");
 		return (ContainerInfo) mainPanel.getChildrenComponents().get(0);
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/generic/FlowContainerAbstractGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/generic/FlowContainerAbstractGefTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -44,17 +44,16 @@ public abstract class FlowContainerAbstractGefTest extends SwingGefTest {
 	@Test
 	public void test_canvas_CREATE_empty() throws Exception {
 		prepareFlowPanel();
-		ContainerInfo mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      FlowPanel panel = new FlowPanel();",
-						"      add(panel);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							FlowPanel panel = new FlowPanel();
+							add(panel);
+						}
+					}
+				}""");
 		ContainerInfo panel = (ContainerInfo) mainPanel.getChildrenComponents().get(0);
 		// begin creating Button
 		JavaInfo newButton = loadCreationTool("javax.swing.JButton", "empty");
@@ -65,41 +64,40 @@ public abstract class FlowContainerAbstractGefTest extends SwingGefTest {
 		// click, so finish creation
 		canvas.click();
 		canvas.assertNoFeedbacks();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      FlowPanel panel = new FlowPanel();",
-				"      add(panel);",
-				"      {",
-				"        JButton button = new JButton();",
-				"        panel.add(button);",
-				"      }",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							FlowPanel panel = new FlowPanel();
+							add(panel);
+							{
+								JButton button = new JButton();
+								panel.add(button);
+							}
+						}
+					}
+				}""");
 		canvas.assertPrimarySelected(newButton);
 	}
 
 	@Test
 	public void test_canvas_CREATE() throws Exception {
 		prepareFlowPanel();
-		ContainerInfo mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      FlowPanel panel = new FlowPanel();",
-						"      add(panel);",
-						"      {",
-						"        JButton existingButton = new JButton();",
-						"        panel.add(existingButton);",
-						"      }",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							FlowPanel panel = new FlowPanel();
+							add(panel);
+							{
+								JButton existingButton = new JButton();
+								panel.add(existingButton);
+							}
+						}
+					}
+				}""");
 		ContainerInfo panel = (ContainerInfo) mainPanel.getChildrenComponents().get(0);
 		ComponentInfo existingButton = panel.getChildrenComponents().get(0);
 		// begin creating Button
@@ -111,49 +109,48 @@ public abstract class FlowContainerAbstractGefTest extends SwingGefTest {
 		// click, so finish creation
 		canvas.click();
 		canvas.assertNoFeedbacks();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      FlowPanel panel = new FlowPanel();",
-				"      add(panel);",
-				"      {",
-				"        JButton button = new JButton('New button');",
-				"        panel.add(button);",
-				"      }",
-				"      {",
-				"        JButton existingButton = new JButton();",
-				"        panel.add(existingButton);",
-				"      }",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							FlowPanel panel = new FlowPanel();
+							add(panel);
+							{
+								JButton button = new JButton("New button");
+								panel.add(button);
+							}
+							{
+								JButton existingButton = new JButton();
+								panel.add(existingButton);
+							}
+						}
+					}
+				}""");
 		canvas.assertPrimarySelected(newButton);
 	}
 
 	@Test
 	public void test_canvas_MOVE() throws Exception {
 		prepareFlowPanel();
-		ContainerInfo mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      FlowPanel panel = new FlowPanel();",
-						"      add(panel);",
-						"      {",
-						"        JButton buttonA = new JButton();",
-						"        panel.add(buttonA);",
-						"      }",
-						"      {",
-						"        JButton buttonB = new JButton();",
-						"        panel.add(buttonB);",
-						"      }",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							FlowPanel panel = new FlowPanel();
+							add(panel);
+							{
+								JButton buttonA = new JButton();
+								panel.add(buttonA);
+							}
+							{
+								JButton buttonB = new JButton();
+								panel.add(buttonB);
+							}
+						}
+					}
+				}""");
 		ContainerInfo panel = (ContainerInfo) mainPanel.getChildrenComponents().get(0);
 		ComponentInfo buttonA = panel.getChildrenComponents().get(0);
 		ComponentInfo buttonB = panel.getChildrenComponents().get(1);
@@ -164,49 +161,48 @@ public abstract class FlowContainerAbstractGefTest extends SwingGefTest {
 		// done drag, so finish MOVE
 		canvas.endDrag();
 		canvas.assertNoFeedbacks();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      FlowPanel panel = new FlowPanel();",
-				"      add(panel);",
-				"      {",
-				"        JButton buttonB = new JButton();",
-				"        panel.add(buttonB);",
-				"      }",
-				"      {",
-				"        JButton buttonA = new JButton();",
-				"        panel.add(buttonA);",
-				"      }",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							FlowPanel panel = new FlowPanel();
+							add(panel);
+							{
+								JButton buttonB = new JButton();
+								panel.add(buttonB);
+							}
+							{
+								JButton buttonA = new JButton();
+								panel.add(buttonA);
+							}
+						}
+					}
+				}""");
 	}
 
 	@Ignore
 	@Test
 	public void test_canvas_PASTE() throws Exception {
 		prepareFlowPanel();
-		ContainerInfo mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      FlowPanel panel = new FlowPanel();",
-						"      add(panel);",
-						"      {",
-						"        JButton existingButton = new JButton();",
-						"        panel.add(existingButton);",
-						"      }",
-						"    }",
-						"    {",
-						"      JButton rootButton = new JButton('A');",
-						"      add(rootButton, BorderLayout.NORTH);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							FlowPanel panel = new FlowPanel();
+							add(panel);
+							{
+								JButton existingButton = new JButton();
+								panel.add(existingButton);
+							}
+						}
+						{
+							JButton rootButton = new JButton("A");
+							add(rootButton, BorderLayout.NORTH);
+						}
+					}
+				}""");
 		ContainerInfo panel = (ContainerInfo) mainPanel.getChildrenComponents().get(0);
 		ComponentInfo existingButton = panel.getChildrenComponents().get(0);
 		ComponentInfo rootButton = mainPanel.getChildrenComponents().get(1);
@@ -233,28 +229,28 @@ public abstract class FlowContainerAbstractGefTest extends SwingGefTest {
 		// click, so finish creation
 		canvas.click();
 		canvas.assertNoFeedbacks();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      FlowPanel panel = new FlowPanel();",
-				"      add(panel);",
-				"      {",
-				"        JButton button = new JButton('A');",
-				"        panel.add(button);",
-				"      }",
-				"      {",
-				"        JButton existingButton = new JButton();",
-				"        panel.add(existingButton);",
-				"      }",
-				"    }",
-				"    {",
-				"      JButton rootButton = new JButton('A');",
-				"      add(rootButton, BorderLayout.NORTH);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							FlowPanel panel = new FlowPanel();
+							add(panel);
+							{
+								JButton button = new JButton("A");
+								panel.add(button);
+							}
+							{
+								JButton existingButton = new JButton();
+								panel.add(existingButton);
+							}
+						}
+						{
+							JButton rootButton = new JButton("A");
+							add(rootButton, BorderLayout.NORTH);
+						}
+					}
+				}""");
 		// EditPart for "newButton" exists and selected
 		{
 			ComponentInfo newButton = panel.getChildrenComponents().get(0);
@@ -265,25 +261,24 @@ public abstract class FlowContainerAbstractGefTest extends SwingGefTest {
 	@Test
 	public void test_canvas_ADD() throws Exception {
 		prepareFlowPanel();
-		ContainerInfo mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      FlowPanel panel = new FlowPanel();",
-						"      add(panel);",
-						"      {",
-						"        JButton existingButton = new JButton();",
-						"        panel.add(existingButton);",
-						"      }",
-						"    }",
-						"    {",
-						"      JButton rootButton = new JButton();",
-						"      add(rootButton, BorderLayout.NORTH);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							FlowPanel panel = new FlowPanel();
+							add(panel);
+							{
+								JButton existingButton = new JButton();
+								panel.add(existingButton);
+							}
+						}
+						{
+							JButton rootButton = new JButton();
+							add(rootButton, BorderLayout.NORTH);
+						}
+					}
+				}""");
 		ContainerInfo panel = (ContainerInfo) mainPanel.getChildrenComponents().get(0);
 		ComponentInfo existingButton = panel.getChildrenComponents().get(0);
 		ComponentInfo rootButton = mainPanel.getChildrenComponents().get(1);
@@ -294,24 +289,24 @@ public abstract class FlowContainerAbstractGefTest extends SwingGefTest {
 		// done drag, so finish ADD
 		canvas.endDrag();
 		canvas.assertNoFeedbacks();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      FlowPanel panel = new FlowPanel();",
-				"      add(panel);",
-				"      {",
-				"        JButton rootButton = new JButton();",
-				"        panel.add(rootButton);",
-				"      }",
-				"      {",
-				"        JButton existingButton = new JButton();",
-				"        panel.add(existingButton);",
-				"      }",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							FlowPanel panel = new FlowPanel();
+							add(panel);
+							{
+								JButton rootButton = new JButton();
+								panel.add(rootButton);
+							}
+							{
+								JButton existingButton = new JButton();
+								panel.add(existingButton);
+							}
+						}
+					}
+				}""");
 		canvas.assertPrimarySelected(rootButton);
 	}
 
@@ -323,21 +318,20 @@ public abstract class FlowContainerAbstractGefTest extends SwingGefTest {
 	@Test
 	public void test_tree_CREATE() throws Exception {
 		prepareFlowPanel();
-		ContainerInfo mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      FlowPanel panel = new FlowPanel();",
-						"      add(panel);",
-						"      {",
-						"        JButton existingButton = new JButton();",
-						"        panel.add(existingButton);",
-						"      }",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							FlowPanel panel = new FlowPanel();
+							add(panel);
+							{
+								JButton existingButton = new JButton();
+								panel.add(existingButton);
+							}
+						}
+					}
+				}""");
 		ContainerInfo panel = (ContainerInfo) mainPanel.getChildrenComponents().get(0);
 		ComponentInfo existingButton = panel.getChildrenComponents().get(0);
 		// begin creating Button
@@ -349,49 +343,48 @@ public abstract class FlowContainerAbstractGefTest extends SwingGefTest {
 		// click, so finish creation
 		tree.click();
 		tree.assertFeedback_empty();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      FlowPanel panel = new FlowPanel();",
-				"      add(panel);",
-				"      {",
-				"        JButton button = new JButton('New button');",
-				"        panel.add(button);",
-				"      }",
-				"      {",
-				"        JButton existingButton = new JButton();",
-				"        panel.add(existingButton);",
-				"      }",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							FlowPanel panel = new FlowPanel();
+							add(panel);
+							{
+								JButton button = new JButton("New button");
+								panel.add(button);
+							}
+							{
+								JButton existingButton = new JButton();
+								panel.add(existingButton);
+							}
+						}
+					}
+				}""");
 		tree.assertPrimarySelected(newButton);
 	}
 
 	@Test
 	public void test_tree_MOVE() throws Exception {
 		prepareFlowPanel();
-		ContainerInfo mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      FlowPanel panel = new FlowPanel();",
-						"      add(panel);",
-						"      {",
-						"        JButton buttonA = new JButton();",
-						"        panel.add(buttonA);",
-						"      }",
-						"      {",
-						"        JButton buttonB = new JButton();",
-						"        panel.add(buttonB);",
-						"      }",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							FlowPanel panel = new FlowPanel();
+							add(panel);
+							{
+								JButton buttonA = new JButton();
+								panel.add(buttonA);
+							}
+							{
+								JButton buttonB = new JButton();
+								panel.add(buttonB);
+							}
+						}
+					}
+				}""");
 		ContainerInfo panel = (ContainerInfo) mainPanel.getChildrenComponents().get(0);
 		ComponentInfo buttonA = panel.getChildrenComponents().get(0);
 		ComponentInfo buttonB = panel.getChildrenComponents().get(1);
@@ -405,49 +398,48 @@ public abstract class FlowContainerAbstractGefTest extends SwingGefTest {
 		// done drag, so finish MOVE
 		tree.endDrag();
 		tree.assertFeedback_empty();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      FlowPanel panel = new FlowPanel();",
-				"      add(panel);",
-				"      {",
-				"        JButton buttonB = new JButton();",
-				"        panel.add(buttonB);",
-				"      }",
-				"      {",
-				"        JButton buttonA = new JButton();",
-				"        panel.add(buttonA);",
-				"      }",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							FlowPanel panel = new FlowPanel();
+							add(panel);
+							{
+								JButton buttonB = new JButton();
+								panel.add(buttonB);
+							}
+							{
+								JButton buttonA = new JButton();
+								panel.add(buttonA);
+							}
+						}
+					}
+				}""");
 	}
 
 	@Ignore
 	@Test
 	public void test_tree_PASTE() throws Exception {
 		prepareFlowPanel();
-		ContainerInfo mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      FlowPanel panel = new FlowPanel();",
-						"      add(panel);",
-						"      {",
-						"        JButton existingButton = new JButton();",
-						"        panel.add(existingButton);",
-						"      }",
-						"    }",
-						"    {",
-						"      JButton rootButton = new JButton('A');",
-						"      add(rootButton, BorderLayout.NORTH);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							FlowPanel panel = new FlowPanel();
+							add(panel);
+							{
+								JButton existingButton = new JButton();
+								panel.add(existingButton);
+							}
+						}
+						{
+							JButton rootButton = new JButton("A");
+							add(rootButton, BorderLayout.NORTH);
+						}
+					}
+				}""");
 		ContainerInfo panel = (ContainerInfo) mainPanel.getChildrenComponents().get(0);
 		ComponentInfo existingButton = panel.getChildrenComponents().get(0);
 		ComponentInfo rootButton = mainPanel.getChildrenComponents().get(1);
@@ -474,28 +466,28 @@ public abstract class FlowContainerAbstractGefTest extends SwingGefTest {
 		// click, so finish creation
 		tree.click();
 		tree.assertFeedback_empty();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      FlowPanel panel = new FlowPanel();",
-				"      add(panel);",
-				"      {",
-				"        JButton button = new JButton('A');",
-				"        panel.add(button);",
-				"      }",
-				"      {",
-				"        JButton existingButton = new JButton();",
-				"        panel.add(existingButton);",
-				"      }",
-				"    }",
-				"    {",
-				"      JButton rootButton = new JButton('A');",
-				"      add(rootButton, BorderLayout.NORTH);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							FlowPanel panel = new FlowPanel();
+							add(panel);
+							{
+								JButton button = new JButton("A");
+								panel.add(button);
+							}
+							{
+								JButton existingButton = new JButton();
+								panel.add(existingButton);
+							}
+						}
+						{
+							JButton rootButton = new JButton("A");
+							add(rootButton, BorderLayout.NORTH);
+						}
+					}
+				}""");
 		// EditPart for "newButton" exists and selected
 		{
 			ComponentInfo newButton = panel.getChildrenComponents().get(0);
@@ -506,25 +498,24 @@ public abstract class FlowContainerAbstractGefTest extends SwingGefTest {
 	@Test
 	public void test_tree_ADD() throws Exception {
 		prepareFlowPanel();
-		ContainerInfo mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      FlowPanel panel = new FlowPanel();",
-						"      add(panel);",
-						"      {",
-						"        JButton existingButton = new JButton();",
-						"        panel.add(existingButton);",
-						"      }",
-						"    }",
-						"    {",
-						"      JButton rootButton = new JButton();",
-						"      add(rootButton, BorderLayout.NORTH);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							FlowPanel panel = new FlowPanel();
+							add(panel);
+							{
+								JButton existingButton = new JButton();
+								panel.add(existingButton);
+							}
+						}
+						{
+							JButton rootButton = new JButton();
+							add(rootButton, BorderLayout.NORTH);
+						}
+					}
+				}""");
 		ContainerInfo panel = (ContainerInfo) mainPanel.getChildrenComponents().get(0);
 		ComponentInfo existingButton = panel.getChildrenComponents().get(0);
 		ComponentInfo rootButton = mainPanel.getChildrenComponents().get(1);
@@ -532,24 +523,24 @@ public abstract class FlowContainerAbstractGefTest extends SwingGefTest {
 		tree.startDrag(rootButton);
 		tree.dragBefore(existingButton);
 		tree.endDrag();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      FlowPanel panel = new FlowPanel();",
-				"      add(panel);",
-				"      {",
-				"        JButton rootButton = new JButton();",
-				"        panel.add(rootButton);",
-				"      }",
-				"      {",
-				"        JButton existingButton = new JButton();",
-				"        panel.add(existingButton);",
-				"      }",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							FlowPanel panel = new FlowPanel();
+							add(panel);
+							{
+								JButton rootButton = new JButton();
+								panel.add(rootButton);
+							}
+							{
+								JButton existingButton = new JButton();
+								panel.add(existingButton);
+							}
+						}
+					}
+				}""");
 		tree.assertPrimarySelected(rootButton);
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/generic/FlowContainerGroupGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/generic/FlowContainerGroupGefTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -36,25 +36,24 @@ public class FlowContainerGroupGefTest extends FlowContainerAbstractGefTest {
 	@Test
 	public void test_group_hierarchy() throws Exception {
 		prepareFlowPanel();
-		ContainerInfo mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      FlowPanel panel = new FlowPanel();",
-						"      add(panel);",
-						"      {",
-						"        JButton buttonA = new JButton();",
-						"        panel.add(buttonA);",
-						"      }",
-						"      {",
-						"        JButton buttonB = new JButton();",
-						"        panel.add(buttonB);",
-						"      }",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							FlowPanel panel = new FlowPanel();
+							add(panel);
+							{
+								JButton buttonA = new JButton();
+								panel.add(buttonA);
+							}
+							{
+								JButton buttonB = new JButton();
+								panel.add(buttonB);
+							}
+						}
+					}
+				}""");
 		ContainerInfo panel = (ContainerInfo) mainPanel.getChildrenComponents().get(0);
 		FlowContainerGroupInfo group = panel.getChildren(FlowContainerGroupInfo.class).get(0);
 		ComponentInfo buttonA = panel.getChildrenComponents().get(0);
@@ -76,25 +75,24 @@ public class FlowContainerGroupGefTest extends FlowContainerAbstractGefTest {
 	@Test
 	public void test_group_add() throws Exception {
 		prepareFlowPanel();
-		ContainerInfo mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      FlowPanel panel = new FlowPanel();",
-						"      add(panel);",
-						"      {",
-						"        JButton existingButton = new JButton();",
-						"        panel.add(existingButton);",
-						"      }",
-						"    }",
-						"    {",
-						"      JButton rootButton = new JButton('A');",
-						"      add(rootButton, BorderLayout.NORTH);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							FlowPanel panel = new FlowPanel();
+							add(panel);
+							{
+								JButton existingButton = new JButton();
+								panel.add(existingButton);
+							}
+						}
+						{
+							JButton rootButton = new JButton("A");
+							add(rootButton, BorderLayout.NORTH);
+						}
+					}
+				}""");
 		ContainerInfo panel = (ContainerInfo) mainPanel.getChildrenComponents().get(0);
 		ComponentInfo rootButton = mainPanel.getChildrenComponents().get(1);
 		FlowContainerGroupInfo group = panel.getChildren(FlowContainerGroupInfo.class).get(0);
@@ -106,24 +104,24 @@ public class FlowContainerGroupGefTest extends FlowContainerAbstractGefTest {
 		// done drag, so finish MOVE
 		tree.endDrag();
 		tree.assertFeedback_empty();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      FlowPanel panel = new FlowPanel();",
-				"      add(panel);",
-				"      {",
-				"        JButton existingButton = new JButton();",
-				"        panel.add(existingButton);",
-				"      }",
-				"      {",
-				"        JButton rootButton = new JButton('A');",
-				"        panel.add(rootButton);",
-				"      }",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							FlowPanel panel = new FlowPanel();
+							add(panel);
+							{
+								JButton existingButton = new JButton();
+								panel.add(existingButton);
+							}
+							{
+								JButton rootButton = new JButton("A");
+								panel.add(rootButton);
+							}
+						}
+					}
+				}""");
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/generic/OpenListenerEditPolicyTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/generic/OpenListenerEditPolicyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -42,14 +42,14 @@ public class OpenListenerEditPolicyTest extends SwingGefTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_newHandler() throws Exception {
-		openContainer(
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    JButton button = new JButton();",
-				"    add(button);",
-				"  }",
-				"}");
+		openContainer("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						JButton button = new JButton();
+						add(button);
+					}
+				}""");
 		ComponentInfo button = getJavaInfoByName("button");
 		// add "refresh" broadcast listener
 		final AtomicBoolean refreshFlag = new AtomicBoolean();
@@ -72,18 +72,18 @@ public class OpenListenerEditPolicyTest extends SwingGefTest {
 			assertTrue(multiMode.isSourceActive());
 		}
 		// source changes
-		assertEditor(
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    JButton button = new JButton();",
-				"    button.addActionListener(new ActionListener() {",
-				"      public void actionPerformed(ActionEvent e) {",
-				"      }",
-				"    });",
-				"    add(button);",
-				"  }",
-				"}");
+		assertEditor("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						JButton button = new JButton();
+						button.addActionListener(new ActionListener() {
+							public void actionPerformed(ActionEvent e) {
+							}
+						});
+						add(button);
+					}
+				}""");
 	}
 
 	/**
@@ -93,18 +93,18 @@ public class OpenListenerEditPolicyTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_existingHandler() throws Exception {
-		openContainer(
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    JButton button = new JButton();",
-				"    button.addActionListener(new ActionListener() {",
-				"      public void actionPerformed(ActionEvent e) {",
-				"      }",
-				"    });",
-				"    add(button);",
-				"  }",
-				"}");
+		openContainer("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						JButton button = new JButton();
+						button.addActionListener(new ActionListener() {
+							public void actionPerformed(ActionEvent e) {
+							}
+						});
+						add(button);
+					}
+				}""");
 		ComponentInfo button = getJavaInfoByName("button");
 		// add "refresh" broadcast listener
 		final AtomicBoolean refreshFlag = new AtomicBoolean();

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/generic/SimpleContainerAbstractGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/generic/SimpleContainerAbstractGefTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -44,21 +44,20 @@ public abstract class SimpleContainerAbstractGefTest extends SwingGefTest {
 	@Test
 	public void test_canvas_CREATE_filled() throws Exception {
 		prepareSimplePanel();
-		ContainerInfo mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      SimplePanel panel = new SimplePanel();",
-						"      add(panel);",
-						"      {",
-						"        JButton existingButton = new JButton();",
-						"        panel.setContent(existingButton);",
-						"      }",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							SimplePanel panel = new SimplePanel();
+							add(panel);
+							{
+								JButton existingButton = new JButton();
+								panel.setContent(existingButton);
+							}
+						}
+					}
+				}""");
 		ContainerInfo panel = (ContainerInfo) mainPanel.getChildrenComponents().get(0);
 		// begin creating Button
 		loadCreationTool("javax.swing.JButton");
@@ -71,17 +70,16 @@ public abstract class SimpleContainerAbstractGefTest extends SwingGefTest {
 	@Test
 	public void test_canvas_CREATE_empty() throws Exception {
 		prepareSimplePanel();
-		ContainerInfo mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      SimplePanel panel = new SimplePanel();",
-						"      add(panel);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							SimplePanel panel = new SimplePanel();
+							add(panel);
+						}
+					}
+				}""");
 		ContainerInfo panel = (ContainerInfo) mainPanel.getChildrenComponents().get(0);
 		// begin creating Button
 		JavaInfo newButton = loadCreationTool("javax.swing.JButton");
@@ -92,20 +90,20 @@ public abstract class SimpleContainerAbstractGefTest extends SwingGefTest {
 		// click, so finish creation
 		canvas.click();
 		canvas.assertNoFeedbacks();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      SimplePanel panel = new SimplePanel();",
-				"      add(panel);",
-				"      {",
-				"        JButton button = new JButton('New button');",
-				"        panel.setContent(button);",
-				"      }",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							SimplePanel panel = new SimplePanel();
+							add(panel);
+							{
+								JButton button = new JButton("New button");
+								panel.setContent(button);
+							}
+						}
+					}
+				}""");
 		canvas.assertPrimarySelected(newButton);
 	}
 
@@ -113,21 +111,20 @@ public abstract class SimpleContainerAbstractGefTest extends SwingGefTest {
 	@Test
 	public void test_canvas_PASTE() throws Exception {
 		prepareSimplePanel();
-		ContainerInfo mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      SimplePanel panel = new SimplePanel();",
-						"      add(panel);",
-						"    }",
-						"    {",
-						"      JButton rootButton = new JButton('A');",
-						"      add(rootButton, BorderLayout.NORTH);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							SimplePanel panel = new SimplePanel();
+							add(panel);
+						}
+						{
+							JButton rootButton = new JButton("A");
+							add(rootButton, BorderLayout.NORTH);
+						}
+					}
+				}""");
 		ContainerInfo panel = (ContainerInfo) mainPanel.getChildrenComponents().get(0);
 		ComponentInfo rootButton = mainPanel.getChildrenComponents().get(1);
 		// copy "rootButton"
@@ -152,24 +149,24 @@ public abstract class SimpleContainerAbstractGefTest extends SwingGefTest {
 		// click, so finish creation
 		canvas.click();
 		canvas.assertNoFeedbacks();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      SimplePanel panel = new SimplePanel();",
-				"      add(panel);",
-				"      {",
-				"        JButton button = new JButton('A');",
-				"        panel.setContent(button);",
-				"      }",
-				"    }",
-				"    {",
-				"      JButton rootButton = new JButton('A');",
-				"      add(rootButton, BorderLayout.NORTH);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							SimplePanel panel = new SimplePanel();
+							add(panel);
+							{
+								JButton button = new JButton("A");
+								panel.setContent(button);
+							}
+						}
+						{
+							JButton rootButton = new JButton("A");
+							add(rootButton, BorderLayout.NORTH);
+						}
+					}
+				}""");
 		// EditPart for "newButton" exists and selected
 		{
 			ComponentInfo newButton = panel.getChildrenComponents().get(0);
@@ -180,21 +177,20 @@ public abstract class SimpleContainerAbstractGefTest extends SwingGefTest {
 	@Test
 	public void test_canvas_ADD_1() throws Exception {
 		prepareSimplePanel();
-		ContainerInfo mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      SimplePanel panel = new SimplePanel();",
-						"      add(panel);",
-						"    }",
-						"    {",
-						"      JButton rootButton = new JButton();",
-						"      add(rootButton, BorderLayout.NORTH);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							SimplePanel panel = new SimplePanel();
+							add(panel);
+						}
+						{
+							JButton rootButton = new JButton();
+							add(rootButton, BorderLayout.NORTH);
+						}
+					}
+				}""");
 		ContainerInfo panel = (ContainerInfo) mainPanel.getChildrenComponents().get(0);
 		ComponentInfo rootButton = mainPanel.getChildrenComponents().get(1);
 		// drag "rootButton"
@@ -204,45 +200,44 @@ public abstract class SimpleContainerAbstractGefTest extends SwingGefTest {
 		// done drag, so finish ADD
 		canvas.endDrag();
 		canvas.assertNoFeedbacks();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      SimplePanel panel = new SimplePanel();",
-				"      add(panel);",
-				"      {",
-				"        JButton rootButton = new JButton();",
-				"        panel.setContent(rootButton);",
-				"      }",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							SimplePanel panel = new SimplePanel();
+							add(panel);
+							{
+								JButton rootButton = new JButton();
+								panel.setContent(rootButton);
+							}
+						}
+					}
+				}""");
 		canvas.assertPrimarySelected(rootButton);
 	}
 
 	@Test
 	public void test_canvas_ADD_2() throws Exception {
 		prepareSimplePanel();
-		ContainerInfo mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      SimplePanel panel = new SimplePanel();",
-						"      add(panel);",
-						"    }",
-						"    {",
-						"      JButton button_1 = new JButton();",
-						"      add(button_1, BorderLayout.NORTH);",
-						"    }",
-						"    {",
-						"      JButton button_2 = new JButton();",
-						"      add(button_2, BorderLayout.SOUTH);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							SimplePanel panel = new SimplePanel();
+							add(panel);
+						}
+						{
+							JButton button_1 = new JButton();
+							add(button_1, BorderLayout.NORTH);
+						}
+						{
+							JButton button_2 = new JButton();
+							add(button_2, BorderLayout.SOUTH);
+						}
+					}
+				}""");
 		ContainerInfo panel = (ContainerInfo) mainPanel.getChildrenComponents().get(0);
 		ComponentInfo button_1 = mainPanel.getChildrenComponents().get(1);
 		ComponentInfo button_2 = mainPanel.getChildrenComponents().get(2);
@@ -261,21 +256,20 @@ public abstract class SimpleContainerAbstractGefTest extends SwingGefTest {
 	@Test
 	public void test_tree_CREATE_filled_1() throws Exception {
 		prepareSimplePanel();
-		ContainerInfo mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      SimplePanel panel = new SimplePanel();",
-						"      add(panel);",
-						"      {",
-						"        JButton existingButton = new JButton();",
-						"        panel.setContent(existingButton);",
-						"      }",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							SimplePanel panel = new SimplePanel();
+							add(panel);
+							{
+								JButton existingButton = new JButton();
+								panel.setContent(existingButton);
+							}
+						}
+					}
+				}""");
 		ContainerInfo panel = (ContainerInfo) mainPanel.getChildrenComponents().get(0);
 		ComponentInfo existingButton = panel.getChildrenComponents().get(0);
 		// begin creating Button
@@ -289,21 +283,20 @@ public abstract class SimpleContainerAbstractGefTest extends SwingGefTest {
 	@Test
 	public void test_tree_CREATE_filled_2() throws Exception {
 		prepareSimplePanel();
-		ContainerInfo mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      SimplePanel panel = new SimplePanel();",
-						"      add(panel);",
-						"      {",
-						"        JButton existingButton = new JButton();",
-						"        panel.setContent(existingButton);",
-						"      }",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							SimplePanel panel = new SimplePanel();
+							add(panel);
+							{
+								JButton existingButton = new JButton();
+								panel.setContent(existingButton);
+							}
+						}
+					}
+				}""");
 		ContainerInfo panel = (ContainerInfo) mainPanel.getChildrenComponents().get(0);
 		// begin creating Button
 		loadCreationTool("javax.swing.JButton");
@@ -316,17 +309,16 @@ public abstract class SimpleContainerAbstractGefTest extends SwingGefTest {
 	@Test
 	public void test_tree_CREATE_empty() throws Exception {
 		prepareSimplePanel();
-		ContainerInfo mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      SimplePanel panel = new SimplePanel();",
-						"      add(panel);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							SimplePanel panel = new SimplePanel();
+							add(panel);
+						}
+					}
+				}""");
 		ContainerInfo panel = (ContainerInfo) mainPanel.getChildrenComponents().get(0);
 		// begin creating Button
 		JavaInfo newButton = loadCreationTool("javax.swing.JButton");
@@ -337,20 +329,20 @@ public abstract class SimpleContainerAbstractGefTest extends SwingGefTest {
 		// click, so finish creation
 		tree.click();
 		tree.assertFeedback_empty();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      SimplePanel panel = new SimplePanel();",
-				"      add(panel);",
-				"      {",
-				"        JButton button = new JButton('New button');",
-				"        panel.setContent(button);",
-				"      }",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							SimplePanel panel = new SimplePanel();
+							add(panel);
+							{
+								JButton button = new JButton("New button");
+								panel.setContent(button);
+							}
+						}
+					}
+				}""");
 		tree.assertPrimarySelected(newButton);
 	}
 
@@ -358,21 +350,20 @@ public abstract class SimpleContainerAbstractGefTest extends SwingGefTest {
 	@Test
 	public void test_tree_PASTE() throws Exception {
 		prepareSimplePanel();
-		ContainerInfo mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      SimplePanel panel = new SimplePanel();",
-						"      add(panel);",
-						"    }",
-						"    {",
-						"      JButton rootButton = new JButton('A');",
-						"      add(rootButton, BorderLayout.NORTH);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							SimplePanel panel = new SimplePanel();
+							add(panel);
+						}
+						{
+							JButton rootButton = new JButton("A");
+							add(rootButton, BorderLayout.NORTH);
+						}
+					}
+				}""");
 		ContainerInfo panel = (ContainerInfo) mainPanel.getChildrenComponents().get(0);
 		ComponentInfo rootButton = mainPanel.getChildrenComponents().get(1);
 		// copy "rootButton"
@@ -397,24 +388,24 @@ public abstract class SimpleContainerAbstractGefTest extends SwingGefTest {
 		// click, so finish creation
 		tree.click();
 		tree.assertFeedback_empty();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      SimplePanel panel = new SimplePanel();",
-				"      add(panel);",
-				"      {",
-				"        JButton button = new JButton('A');",
-				"        panel.setContent(button);",
-				"      }",
-				"    }",
-				"    {",
-				"      JButton rootButton = new JButton('A');",
-				"      add(rootButton, BorderLayout.NORTH);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							SimplePanel panel = new SimplePanel();
+							add(panel);
+							{
+								JButton button = new JButton("A");
+								panel.setContent(button);
+							}
+						}
+						{
+							JButton rootButton = new JButton("A");
+							add(rootButton, BorderLayout.NORTH);
+						}
+					}
+				}""");
 		// EditPart for "newButton" exists and selected
 		{
 			ComponentInfo newButton = panel.getChildrenComponents().get(0);
@@ -425,21 +416,20 @@ public abstract class SimpleContainerAbstractGefTest extends SwingGefTest {
 	@Test
 	public void test_tree_MOVE() throws Exception {
 		prepareSimplePanel();
-		ContainerInfo mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      SimplePanel panel = new SimplePanel();",
-						"      add(panel);",
-						"      {",
-						"        JButton button = new JButton();",
-						"        panel.setContent(button);",
-						"      }",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							SimplePanel panel = new SimplePanel();
+							add(panel);
+							{
+								JButton button = new JButton();
+								panel.setContent(button);
+							}
+						}
+					}
+				}""");
 		ContainerInfo panel = (ContainerInfo) mainPanel.getChildrenComponents().get(0);
 		ComponentInfo button = panel.getChildrenComponents().get(0);
 		// drag "button"
@@ -452,21 +442,20 @@ public abstract class SimpleContainerAbstractGefTest extends SwingGefTest {
 	@Test
 	public void test_tree_ADD() throws Exception {
 		prepareSimplePanel();
-		ContainerInfo mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      SimplePanel panel = new SimplePanel();",
-						"      add(panel);",
-						"    }",
-						"    {",
-						"      JButton button = new JButton();",
-						"      add(button, BorderLayout.NORTH);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							SimplePanel panel = new SimplePanel();
+							add(panel);
+						}
+						{
+							JButton button = new JButton();
+							add(button, BorderLayout.NORTH);
+						}
+					}
+				}""");
 		ContainerInfo panel = (ContainerInfo) mainPanel.getChildrenComponents().get(0);
 		ComponentInfo button = mainPanel.getChildrenComponents().get(1);
 		// drag "button"
@@ -477,20 +466,20 @@ public abstract class SimpleContainerAbstractGefTest extends SwingGefTest {
 		// done drag, so finish ADD
 		tree.endDrag();
 		tree.assertFeedback_empty();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      SimplePanel panel = new SimplePanel();",
-				"      add(panel);",
-				"      {",
-				"        JButton button = new JButton();",
-				"        panel.setContent(button);",
-				"      }",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							SimplePanel panel = new SimplePanel();
+							add(panel);
+							{
+								JButton button = new JButton();
+								panel.setContent(button);
+							}
+						}
+					}
+				}""");
 		tree.assertPrimarySelected(button);
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/nonvisual/NonVisualBeansGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/nonvisual/NonVisualBeansGefTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -40,13 +40,12 @@ public class NonVisualBeansGefTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_canNotDropLayout_asNVO() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"// filler filler filler",
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				// filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+					}
+				}""");
 		loadCreationTool("java.awt.FlowLayout");
 		// use canvas
 		canvas.sideMode().create(10, 10);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/ContributionItemTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/ContributionItemTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -47,13 +47,13 @@ public class ContributionItemTest extends AbstractNlsUiTest {
 		setFileContentSrc("test/messages_it.properties", getSourceDQ("frame.title=My JFrame IT"));
 		waitForAutoBuild();
 		// open editor
-		openContainer(
-				"import java.util.ResourceBundle;",
-				"public class Test extends JFrame {",
-				"  public Test() {",
-				"    setTitle(ResourceBundle.getBundle('test.messages').getString('frame.title')); //$NON-NLS-1$ //$NON-NLS-2$",
-				"  }",
-				"}");
+		openContainer("""
+				import java.util.ResourceBundle;
+				public class Test extends JFrame {
+					public Test() {
+						setTitle(ResourceBundle.getBundle("test.messages").getString("frame.title")); //$NON-NLS-1$ //$NON-NLS-2$
+					}
+				}""");
 		// check default title
 		assertEquals("My JFrame", ((JFrame) m_contentJavaInfo.getObject()).getTitle());
 		{

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/NlsDialogTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/NlsDialogTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -34,13 +34,12 @@ public class NlsDialogTest extends AbstractDialogTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_noSources() throws Exception {
-		String initialSource =
-				getTestSource(
-						"import java.util.ResourceBundle;",
-						"public class Test extends JFrame {",
-						"  public Test() {",
-						"  }",
-						"}");
+		String initialSource = getTestSource("""
+				import java.util.ResourceBundle;
+				public class Test extends JFrame {
+					public Test() {
+					}
+				}""");
 		openDialogNLS(initialSource, new NLSDialogRunnable() {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
@@ -61,13 +60,12 @@ public class NlsDialogTest extends AbstractDialogTest {
 		setFileContentSrc(
 				"test/messages2.properties",
 				getSourceDQ("#Direct ResourceBundle", "frame.name=My name"));
-		String initialSource =
-				getTestSource(
-						"import java.util.ResourceBundle;",
-						"public class Test extends JFrame {",
-						"  public Test() {",
-						"  }",
-						"}");
+		String initialSource = getTestSource("""
+				import java.util.ResourceBundle;
+				public class Test extends JFrame {
+					public Test() {
+					}
+				}""");
 		openDialogNLS(initialSource, new NLSDialogRunnable() {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
@@ -98,14 +96,13 @@ public class NlsDialogTest extends AbstractDialogTest {
 		setFileContentSrc("test/messages_it.properties", getSourceDQ("frame.title=My JFrame IT"));
 		waitForAutoBuild();
 		//
-		String initialSource =
-				getTestSource(
-						"import java.util.ResourceBundle;",
-						"public class Test extends JFrame {",
-						"  public Test() {",
-						"    setTitle(ResourceBundle.getBundle(\"test.messages\").getString(\"frame.title\")); //$NON-NLS-1$ //$NON-NLS-2$",
-						"  }",
-						"}");
+		String initialSource = getTestSource("""
+				import java.util.ResourceBundle;
+				public class Test extends JFrame {
+					public Test() {
+						setTitle(ResourceBundle.getBundle("test.messages").getString("frame.title")); //$NON-NLS-1$ //$NON-NLS-2$
+					}
+				}""");
 		openDialogNLS(initialSource, new NLSDialogRunnable() {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/PropertiesCompositeTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/PropertiesCompositeTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -45,12 +45,12 @@ public class PropertiesCompositeTest extends AbstractDialogTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_noSources() throws Exception {
-		String initialSource = getTestSource(
-				"// filler filler filler",
-				"public class Test extends JFrame {",
-				"  public Test() {",
-				"  }",
-				"}");
+		String initialSource = getTestSource("""
+				// filler filler filler
+				public class Test extends JFrame {
+					public Test() {
+					}
+				}""");
 		openDialogNLS(initialSource, new NLSDialogRunnable() {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
@@ -72,12 +72,12 @@ public class PropertiesCompositeTest extends AbstractDialogTest {
 		setFileContentSrc(
 				"test/messages2.properties",
 				getSourceDQ("#Direct ResourceBundle", "frame.name=My name"));
-		String initialSource = getTestSource(
-				"import java.util.ResourceBundle;",
-				"public class Test extends JFrame {",
-				"  public Test() {",
-				"  }",
-				"}");
+		String initialSource = getTestSource("""
+				import java.util.ResourceBundle;
+				public class Test extends JFrame {
+					public Test() {
+					}
+				}""");
 		openDialogNLS(initialSource, new NLSDialogRunnable() {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
@@ -102,13 +102,13 @@ public class PropertiesCompositeTest extends AbstractDialogTest {
 		setFileContentSrc("test/messages_it.properties", getSourceDQ("frame.title=My JFrame IT"));
 		waitForAutoBuild();
 		//
-		String initialSource = getTestSource(
-				"import java.util.ResourceBundle;",
-				"public class Test extends JFrame {",
-				"  public Test() {",
-				"    setTitle(ResourceBundle.getBundle(\"test.messages\").getString(\"frame.title\")); //$NON-NLS-1$ //$NON-NLS-2$",
-				"  }",
-				"}");
+		String initialSource = getTestSource("""
+				import java.util.ResourceBundle;
+				public class Test extends JFrame {
+					public Test() {
+						setTitle(ResourceBundle.getBundle("test.messages").getString("frame.title")); //$NON-NLS-1$ //$NON-NLS-2$
+					}
+				}""");
 		openDialogNLS(initialSource, new NLSDialogRunnable() {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
@@ -123,20 +123,20 @@ public class PropertiesCompositeTest extends AbstractDialogTest {
 	@Test
 	public void test_properties() throws Exception {
 		setFileContentSrc("test/messages.properties", getSourceDQ("#Direct ResourceBundle"));
-		String initialSource = getTestSource(
-				"public class Test extends JFrame {",
-				"  public Test() {",
-				"    setTitle(\"My JFrame\");",
-				"    {",
-				"      JButton button = new JButton(\"New button\");",
-				"      getContentPane().add(button, BorderLayout.NORTH);",
-				"    }",
-				"    {",
-				"      JTextField textField = new JTextField();",
-				"      getContentPane().add(textField, BorderLayout.SOUTH);",
-				"    }",
-				"  }",
-				"}");
+		String initialSource = getTestSource("""
+				public class Test extends JFrame {
+					public Test() {
+						setTitle("My JFrame");
+						{
+							JButton button = new JButton("New button");
+							getContentPane().add(button, BorderLayout.NORTH);
+						}
+						{
+							JTextField textField = new JTextField();
+							getContentPane().add(textField, BorderLayout.SOUTH);
+						}
+					}
+				}""");
 		openDialogNLS(initialSource, new NLSDialogRunnable() {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
@@ -251,12 +251,12 @@ public class PropertiesCompositeTest extends AbstractDialogTest {
 	 */
 	@Test
 	public void test_open_NewSourceDialog() throws Exception {
-		String initialSource = getTestSource(
-				"// filler filler filler",
-				"public class Test extends JFrame {",
-				"  public Test() {",
-				"  }",
-				"}");
+		String initialSource = getTestSource("""
+				// filler filler filler
+				public class Test extends JFrame {
+					public Test() {
+					}
+				}""");
 		openDialogNLS(initialSource, new NLSDialogRunnable() {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/SourceCompositeTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/SourceCompositeTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -58,13 +58,13 @@ public class SourceCompositeTest extends AbstractDialogTest {
 				getSourceDQ("frame.title=My JFrame", "frame.name=My name"));
 		waitForAutoBuild();
 		//
-		String initialSource = getTestSource(
-				"import java.util.ResourceBundle;",
-				"public class Test extends JFrame {",
-				"  public Test() {",
-				"    setTitle(ResourceBundle.getBundle(\"test.messages\").getString(\"frame.title\")); //$NON-NLS-1$ //$NON-NLS-2$",
-				"  }",
-				"}");
+		String initialSource = getTestSource("""
+				import java.util.ResourceBundle;
+				public class Test extends JFrame {
+					public Test() {
+						setTitle(ResourceBundle.getBundle("test.messages").getString("frame.title")); //$NON-NLS-1$ //$NON-NLS-2$
+					}
+				}""");
 		openDialogNLS(initialSource, new NLSDialogRunnable() {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
@@ -125,13 +125,13 @@ public class SourceCompositeTest extends AbstractDialogTest {
 				getSourceDQ("frame.title=My JFrame IT", "frame.name=My name IT"));
 		waitForAutoBuild();
 		//
-		String initialSource = getTestSource(
-				"import java.util.ResourceBundle;",
-				"public class Test extends JFrame {",
-				"  public Test() {",
-				"    setTitle(ResourceBundle.getBundle(\"test.messages\").getString(\"frame.title\")); //$NON-NLS-1$ //$NON-NLS-2$",
-				"  }",
-				"}");
+		String initialSource = getTestSource("""
+				import java.util.ResourceBundle;
+				public class Test extends JFrame {
+					public Test() {
+						setTitle(ResourceBundle.getBundle("test.messages").getString("frame.title")); //$NON-NLS-1$ //$NON-NLS-2$
+					}
+				}""");
 		openDialogNLS(initialSource, new NLSDialogRunnable() {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
@@ -199,13 +199,13 @@ public class SourceCompositeTest extends AbstractDialogTest {
 		setFileContentSrc("test/messages.properties", getSourceDQ("frame.title=My JFrame"));
 		waitForAutoBuild();
 		//
-		String initialSource = getTestSource(
-				"import java.util.ResourceBundle;",
-				"public class Test extends JFrame {",
-				"  public Test() {",
-				"    setTitle(ResourceBundle.getBundle(\"test.messages\").getString(\"frame.title\")); //$NON-NLS-1$ //$NON-NLS-2$",
-				"  }",
-				"}");
+		String initialSource = getTestSource("""
+				import java.util.ResourceBundle;
+				public class Test extends JFrame {
+					public Test() {
+						setTitle(ResourceBundle.getBundle("test.messages").getString("frame.title")); //$NON-NLS-1$ //$NON-NLS-2$
+					}
+				}""");
 		openDialogNLS(initialSource, new NLSDialogRunnable() {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
@@ -258,13 +258,13 @@ public class SourceCompositeTest extends AbstractDialogTest {
 			}
 		});
 		// check source
-		assertEditor(
-				"import java.util.ResourceBundle;",
-				"public class Test extends JFrame {",
-				"  public Test() {",
-				"    setTitle('My JFrame');",
-				"  }",
-				"}");
+		assertEditor("""
+				import java.util.ResourceBundle;
+				public class Test extends JFrame {
+					public Test() {
+						setTitle("My JFrame");
+					}
+				}""");
 		assertFalse(getFileContentSrc("test/messages.properties").contains("frame.title"));
 	}
 
@@ -273,13 +273,13 @@ public class SourceCompositeTest extends AbstractDialogTest {
 		setFileContentSrc("test/messages.properties", getSourceDQ("frame.title=My JFrame"));
 		waitForAutoBuild();
 		//
-		String initialSource = getTestSource(
-				"import java.util.ResourceBundle;",
-				"public class Test extends JFrame {",
-				"  public Test() {",
-				"    setTitle(ResourceBundle.getBundle(\"test.messages\").getString(\"frame.title\")); //$NON-NLS-1$ //$NON-NLS-2$",
-				"  }",
-				"}");
+		String initialSource = getTestSource("""
+				import java.util.ResourceBundle;
+				public class Test extends JFrame {
+					public Test() {
+						setTitle(ResourceBundle.getBundle("test.messages").getString("frame.title")); //$NON-NLS-1$ //$NON-NLS-2$
+					}
+				}""");
 		openDialogNLS(initialSource, new NLSDialogRunnable() {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
@@ -332,13 +332,13 @@ public class SourceCompositeTest extends AbstractDialogTest {
 		setFileContentSrc("test/messages.properties", getSourceDQ("frame.title=My JFrame"));
 		waitForAutoBuild();
 		//
-		String initialSource = getTestSource(
-				"import java.util.ResourceBundle;",
-				"public class Test extends JFrame {",
-				"  public Test() {",
-				"    setTitle(ResourceBundle.getBundle(\"test.messages\").getString(\"frame.title\")); //$NON-NLS-1$ //$NON-NLS-2$",
-				"  }",
-				"}");
+		String initialSource = getTestSource("""
+				import java.util.ResourceBundle;
+				public class Test extends JFrame {
+					public Test() {
+						setTitle(ResourceBundle.getBundle("test.messages").getString("frame.title")); //$NON-NLS-1$ //$NON-NLS-2$
+					}
+				}""");
 		openDialogNLS(initialSource, new NLSDialogRunnable() {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
@@ -385,13 +385,13 @@ public class SourceCompositeTest extends AbstractDialogTest {
 		setFileContentSrc("test/messages_it.properties", getSourceDQ(""));
 		waitForAutoBuild();
 		//
-		String initialSource = getTestSource(
-				"import java.util.ResourceBundle;",
-				"public class Test extends JFrame {",
-				"  public Test() {",
-				"    setTitle(ResourceBundle.getBundle(\"test.messages\").getString(\"frame.title\")); //$NON-NLS-1$ //$NON-NLS-2$",
-				"  }",
-				"}");
+		String initialSource = getTestSource("""
+				import java.util.ResourceBundle;
+				public class Test extends JFrame {
+					public Test() {
+						setTitle(ResourceBundle.getBundle("test.messages").getString("frame.title")); //$NON-NLS-1$ //$NON-NLS-2$
+					}
+				}""");
 		openDialogNLS(initialSource, new NLSDialogRunnable() {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
@@ -473,14 +473,14 @@ public class SourceCompositeTest extends AbstractDialogTest {
 		setFileContentSrc("test/messages.properties", getSourceDQ("frame.title=My JFrame"));
 		waitForAutoBuild();
 		//
-		String initialSource = getTestSource(
-				"import java.util.ResourceBundle;",
-				"public class Test extends JFrame {",
-				"  public Test() {",
-				"    setTitle(ResourceBundle.getBundle(\"test.messages\").getString(\"frame.title\")); //$NON-NLS-1$ //$NON-NLS-2$",
-				"    setName(\"My name\");",
-				"  }",
-				"}");
+		String initialSource = getTestSource("""
+				import java.util.ResourceBundle;
+				public class Test extends JFrame {
+					public Test() {
+						setTitle(ResourceBundle.getBundle("test.messages").getString("frame.title")); //$NON-NLS-1$ //$NON-NLS-2$
+						setName("My name");
+					}
+				}""");
 		openDialogNLS(initialSource, new NLSDialogRunnable() {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
@@ -522,14 +522,14 @@ public class SourceCompositeTest extends AbstractDialogTest {
 				getSourceDQ("frame.title=My JFrame", "frame.name=My name"));
 		waitForAutoBuild();
 		//
-		String initialSource = getTestSource(
-				"import java.util.ResourceBundle;",
-				"public class Test extends JFrame {",
-				"  public Test() {",
-				"    setTitle(ResourceBundle.getBundle(\"test.messages\").getString(\"frame.title\")); //$NON-NLS-1$ //$NON-NLS-2$",
-				"    setName(ResourceBundle.getBundle(\"test.messages\").getString(\"frame.name\")); //$NON-NLS-1$ //$NON-NLS-2$",
-				"  }",
-				"}");
+		String initialSource = getTestSource("""
+				import java.util.ResourceBundle;
+				public class Test extends JFrame {
+					public Test() {
+						setTitle(ResourceBundle.getBundle("test.messages").getString("frame.title")); //$NON-NLS-1$ //$NON-NLS-2$
+						setName(ResourceBundle.getBundle("test.messages").getString("frame.name")); //$NON-NLS-1$ //$NON-NLS-2$
+					}
+				}""");
 		openDialogNLS(initialSource, new NLSDialogRunnable() {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
@@ -579,13 +579,13 @@ public class SourceCompositeTest extends AbstractDialogTest {
 				getSourceDQ("frame.title=My JFrame", "frame.name=My name"));
 		waitForAutoBuild();
 		//
-		String initialSource = getTestSource(
-				"import java.util.ResourceBundle;",
-				"public class Test extends JFrame {",
-				"  public Test() {",
-				"    setTitle(ResourceBundle.getBundle(\"test.messages\").getString(\"frame.title\")); //$NON-NLS-1$ //$NON-NLS-2$",
-				"  }",
-				"}");
+		String initialSource = getTestSource("""
+				import java.util.ResourceBundle;
+				public class Test extends JFrame {
+					public Test() {
+						setTitle(ResourceBundle.getBundle("test.messages").getString("frame.title")); //$NON-NLS-1$ //$NON-NLS-2$
+					}
+				}""");
 		openDialogNLS(initialSource, new NLSDialogRunnable() {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
@@ -624,12 +624,12 @@ public class SourceCompositeTest extends AbstractDialogTest {
 				getSourceDQ("#Direct ResourceBundle", "key.1=1 2", "key.2=2 2"));
 		waitForAutoBuild();
 		//
-		String initialSource = getTestSource(
-				"// filler filler filler",
-				"public class Test extends JFrame {",
-				"  public Test() {",
-				"  }",
-				"}");
+		String initialSource = getTestSource("""
+				// filler filler filler
+				public class Test extends JFrame {
+					public Test() {
+					}
+				}""");
 		openDialogNLS(initialSource, new NLSDialogRunnable() {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/ComponentsPropertiesPageTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/ComponentsPropertiesPageTest.java
@@ -66,8 +66,12 @@ public class ComponentsPropertiesPageTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_PropertyCategoryProvider_Provider() throws Exception {
-		ContainerInfo panel = openContainer("public class Test extends JPanel {", "  public Test() {",
-				"    // filler filler filler", "  }", "}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						// filler filler filler
+					}
+				}""");
 		//
 		TestBundle testBundle = new TestBundle();
 		try {
@@ -113,8 +117,12 @@ public class ComponentsPropertiesPageTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_PropertyList_Processor() throws Exception {
-		ContainerInfo panel = openContainer("public class Test extends JPanel {", "  public Test() {",
-				"    // filler filler filler", "  }", "}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						// filler filler filler
+					}
+				}""");
 		//
 		TestBundle testBundle = new TestBundle();
 		try {

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/ComponentsTreePageTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/ComponentsTreePageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -59,16 +59,15 @@ public class ComponentsTreePageTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_ObjectEventListener_select_existingComponent() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    {",
-						"      JButton button = new JButton();",
-						"      add(button);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						{
+							JButton button = new JButton();
+							add(button);
+						}
+					}
+				}""");
 		ComponentInfo button = panel.getChildrenComponents().get(0);
 		// no initial selection
 		assertTreeSelectionModels();
@@ -88,13 +87,12 @@ public class ComponentsTreePageTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_ObjectEventListener_select_newComponent() throws Exception {
-		final ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"  }",
-						"  // filler filler filler",
-						"}");
+		final ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+					}
+					// filler filler filler
+				}""");
 		// no initial selection
 		assertTreeSelectionModels();
 		assertSelectionModels();
@@ -127,22 +125,22 @@ public class ComponentsTreePageTest extends SwingGefTest {
 	@Test
 	public void test_TreeDropListener_dragAfterException() throws Exception {
 		removeExceptionsListener();
-		openContainer(
-				"// filler filler filler filler filler",
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      JButton button = new JButton();",
-				"      add(button, BorderLayout.NORTH);",
-				"    }",
-				"    {",
-				"      JPanel inner = new JPanel();",
-				"      add(inner, BorderLayout.CENTER);",
-				"    }",
-				"  }",
-				"}");
+		openContainer("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JButton button = new JButton();
+							add(button, BorderLayout.NORTH);
+						}
+						{
+							JPanel inner = new JPanel();
+							add(inner, BorderLayout.CENTER);
+						}
+					}
+				}""");
 		// simulate exception
 		{
 			System.setProperty("wbp.EditDomain.simulateCommandException", "true");
@@ -171,22 +169,22 @@ public class ComponentsTreePageTest extends SwingGefTest {
 			ComponentInfo inner = getJavaInfoByName("inner");
 			tree.startDrag(button).dragOn(inner).endDrag();
 		}
-		assertEditor(
-				"// filler filler filler filler filler",
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      JPanel inner = new JPanel();",
-				"      add(inner, BorderLayout.CENTER);",
-				"      {",
-				"        JButton button = new JButton();",
-				"        inner.add(button);",
-				"      }",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JPanel inner = new JPanel();
+							add(inner, BorderLayout.CENTER);
+							{
+								JButton button = new JButton();
+								inner.add(button);
+							}
+						}
+					}
+				}""");
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/JavaPropertiesToolBarContributorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/JavaPropertiesToolBarContributorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -48,17 +48,17 @@ public class JavaPropertiesToolBarContributorTest extends SwingGefTest {
 	@Ignore
 	@Test
 	public void test_gotoDefinition() throws Exception {
-		openContainer(
-				"// filler filler filler filler filler",
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    {",
-				"      JButton button = new JButton();",
-				"      add(button);",
-				"    }",
-				"  }",
-				"}");
+		openContainer("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						{
+							JButton button = new JButton();
+							add(button);
+						}
+					}
+				}""");
 		JavaInfo button = getJavaInfoByName("button");
 		// prepare UiContext
 		UiContext context = new UiContext();
@@ -93,17 +93,17 @@ public class JavaPropertiesToolBarContributorTest extends SwingGefTest {
 	@Ignore
 	@Test
 	public void test_convertLocalToField() throws Exception {
-		openContainer(
-				"// filler filler filler filler filler",
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    {",
-				"      JButton button = new JButton();",
-				"      add(button);",
-				"    }",
-				"  }",
-				"}");
+		openContainer("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						{
+							JButton button = new JButton();
+							add(button);
+						}
+					}
+				}""");
 		JavaInfo button = getJavaInfoByName("button");
 		// prepare UiContext
 		UiContext context = new UiContext();
@@ -120,34 +120,34 @@ public class JavaPropertiesToolBarContributorTest extends SwingGefTest {
 			assertNotNull(toolItem);
 			context.click(toolItem, SWT.NONE);
 		}
-		assertEditor(
-				"// filler filler filler filler filler",
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  private JButton button;",
-				"  public Test() {",
-				"    {",
-				"      button = new JButton();",
-				"      add(button);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					private JButton button;
+					public Test() {
+						{
+							button = new JButton();
+							add(button);
+						}
+					}
+				}""");
 		// use action
 		{
 			ToolItem toolItem = context.getToolItem("Convert field to local");
 			assertNotNull(toolItem);
 			context.click(toolItem, SWT.NONE);
 		}
-		assertEditor(
-				"// filler filler filler filler filler",
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    {",
-				"      JButton button = new JButton();",
-				"      add(button);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						{
+							JButton button = new JButton();
+							add(button);
+						}
+					}
+				}""");
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/ReparseOnModificationTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/ReparseOnModificationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -59,20 +59,19 @@ public class ReparseOnModificationTest extends SwingGefTest {
 				createModelCompilationUnit(
 						"test",
 						"MyComponent.java",
-						getTestSource(
-								"public class MyComponent extends JPanel {",
-								"  public MyComponent() {",
-								"  }",
-								"}"));
+						getTestSource("""
+								public class MyComponent extends JPanel {
+									public MyComponent() {
+									}
+								}"""));
 		waitForAutoBuild();
 		// initial state, Design visible
-		ContainerInfo initialPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    add(new MyComponent());",
-						"  }",
-						"}");
+		ContainerInfo initialPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						add(new MyComponent());
+					}
+				}""");
 		// open MyComponent
 		IEditorPart componentEditor = JavaUI.openInEditor(componentUnit);
 		// modify MyComponent
@@ -104,20 +103,19 @@ public class ReparseOnModificationTest extends SwingGefTest {
 				createModelCompilationUnit(
 						"test",
 						"MyComponent.java",
-						getTestSource(
-								"public class MyComponent extends JPanel {",
-								"  public MyComponent() {",
-								"  }",
-								"}"));
+						getTestSource("""
+								public class MyComponent extends JPanel {
+									public MyComponent() {
+									}
+								}"""));
 		waitForAutoBuild();
 		// open editor
-		ContainerInfo initialPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    add(new MyComponent());",
-						"  }",
-						"}");
+		ContainerInfo initialPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						add(new MyComponent());
+					}
+				}""");
 		// initial state, Design visible
 		// switch to Source page
 		openSourcePage();
@@ -153,20 +151,19 @@ public class ReparseOnModificationTest extends SwingGefTest {
 				createModelCompilationUnit(
 						"test",
 						"MyComponent.java",
-						getTestSource(
-								"public class MyComponent extends JPanel {",
-								"  public MyComponent() {",
-								"  }",
-								"}"));
+						getTestSource("""
+								public class MyComponent extends JPanel {
+									public MyComponent() {
+									}
+								}"""));
 		waitForAutoBuild();
 		//
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    add(new MyComponent());",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						add(new MyComponent());
+					}
+				}""");
 		// no modifications yet
 		assertFalse(shouldReparse_editorActivated(panel));
 		// modify and check
@@ -184,28 +181,27 @@ public class ReparseOnModificationTest extends SwingGefTest {
 				createModelCompilationUnit(
 						"test",
 						"MyComponent_inner.java",
-						getTestSource(
-								"public class MyComponent_inner extends JPanel {",
-								"  public MyComponent_inner() {",
-								"  }",
-								"}"));
+						getTestSource("""
+								public class MyComponent_inner extends JPanel {
+									public MyComponent_inner() {
+									}
+								}"""));
 		setFileContentSrc(
 				"test/MyComponent.java",
-				getTestSource(
-						"public class MyComponent extends JPanel {",
-						"  public MyComponent() {",
-						"    add(new MyComponent_inner());",
-						"  }",
-						"}"));
+				getTestSource("""
+						public class MyComponent extends JPanel {
+							public MyComponent() {
+								add(new MyComponent_inner());
+							}
+						}"""));
 		waitForAutoBuild();
 		//
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    add(new MyComponent());",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						add(new MyComponent());
+					}
+				}""");
 		// no modifications yet
 		assertFalse(shouldReparse_editorActivated(panel));
 		// modify and check
@@ -220,7 +216,7 @@ public class ReparseOnModificationTest extends SwingGefTest {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected ContainerInfo openContainer(String... lines) throws Exception {
+	protected ContainerInfo openContainer(String lines) throws Exception {
 		ContainerInfo container = super.openContainer(lines);
 		waitDependencyInformation(container);
 		return container;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/SelectSupportTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/SelectSupportTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,25 +35,24 @@ public class SelectSupportTest extends SwingGefTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_all() throws Exception {
-		JavaInfo panel =
-				openContainer(
-						"// filler filler filler filler filler",
-						"public class Test extends JPanel {",
-						"	public Test() {",
-						"	  {",
-						"	    JButton button_1 = new JButton('Button 1');",
-						"	    add(button_1);",
-						"	  }",
-						"	  {",
-						"	    JButton button_2 = new JButton('Button 2');",
-						"	    add(button_2);",
-						"	  }",
-						"	  {",
-						"	    JTextField text_1 = new JTextField(15);",
-						"	    add(text_1);",
-						"	  }",
-						"	}",
-						"}");
+		JavaInfo panel = openContainer("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						{
+							JButton button_1 = new JButton("Button 1");
+							add(button_1);
+						}
+						{
+							JButton button_2 = new JButton("Button 2");
+							add(button_2);
+						}
+						{
+							JTextField text_1 = new JTextField(15);
+							add(text_1);
+						}
+					}
+				}""");
 		JavaInfo button_1 = getJavaInfoByName("button_1");
 		JavaInfo button_2 = getJavaInfoByName("button_2");
 		JavaInfo text_1 = getJavaInfoByName("text_1");
@@ -109,13 +108,13 @@ public class SelectSupportTest extends SwingGefTest {
 
 	@Test
 	public void test_disposeHierarchy() throws Exception {
-		openContainer(
-				"// filler filler filler filler filler",
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"	public Test() {",
-				"	}",
-				"}");
+		openContainer("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+					}
+				}""");
 		// reparse
 		{
 			IDesignPageSite.Helper.getSite(m_contentJavaInfo).reparse();

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/SplitModeTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/SplitModeTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -68,12 +68,12 @@ public class SplitModeTest extends SwingGefTest {
 				IPreferenceConstants.P_EDITOR_LAYOUT,
 				IPreferenceConstants.V_EDITOR_LAYOUT_SPLIT_VERTICAL_DESIGN);
 		preferences.setValue(IPreferenceConstants.P_EDITOR_LAYOUT_SYNC_DELAY, 100);
-		openContainer(
-				"// filler filler filler",
-				"public class Test extends JPanel {",
-				"	public Test() {",
-				"	} // marker",
-				"}");
+		openContainer("""
+				// filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+					} // marker
+				}""");
 		openSourcePage();
 		// initially no setEnabled(false) invocation
 		check_isEnabled(true);
@@ -103,12 +103,12 @@ public class SplitModeTest extends SwingGefTest {
 				IPreferenceConstants.P_EDITOR_LAYOUT,
 				IPreferenceConstants.V_EDITOR_LAYOUT_SPLIT_VERTICAL_DESIGN);
 		preferences.setValue(IPreferenceConstants.P_EDITOR_LAYOUT_SYNC_DELAY, -1);
-		openContainer(
-				"// filler filler filler",
-				"public class Test extends JPanel {",
-				"	public Test() {",
-				"	} // marker",
-				"}");
+		openContainer("""
+				// filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+					} // marker
+				}""");
 		openSourcePage();
 		// initially no setEnabled(false) invocation
 		check_isEnabled(true);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/TopSelectionEditPolicyTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/TopSelectionEditPolicyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -42,14 +42,13 @@ public class TopSelectionEditPolicyTest extends SwingGefTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_resizeBoth() throws Exception {
-		ComponentInfo shell =
-				openContainer(
-						"// filler filler filler filler filler",
-						"// filler filler filler filler filler",
-						"public class Test extends JPanel {",
-						"	public Test() {",
-						"	}",
-						"}");
+		ComponentInfo shell = openContainer("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+					}
+				}""");
 		// initial size
 		{
 			Rectangle bounds = shell.getBounds();
@@ -68,14 +67,13 @@ public class TopSelectionEditPolicyTest extends SwingGefTest {
 
 	@Test
 	public void test_resizeEast_toNegative() throws Exception {
-		ComponentInfo shell =
-				openContainer(
-						"// filler filler filler filler filler",
-						"// filler filler filler filler filler",
-						"public class Test extends JPanel {",
-						"	public Test() {",
-						"	}",
-						"}");
+		ComponentInfo shell = openContainer("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+					}
+				}""");
 		// initial size
 		{
 			Rectangle bounds = shell.getBounds();
@@ -96,14 +94,13 @@ public class TopSelectionEditPolicyTest extends SwingGefTest {
 
 	@Test
 	public void test_resizeSouth_toNegative() throws Exception {
-		ComponentInfo shell =
-				openContainer(
-						"// filler filler filler filler filler",
-						"// filler filler filler filler filler",
-						"public class Test extends JPanel {",
-						"	public Test() {",
-						"	}",
-						"}");
+		ComponentInfo shell = openContainer("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+					}
+				}""");
 		// initial size
 		{
 			Rectangle bounds = shell.getBounds();

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/UndoManagerTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/UndoManagerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -89,12 +89,12 @@ public class UndoManagerTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_undoRedo() throws Exception {
-		openContainer(
-				"// filler filler filler",
-				"public class Test extends JFrame {",
-				"  public Test() {",
-				"  }",
-				"}");
+		openContainer("""
+				// filler filler filler
+				public class Test extends JFrame {
+					public Test() {
+					}
+				}""");
 		String initialSource = m_lastEditor.getSource();
 		IActionBars actionBars = m_designerEditor.getEditorSite().getActionBars();
 		// do edit
@@ -115,16 +115,16 @@ public class UndoManagerTest extends SwingGefTest {
 				// use creation tool
 				canvas.moveTo(contentPane, 100, 50);
 				canvas.click();
-				assertEditor(
-						"// filler filler filler",
-						"public class Test extends JFrame {",
-						"  public Test() {",
-						"    {",
-						"      JButton button = new JButton('New button');",
-						"      getContentPane().add(button, BorderLayout.NORTH);",
-						"    }",
-						"  }",
-						"}");
+				assertEditor("""
+						// filler filler filler
+						public class Test extends JFrame {
+							public Test() {
+								{
+									JButton button = new JButton("New button");
+									getContentPane().add(button, BorderLayout.NORTH);
+								}
+							}
+						}""");
 				source_withButton = m_lastEditor.getSource();
 			}
 			// check selection on new JButton
@@ -164,12 +164,12 @@ public class UndoManagerTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_modifyLogicAndSwitchDesign() throws Exception {
-		openContainer(
-				"// filler filler filler",
-				"public class Test extends JFrame {",
-				"  public Test() {",
-				"  }",
-				"}");
+		openContainer("""
+				// filler filler filler
+				public class Test extends JFrame {
+					public Test() {
+					}
+				}""");
 		// prepare ICompilationUnit
 		ICompilationUnit compilationUnit;
 		{
@@ -210,13 +210,12 @@ public class UndoManagerTest extends SwingGefTest {
 	@Test
 	public void test_modifyInParallelJavaEditor() throws Exception {
 		IWorkbenchPage activePage = DesignerPlugin.getActivePage();
-		ContainerInfo originalContainer =
-				openContainer(
-						"// filler filler filler",
-						"public class Test extends JFrame {",
-						"  public Test() {",
-						"  }",
-						"}");
+		ContainerInfo originalContainer = openContainer("""
+				// filler filler filler
+				public class Test extends JFrame {
+					public Test() {
+					}
+				}""");
 		// open in Java editor
 		ISourceViewer sourceViewer;
 		{
@@ -250,13 +249,12 @@ public class UndoManagerTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_expandOnSelection() throws Exception {
-		ContainerInfo frame =
-				openContainer(
-						"// filler filler filler",
-						"public class Test extends JFrame {",
-						"  public Test() {",
-						"  }",
-						"}");
+		ContainerInfo frame = openContainer("""
+				// filler filler filler
+				public class Test extends JFrame {
+					public Test() {
+					}
+				}""");
 		ContainerInfo contentPane = (ContainerInfo) frame.getChildrenComponents().get(0);
 		IComponentsTree componentTree = DesignPageSite.Helper.getSite(frame).getComponentTree();
 		// collapse all
@@ -277,15 +275,14 @@ public class UndoManagerTest extends SwingGefTest {
 	@Ignore
 	@Test
 	public void test_expandRemembered_bug_0() throws Exception {
-		ContainerInfo frame =
-				openContainer(
-						"public class Test extends JFrame {",
-						"  public Test() {",
-						"    JPanel panel = new JPanel();",
-						"    getContentPane().add(panel);",
-						"    panel.add(new JButton());",
-						"  }",
-						"}");
+		ContainerInfo frame = openContainer("""
+				public class Test extends JFrame {
+					public Test() {
+						JPanel panel = new JPanel();
+						getContentPane().add(panel);
+						panel.add(new JButton());
+					}
+				}""");
 		IActionBars actionBars = m_designerEditor.getEditorSite().getActionBars();
 		ContainerInfo contentPane = (ContainerInfo) frame.getChildrenComponents().get(0);
 		ContainerInfo panel = (ContainerInfo) contentPane.getChildrenComponents().get(0);
@@ -336,13 +333,12 @@ public class UndoManagerTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_expandOnOpen_1() throws Exception {
-		ContainerInfo frame =
-				openContainer(
-						"// filler filler filler",
-						"public class Test extends JFrame {",
-						"  public Test() {",
-						"  }",
-						"}");
+		ContainerInfo frame = openContainer("""
+				// filler filler filler
+				public class Test extends JFrame {
+					public Test() {
+					}
+				}""");
 		// "frame" should be expanded
 		assertExpandedComponents(frame);
 	}
@@ -354,14 +350,13 @@ public class UndoManagerTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_expandOnOpen_2() throws Exception {
-		ContainerInfo frame =
-				openContainer(
-						"public class Test extends JFrame {",
-						"  public Test() {",
-						"    getContentPane().add(new JButton());",
-						"    getContentPane().add(new JButton());",
-						"  }",
-						"}");
+		ContainerInfo frame = openContainer("""
+				public class Test extends JFrame {
+					public Test() {
+						getContentPane().add(new JButton());
+						getContentPane().add(new JButton());
+					}
+				}""");
 		ContainerInfo contentPane = (ContainerInfo) frame.getChildrenComponents().get(0);
 		// "frame" and "contentPane" should be expanded
 		assertExpandedComponents(frame, contentPane);
@@ -375,19 +370,18 @@ public class UndoManagerTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_expandOnOpen_3() throws Exception {
-		ContainerInfo frame =
-				openContainer(
-						"// filler filler filler",
-						"public class Test extends JFrame {",
-						"  public Test() {",
-						"    {",
-						"      JPanel panel = new JPanel();",
-						"      getContentPane().add(panel);",
-						"      panel.add(new JButton());",
-						"    }",
-						"    getContentPane().add(new JButton());",
-						"  }",
-						"}");
+		ContainerInfo frame = openContainer("""
+				// filler filler filler
+				public class Test extends JFrame {
+					public Test() {
+						{
+							JPanel panel = new JPanel();
+							getContentPane().add(panel);
+							panel.add(new JButton());
+						}
+						getContentPane().add(new JButton());
+					}
+				}""");
 		ContainerInfo contentPane = (ContainerInfo) frame.getChildrenComponents().get(0);
 		// "frame" and "contentPane" should be expanded
 		assertExpandedComponents(frame, contentPane);
@@ -412,19 +406,19 @@ public class UndoManagerTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_restoreSelection_good() throws Exception {
-		openContainer(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    {",
-				"      JButton button_1 = new JButton();",
-				"      add(button_1);",
-				"    }",
-				"    {",
-				"      JButton button_2 = new JButton();",
-				"      add(button_2);",
-				"    }",
-				"  }",
-				"}");
+		openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						{
+							JButton button_1 = new JButton();
+							add(button_1);
+						}
+						{
+							JButton button_2 = new JButton();
+							add(button_2);
+						}
+					}
+				}""");
 		// select
 		tree.select(getJavaInfoByName("button_2"));
 		tree.assertPrimarySelected(getJavaInfoByName("button_2"));
@@ -444,24 +438,24 @@ public class UndoManagerTest extends SwingGefTest {
 	public void test_restoreSelection_whenComponentDisappears() throws Exception {
 		setFileContentSrc(
 				"test/MyPanel.java",
-				getTestSource(
-						"public class MyPanel extends JPanel {",
-						"  private JButton m_button = new JButton();",
-						"  public MyPanel() {",
-						"    add(m_button);",
-						"  }",
-						"  public JButton getButton() {",
-						"    return m_button;",
-						"  }",
-						"}"));
+				getTestSource("""
+						public class MyPanel extends JPanel {
+							private JButton m_button = new JButton();
+							public MyPanel() {
+								add(m_button);
+							}
+							public JButton getButton() {
+								return m_button;
+							}
+						}"""));
 		waitForAutoBuild();
 		// parse
-		openContainer(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    add(new MyPanel());",
-				"  }",
-				"}");
+		openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						add(new MyPanel());
+					}
+				}""");
 		// select
 		{
 			ComponentInfo button = getJavaInfoByName("getButton()");
@@ -471,13 +465,13 @@ public class UndoManagerTest extends SwingGefTest {
 		// use "MyPanel" which does not expose "getButton()"
 		setFileContentSrc(
 				"test/MyPanel.java",
-				getTestSource(
-						"public class MyPanel extends JPanel {",
-						"  private JButton m_button = new JButton();",
-						"  public MyPanel() {",
-						"    add(m_button);",
-						"  }",
-						"}"));
+				getTestSource("""
+						public class MyPanel extends JPanel {
+							private JButton m_button = new JButton();
+							public MyPanel() {
+								add(m_button);
+							}
+						}"""));
 		waitForAutoBuild();
 		// reparse
 		{
@@ -498,15 +492,14 @@ public class UndoManagerTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_readOnly_Yes() throws Exception {
-		String[] expectedSource =
-				new String[]{
-						"// filler filler filler",
-						"public class Test extends JFrame {",
-						"  public Test() {",
-						"  }",
-						"  void foo() {",
-						"  }",
-		"}"};
+		String expectedSource = """
+				// filler filler filler
+				public class Test extends JFrame {
+					public Test() {
+					}
+					void foo() {
+					}
+				}""";
 		test_readOnly(IDialogConstants.YES_LABEL, false, expectedSource, expectedSource);
 	}
 
@@ -515,31 +508,30 @@ public class UndoManagerTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_readOnly_No() throws Exception {
-		test_readOnly(IDialogConstants.NO_LABEL, true, new String[]{
-				"// filler filler filler",
-				"public class Test extends JFrame {",
-				"  public Test() {",
-				"  }",
-				"  void foo() {",
-				"  }",
-		"}"}, new String[]{
-				"// filler filler filler",
-				"public class Test extends JFrame {",
-				"  public Test() {",
-				"  }",
-		"}"});
+		test_readOnly(IDialogConstants.NO_LABEL, true, """
+				// filler filler filler
+				public class Test extends JFrame {
+					public Test() {
+					}
+					void foo() {
+					}
+				}""", """
+				// filler filler filler
+				public class Test extends JFrame {
+					public Test() {
+					}
+				}""");
 	}
 
 	private void test_readOnly(final String buttonId,
 			boolean expectedAccess,
-			String[] expectedSource1,
-			String[] expectedSource2) throws Exception {
-		openContainer(
-				"// filler filler filler",
-				"public class Test extends JFrame {",
-				"  public Test() {",
-				"  }",
-				"}");
+			String expectedSource1, String expectedSource2) throws Exception {
+		openContainer("""
+				// filler filler filler
+				public class Test extends JFrame {
+					public Test() {
+					}
+				}""");
 		ICompilationUnit unit = m_lastEditor.getModelUnit();
 		// modify file access to read-only mode
 		IFile unitFile = (IFile) unit.getUnderlyingResource();
@@ -582,12 +574,12 @@ public class UndoManagerTest extends SwingGefTest {
 	@DisposeProjectAfter
 	@Test
 	public void test_showDesign_switchToSource_rename_showDesign() throws Exception {
-		openContainer(
-				"// filler filler filler",
-				"public class Test extends JFrame {",
-				"  public Test() {",
-				"  }",
-				"}");
+		openContainer("""
+				// filler filler filler
+				public class Test extends JFrame {
+					public Test() {
+					}
+				}""");
 		ICompilationUnit unit = m_lastEditor.getModelUnit();
 		// switch to "Source"
 		openSourcePage();
@@ -606,15 +598,15 @@ public class UndoManagerTest extends SwingGefTest {
 	@Ignore
 	@Test
 	public void test_showDesign_rename() throws Exception {
-		openContainer(
-				"public class Test extends JFrame {",
-				"  public static void main2(String[] args) {",
-				"    Test frame = new Test();",
-				"    frame.setVisible(true);",
-				"  }",
-				"  public Test() {",
-				"  }",
-				"}");
+		openContainer("""
+				public class Test extends JFrame {
+					public static void main2(String[] args) {
+						Test frame = new Test();
+						frame.setVisible(true);
+					}
+					public Test() {
+					}
+				}""");
 		// rename
 		{
 			ICompilationUnit unit = m_lastEditor.getModelUnit();

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/actions/ActionsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/actions/ActionsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -51,12 +51,12 @@ public class ActionsTest extends SwingGefTest {
 	public void test_deactiveEditor_thenActivateAgain() throws Exception {
 		IWorkbenchPage page = DesignerPlugin.getActivePage();
 		// open Design
-		openContainer(
-				"// filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"  }",
-				"}");
+		openContainer("""
+				// filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+					}
+				}""");
 		// "Copy" action exists
 		IAction copyAction = getCopyAction();
 		assertNotNull(copyAction);
@@ -65,13 +65,13 @@ public class ActionsTest extends SwingGefTest {
 			IFile otherFile =
 					setFileContentSrc(
 							"test/Other.java",
-							getTestSource(
-									"// filler filler filler filler filler",
-									"// filler filler filler filler filler",
-									"public class Other extends JPanel {",
-									"  public Other() {",
-									"  }",
-									"}"));
+							getTestSource("""
+									// filler filler filler filler filler
+									// filler filler filler filler filler
+									public class Other extends JPanel {
+										public Other() {
+										}
+									}"""));
 			IDE.openEditor(page, otherFile);
 		}
 		// switch back to our Designer editor

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/actions/CopyActionTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/actions/CopyActionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -47,12 +47,12 @@ public class CopyActionTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_noSelection() throws Exception {
-		openContainer(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"  }",
-				"  // filler filler filler",
-				"}");
+		openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+					}
+					// filler filler filler
+				}""");
 		// prepare "Copy" action
 		IAction copyAction = getCopyAction();
 		// no selection - disabled action
@@ -65,13 +65,12 @@ public class CopyActionTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_thisSelection() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"  }",
-						"  // filler filler filler",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+					}
+					// filler filler filler
+				}""");
 		// prepare "Copy" action
 		IAction copyAction = getCopyAction();
 		// "this" selected - disabled action
@@ -85,16 +84,15 @@ public class CopyActionTest extends SwingGefTest {
 	@Ignore
 	@Test
 	public void test_copySingle() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    {",
-						"      JButton btn = new JButton();",
-						"      add(btn);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						{
+							JButton btn = new JButton();
+							add(btn);
+						}
+					}
+				}""");
 		// select "btn"
 		{
 			ComponentInfo button = panel.getChildrenComponents().get(0);
@@ -117,19 +115,19 @@ public class CopyActionTest extends SwingGefTest {
 				canvas.moveTo(targetEditPart, 10, 10);
 				canvas.click();
 			}
-			assertEditor(
-					"public class Test extends JPanel {",
-					"  public Test() {",
-					"    {",
-					"      JButton button = new JButton();",
-					"      add(button);",
-					"    }",
-					"    {",
-					"      JButton btn = new JButton();",
-					"      add(btn);",
-					"    }",
-					"  }",
-					"}");
+			assertEditor("""
+					public class Test extends JPanel {
+						public Test() {
+							{
+								JButton button = new JButton();
+								add(button);
+							}
+							{
+								JButton btn = new JButton();
+								add(btn);
+							}
+						}
+					}""");
 		}
 	}
 
@@ -140,20 +138,19 @@ public class CopyActionTest extends SwingGefTest {
 	@Ignore
 	@Test
 	public void test_copyParentAndItsChild() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    {",
-						"      JPanel inner = new JPanel();",
-						"      add(inner);",
-						"      {",
-						"        JButton button = new JButton();",
-						"        inner.add(button);",
-						"      }",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						{
+							JPanel inner = new JPanel();
+							add(inner);
+							{
+								JButton button = new JButton();
+								inner.add(button);
+							}
+						}
+					}
+				}""");
 		// select "inner" and "button"
 		{
 			ContainerInfo inner = (ContainerInfo) panel.getChildrenComponents().get(0);
@@ -177,27 +174,27 @@ public class CopyActionTest extends SwingGefTest {
 				canvas.moveTo(targetEditPart, 10, 10);
 				canvas.click();
 			}
-			assertEditor(
-					"public class Test extends JPanel {",
-					"  public Test() {",
-					"    {",
-					"      JPanel panel = new JPanel();",
-					"      add(panel);",
-					"      {",
-					"        JButton button = new JButton();",
-					"        panel.add(button);",
-					"      }",
-					"    }",
-					"    {",
-					"      JPanel inner = new JPanel();",
-					"      add(inner);",
-					"      {",
-					"        JButton button = new JButton();",
-					"        inner.add(button);",
-					"      }",
-					"    }",
-					"  }",
-					"}");
+			assertEditor("""
+					public class Test extends JPanel {
+						public Test() {
+							{
+								JPanel panel = new JPanel();
+								add(panel);
+								{
+									JButton button = new JButton();
+									panel.add(button);
+								}
+							}
+							{
+								JPanel inner = new JPanel();
+								add(inner);
+								{
+									JButton button = new JButton();
+									inner.add(button);
+								}
+							}
+						}
+					}""");
 		}
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/actions/CutActionTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/actions/CutActionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -36,12 +36,12 @@ public class CutActionTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_noSelection() throws Exception {
-		openContainer(
-				"// filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"  }",
-				"}");
+		openContainer("""
+				// filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+					}
+				}""");
 		// prepare "Cut" action
 		IAction cutAction = getCutAction();
 		// no selection - disabled action
@@ -54,13 +54,12 @@ public class CutActionTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_thisSelection() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"// filler filler filler",
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				// filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+					}
+				}""");
 		// prepare "Cut" action
 		IAction cutAction = getCutAction();
 		// "this" selected - disabled action
@@ -74,15 +73,14 @@ public class CutActionTest extends SwingGefTest {
 	@Ignore
 	@Test
 	public void test_cutSingle() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"// filler filler filler",
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    JButton button = new JButton('0');",
-						"    add(button);",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				// filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						JButton button = new JButton("0");
+						add(button);
+					}
+				}""");
 		// select "button"
 		{
 			ComponentInfo button = panel.getChildrenComponents().get(0);
@@ -93,12 +91,12 @@ public class CutActionTest extends SwingGefTest {
 			IAction cutAction = getCutAction();
 			assertTrue(cutAction.isEnabled());
 			cutAction.run();
-			assertEditor(
-					"// filler filler filler",
-					"public class Test extends JPanel {",
-					"  public Test() {",
-					"  }",
-					"}");
+			assertEditor("""
+					// filler filler filler
+					public class Test extends JPanel {
+						public Test() {
+						}
+					}""");
 		}
 		// paste
 		{
@@ -108,16 +106,16 @@ public class CutActionTest extends SwingGefTest {
 			// do paste
 			canvas.moveTo(panel, 10, 10);
 			canvas.click();
-			assertEditor(
-					"// filler filler filler",
-					"public class Test extends JPanel {",
-					"  public Test() {",
-					"    {",
-					"      JButton button = new JButton('0');",
-					"      add(button);",
-					"    }",
-					"  }",
-					"}");
+			assertEditor("""
+					// filler filler filler
+					public class Test extends JPanel {
+						public Test() {
+							{
+								JButton button = new JButton("0");
+								add(button);
+							}
+						}
+					}""");
 		}
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/actions/DeleteActionTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/actions/DeleteActionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -49,21 +49,20 @@ public class DeleteActionTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_ParentChild() throws Exception {
-		ContainerInfo thisPanel =
-				openContainer(
-						"// filler filler filler",
-						"public class Test extends JPanel {",
-						"	public Test() {",
-						"		{",
-						"			JPanel panel = new JPanel();",
-						"			add(panel);",
-						"			{",
-						"				JButton button = new JButton('New button');",
-						"				panel.add(button);",
-						"			}",
-						"		}",
-						"	}",
-						"}");
+		ContainerInfo thisPanel = openContainer("""
+				// filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						{
+							JPanel panel = new JPanel();
+							add(panel);
+							{
+								JButton button = new JButton("New button");
+								panel.add(button);
+							}
+						}
+					}
+				}""");
 		ContainerInfo panel = (ContainerInfo) thisPanel.getChildrenComponents().get(0);
 		ComponentInfo button = panel.getChildrenComponents().get(0);
 		// select
@@ -73,12 +72,12 @@ public class DeleteActionTest extends SwingGefTest {
 			IAction deleteAction = getDeleteAction();
 			assertTrue(deleteAction.isEnabled());
 			deleteAction.run();
-			assertEditor(
-					"// filler filler filler",
-					"public class Test extends JPanel {",
-					"	public Test() {",
-					"	}",
-					"}");
+			assertEditor("""
+					// filler filler filler
+					public class Test extends JPanel {
+						public Test() {
+						}
+					}""");
 		}
 	}
 
@@ -87,28 +86,27 @@ public class DeleteActionTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_canRootComponent() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"// filler filler filler filler filler",
-						"// filler filler filler filler filler",
-						"public class Test extends JPanel {",
-						"	public Test() {",
-						"	  setEnabled(false);",
-						"	}",
-						"}");
+		ContainerInfo panel = openContainer("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setEnabled(false);
+					}
+				}""");
 		// select "panel"
 		canvas.select(panel);
 		// delete "panel"
 		IAction deleteAction = getDeleteAction();
 		assertTrue(deleteAction.isEnabled());
 		deleteAction.run();
-		assertEditor(
-				"// filler filler filler filler filler",
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"	public Test() {",
-				"	}",
-				"}");
+		assertEditor("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+					}
+				}""");
 	}
 
 	/**
@@ -117,13 +115,12 @@ public class DeleteActionTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_componentInTree_butNotOnDesign() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"// filler filler filler",
-						"public class Test extends JPanel {",
-						"	public Test() {",
-						"	}",
-						"}");
+		ContainerInfo panel = openContainer("""
+				// filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+					}
+				}""");
 		// add artificial ObjectInfo
 		ObjectInfo object = new TestObjectInfo("myObject") {
 			@Override
@@ -169,15 +166,14 @@ public class DeleteActionTest extends SwingGefTest {
 				IPreferenceConstants.P_EDITOR_LAYOUT,
 				IPreferenceConstants.V_EDITOR_LAYOUT_PAGES_DESIGN);
 		try {
-			ContainerInfo panel =
-					openContainer(
-							"// filler filler filler filler filler",
-							"// filler filler filler filler filler",
-							"public class Test extends JPanel {",
-							"	public Test() {",
-							"	  add(new JButton('Some button'));",
-							"	}",
-							"}");
+			ContainerInfo panel = openContainer("""
+					// filler filler filler filler filler
+					// filler filler filler filler filler
+					public class Test extends JPanel {
+						public Test() {
+							add(new JButton("Some button"));
+						}
+					}""");
 			// select JButton
 			{
 				ComponentInfo button = panel.getChildrenComponents().get(0);
@@ -188,13 +184,13 @@ public class DeleteActionTest extends SwingGefTest {
 			assertTrue(deleteAction.isEnabled());
 			deleteAction.run();
 			assertEquals(
-					getTestSource(
-							"// filler filler filler filler filler",
-							"// filler filler filler filler filler",
-							"public class Test extends JPanel {",
-							"	public Test() {",
-							"	}",
-							"}"),
+					getTestSource("""
+							// filler filler filler filler filler
+							// filler filler filler filler filler
+							public class Test extends JPanel {
+								public Test() {
+								}
+							}"""),
 					m_lastEditor.getModelUnit().getSource());
 		} finally {
 			preferences.setToDefault(IPreferenceConstants.P_EDITOR_LAYOUT);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/actions/RefreshActionTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/actions/RefreshActionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -31,13 +31,12 @@ public class RefreshActionTest extends SwingGefTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_1() throws Exception {
-		JavaInfo currentRoot =
-				openContainer(
-						"// filler filler filler",
-						"public class Test extends JPanel {",
-						"	public Test() {",
-						"	}",
-						"}");
+		JavaInfo currentRoot = openContainer("""
+				// filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+					}
+				}""");
 		// do refresh
 		{
 			IAction refreshAction = m_designPageActions.getRefreshAction();

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/actions/SwitchActionTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/actions/SwitchActionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -34,12 +34,12 @@ public class SwitchActionTest extends SwingGefTest {
 	@Ignore
 	@Test
 	public void test_1() throws Exception {
-		openContainer(
-				"// filler filler filler",
-				"public class Test extends JPanel {",
-				"	public Test() {",
-				"	}",
-				"}");
+		openContainer("""
+				// filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+					}
+				}""");
 		MultiMode multiMode = (MultiMode) m_designerEditor.getMultiMode();
 		// prepare action
 		SwitchAction switchAction;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/validator/BorderOfChildLayoutRequestValidatorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/validator/BorderOfChildLayoutRequestValidatorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -54,20 +54,20 @@ public class BorderOfChildLayoutRequestValidatorTest extends SwingGefTest {
 		// move on "panel_1": inner part, so not "transparent"
 		canvas.moveTo(panel_1, 10, 10);
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new GridLayout());",
-				"    {",
-				"      JPanel panel_1 = new JPanel();",
-				"      add(panel_1);",
-				"      {",
-				"        JButton button = new JButton();",
-				"        panel_1.add(button);",
-				"      }",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new GridLayout());
+						{
+							JPanel panel_1 = new JPanel();
+							add(panel_1);
+							{
+								JButton button = new JButton();
+								panel_1.add(button);
+							}
+						}
+					}
+				}""");
 	}
 
 	@Test
@@ -79,20 +79,20 @@ public class BorderOfChildLayoutRequestValidatorTest extends SwingGefTest {
 		// move on border "panel_1": but it is not "transparent", because _it_ is selected, not its parent
 		canvas.moveTo(panel_1, 10, 10);
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new GridLayout());",
-				"    {",
-				"      JPanel panel_1 = new JPanel();",
-				"      add(panel_1);",
-				"      {",
-				"        JButton button = new JButton();",
-				"        panel_1.add(button);",
-				"      }",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new GridLayout());
+						{
+							JPanel panel_1 = new JPanel();
+							add(panel_1);
+							{
+								JButton button = new JButton();
+								panel_1.add(button);
+							}
+						}
+					}
+				}""");
 	}
 
 	@Test
@@ -104,20 +104,20 @@ public class BorderOfChildLayoutRequestValidatorTest extends SwingGefTest {
 		// move on border "panel_1": it is "transparent", because its parent is selected
 		canvas.moveTo(panel_1, 1, 10);
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new GridLayout());",
-				"    {",
-				"      JButton button = new JButton();",
-				"      add(button);",
-				"    }",
-				"    {",
-				"      JPanel panel_1 = new JPanel();",
-				"      add(panel_1);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new GridLayout());
+						{
+							JButton button = new JButton();
+							add(button);
+						}
+						{
+							JPanel panel_1 = new JPanel();
+							add(panel_1);
+						}
+					}
+				}""");
 	}
 
 	/**
@@ -136,34 +136,33 @@ public class BorderOfChildLayoutRequestValidatorTest extends SwingGefTest {
 		// move on border "panel_1": it is "transparent" always
 		canvas.moveTo(panel_1, 1, 10);
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new GridLayout());",
-				"    {",
-				"      JButton button = new JButton();",
-				"      add(button);",
-				"    }",
-				"    {",
-				"      JPanel panel_1 = new JPanel();",
-				"      add(panel_1);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new GridLayout());
+						{
+							JButton button = new JButton();
+							add(button);
+						}
+						{
+							JPanel panel_1 = new JPanel();
+							add(panel_1);
+						}
+					}
+				}""");
 	}
 
 	private void prepare_CREATE() throws Exception {
-		mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new GridLayout());",
-						"    {",
-						"      JPanel panel_1 = new JPanel();",
-						"      add(panel_1);",
-						"    }",
-						"  }",
-						"}");
+		mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new GridLayout());
+						{
+							JPanel panel_1 = new JPanel();
+							add(panel_1);
+						}
+					}
+				}""");
 		panel_1 = (ContainerInfo) mainPanel.getChildrenComponents().get(0);
 	}
 
@@ -179,24 +178,24 @@ public class BorderOfChildLayoutRequestValidatorTest extends SwingGefTest {
 		canvas.select(mainPanel);
 		canvas.moveTo(panel_1, 10, 10);
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new GridLayout());",
-				"    {",
-				"      JPanel panel_1 = new JPanel();",
-				"      add(panel_1);",
-				"      {",
-				"        JButton button = new JButton();",
-				"        panel_1.add(button);",
-				"      }",
-				"    }",
-				"    {",
-				"      JButton button = new JButton();",
-				"      add(button);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new GridLayout());
+						{
+							JPanel panel_1 = new JPanel();
+							add(panel_1);
+							{
+								JButton button = new JButton();
+								panel_1.add(button);
+							}
+						}
+						{
+							JButton button = new JButton();
+							add(button);
+						}
+					}
+				}""");
 	}
 
 	@Test
@@ -206,24 +205,24 @@ public class BorderOfChildLayoutRequestValidatorTest extends SwingGefTest {
 		canvas.select(panel_1);
 		canvas.moveTo(panel_1, 2, 10);
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new GridLayout());",
-				"    {",
-				"      JPanel panel_1 = new JPanel();",
-				"      add(panel_1);",
-				"      {",
-				"        JButton button = new JButton();",
-				"        panel_1.add(button);",
-				"      }",
-				"    }",
-				"    {",
-				"      JButton button = new JButton();",
-				"      add(button);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new GridLayout());
+						{
+							JPanel panel_1 = new JPanel();
+							add(panel_1);
+							{
+								JButton button = new JButton();
+								panel_1.add(button);
+							}
+						}
+						{
+							JButton button = new JButton();
+							add(button);
+						}
+					}
+				}""");
 	}
 
 	@Test
@@ -233,42 +232,41 @@ public class BorderOfChildLayoutRequestValidatorTest extends SwingGefTest {
 		canvas.select(mainPanel);
 		canvas.moveTo(panel_1, 2, 10);
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new GridLayout());",
-				"    {",
-				"      JButton button = new JButton();",
-				"      add(button);",
-				"    }",
-				"    {",
-				"      JPanel panel_1 = new JPanel();",
-				"      add(panel_1);",
-				"    }",
-				"    {",
-				"      JButton button = new JButton();",
-				"      add(button);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new GridLayout());
+						{
+							JButton button = new JButton();
+							add(button);
+						}
+						{
+							JPanel panel_1 = new JPanel();
+							add(panel_1);
+						}
+						{
+							JButton button = new JButton();
+							add(button);
+						}
+					}
+				}""");
 	}
 
 	private void prepare_PASTE() throws Exception {
-		mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new GridLayout());",
-						"    {",
-						"      JPanel panel_1 = new JPanel();",
-						"      add(panel_1);",
-						"    }",
-						"    {",
-						"      JButton button = new JButton();",
-						"      add(button);",
-						"    }",
-						"  }",
-						"}");
+		mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new GridLayout());
+						{
+							JPanel panel_1 = new JPanel();
+							add(panel_1);
+						}
+						{
+							JButton button = new JButton();
+							add(button);
+						}
+					}
+				}""");
 		panel_1 = (ContainerInfo) mainPanel.getChildrenComponents().get(0);
 		button = mainPanel.getChildrenComponents().get(1);
 		// copy "button"
@@ -295,20 +293,20 @@ public class BorderOfChildLayoutRequestValidatorTest extends SwingGefTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_ADD_inside() throws Exception {
-		openContainer(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new GridLayout());",
-				"    {",
-				"      JPanel panel_1 = new JPanel();",
-				"      add(panel_1);",
-				"    }",
-				"    {",
-				"      JButton button = new JButton();",
-				"      add(button);",
-				"    }",
-				"  }",
-				"}");
+		openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new GridLayout());
+						{
+							JPanel panel_1 = new JPanel();
+							add(panel_1);
+						}
+						{
+							JButton button = new JButton();
+							add(button);
+						}
+					}
+				}""");
 		panel_1 = getJavaInfoByName("panel_1");
 		button = getJavaInfoByName("button");
 		// drag "button"
@@ -318,39 +316,38 @@ public class BorderOfChildLayoutRequestValidatorTest extends SwingGefTest {
 		// done drag, so finish ADD
 		canvas.endDrag();
 		canvas.assertNoFeedbacks();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new GridLayout());",
-				"    {",
-				"      JPanel panel_1 = new JPanel();",
-				"      add(panel_1);",
-				"      {",
-				"        JButton button = new JButton();",
-				"        panel_1.add(button);",
-				"      }",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new GridLayout());
+						{
+							JPanel panel_1 = new JPanel();
+							add(panel_1);
+							{
+								JButton button = new JButton();
+								panel_1.add(button);
+							}
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_ADD_onBorder() throws Exception {
-		mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new GridLayout());",
-						"    {",
-						"      JPanel panel_1 = new JPanel();",
-						"      add(panel_1);",
-						"    }",
-						"    {",
-						"      JButton button = new JButton();",
-						"      add(button);",
-						"    }",
-						"  }",
-						"}");
+		mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new GridLayout());
+						{
+							JPanel panel_1 = new JPanel();
+							add(panel_1);
+						}
+						{
+							JButton button = new JButton();
+							add(button);
+						}
+					}
+				}""");
 		panel_1 = (ContainerInfo) mainPanel.getChildrenComponents().get(0);
 		button = mainPanel.getChildrenComponents().get(1);
 		// drag "button"
@@ -360,19 +357,19 @@ public class BorderOfChildLayoutRequestValidatorTest extends SwingGefTest {
 		// done drag, so finish MOVE
 		canvas.endDrag();
 		canvas.assertNoFeedbacks();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new GridLayout());",
-				"    {",
-				"      JButton button = new JButton();",
-				"      add(button);",
-				"    }",
-				"    {",
-				"      JPanel panel_1 = new JPanel();",
-				"      add(panel_1);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new GridLayout());
+						{
+							JButton button = new JButton();
+							add(button);
+						}
+						{
+							JPanel panel_1 = new JPanel();
+							add(panel_1);
+						}
+					}
+				}""");
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/SwingGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/SwingGefTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -93,12 +93,12 @@ public abstract class SwingGefTest extends DesignerEditorTestCase {
 	// Utils
 	//
 	////////////////////////////////////////////////////////////////////////////
-	protected ContainerInfo openContainer(String... lines) throws Exception {
+	protected ContainerInfo openContainer(String lines) throws Exception {
 		return openEditor(lines);
 	}
 
 	@SuppressWarnings("unchecked")
-	protected <T extends ObjectInfo> T openEditor(String... lines) throws Exception {
+	protected <T extends ObjectInfo> T openEditor(String lines) throws Exception {
 		ICompilationUnit unit = createModelCompilationUnit("test", "Test.java", getTestSource(lines));
 		openDesign(unit);
 		// prepare models
@@ -108,7 +108,7 @@ public abstract class SwingGefTest extends DesignerEditorTestCase {
 	/**
 	 * Asserts that active {@link AstEditor} has expected Swing source.
 	 */
-	protected void assertEditor(String... lines) {
+	protected void assertEditor(String lines) {
 		AstEditor editor = EditorState.getActiveJavaInfo().getEditor();
 		assertEditor(getTestSource(lines), editor);
 	}
@@ -116,16 +116,15 @@ public abstract class SwingGefTest extends DesignerEditorTestCase {
 	/**
 	 * @return the source for Swing.
 	 */
-	public String getTestSource(String... lines) {
-		lines = getDoubleQuotes(lines);
-		return getSource(new String[][]{
-			new String[]{
-					"package test;",
-					"import java.awt.*;",
-					"import java.awt.event.*;",
-					"import javax.swing.*;",
-			"import javax.swing.border.*;"},
-			lines});
+	public String getTestSource(String source) {
+		return """
+				package test;
+				import java.awt.*;
+				import java.awt.event.*;
+				import javax.swing.*;
+				import javax.swing.border.*;
+				%s
+				""".formatted(source);
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -140,18 +139,18 @@ public abstract class SwingGefTest extends DesignerEditorTestCase {
 	protected final void prepareBox(int width, int height) throws Exception {
 		setFileContentSrc(
 				"test/Box.java",
-				getTestSource(
-						"public class Box extends JLabel {",
-						"  public Box() {",
-						"    setPreferredSize(new Dimension(" + width + ", " + height + "));",
-						"    setBackground(Color.PINK);",
-						"    setOpaque(true);",
-						"  }",
-						"  public Box(String text) {",
-						"    this();",
-						"    setText(text);",
-						"  }",
-						"}"));
+				getTestSource("""
+						public class Box extends JLabel {
+							public Box() {
+								setPreferredSize(new Dimension(%d, %d));
+								setBackground(Color.PINK);
+								setOpaque(true);
+							}
+							public Box(String text) {
+								this();
+								setText(text);
+							}
+						}""".formatted(width, height)));
 		waitForAutoBuild();
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/ams/PropertyTweaksTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/ams/PropertyTweaksTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -144,15 +144,14 @@ public class PropertyTweaksTest extends SwingGefTest {
 	}
 
 	private ComponentInfo parse_MyButton() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"import ams.zpointcs.MyButton;",
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    MyButton button = new MyButton();",
-						"    add(button);",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				import ams.zpointcs.MyButton;
+				public class Test extends JPanel {
+					public Test() {
+						MyButton button = new MyButton();
+						add(button);
+					}
+				}""");
 		panel.refresh();
 		ComponentInfo button = panel.getChildrenComponents().get(0);
 		return button;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/ams/VarmenuLayoutTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/ams/VarmenuLayoutTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -62,120 +62,117 @@ public class VarmenuLayoutTest extends SwingGefTest {
 	@Ignore
 	@Test
 	public void test_CREATE() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"import ams.zpointcs.components.*;",
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new VarmenuLayout());",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				import ams.zpointcs.components.*;
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new VarmenuLayout());
+					}
+				}""");
 		panel.refresh();
 		//
 		loadCreationBox();
 		canvas.sideMode().create(100, 50);
 		canvas.target(panel).in(150, 100).move();
 		canvas.click();
-		assertEditor(
-				"import ams.zpointcs.components.*;",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new VarmenuLayout());",
-				"    {",
-				"      Box box = new Box();",
-				"      add(box, new VarmenuConstraints(150, 100, 0, 0));",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				import ams.zpointcs.components.*;
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new VarmenuLayout());
+						{
+							Box box = new Box();
+							add(box, new VarmenuConstraints(150, 100, 0, 0));
+						}
+					}
+				}""");
 	}
 
 	@Ignore
 	@Test
 	public void test_RESIZE_width() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"import ams.zpointcs.components.*;",
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new VarmenuLayout());",
-						"    {",
-						"      Box box = new Box();",
-						"      add(box, new VarmenuConstraints(150, 100, 0, 0));",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				import ams.zpointcs.components.*;
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new VarmenuLayout());
+						{
+							Box box = new Box();
+							add(box, new VarmenuConstraints(150, 100, 0, 0));
+						}
+					}
+				}""");
 		panel.refresh();
 		ComponentInfo box = panel.getChildrenComponents().get(0);
 		// drag to non-default width
 		canvas.beginResize(box, PositionConstants.EAST).dragOn(30, 0).endDrag();
-		assertEditor(
-				"import ams.zpointcs.components.*;",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new VarmenuLayout());",
-				"    {",
-				"      Box box = new Box();",
-				"      add(box, new VarmenuConstraints(150, 100, 130, 0));",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				import ams.zpointcs.components.*;
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new VarmenuLayout());
+						{
+							Box box = new Box();
+							add(box, new VarmenuConstraints(150, 100, 130, 0));
+						}
+					}
+				}""");
 		// drag to default width
 		canvas.beginResize(box, PositionConstants.EAST).dragOn(-30, 0).endDrag();
-		assertEditor(
-				"import ams.zpointcs.components.*;",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new VarmenuLayout());",
-				"    {",
-				"      Box box = new Box();",
-				"      add(box, new VarmenuConstraints(150, 100, 0, 0));",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				import ams.zpointcs.components.*;
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new VarmenuLayout());
+						{
+							Box box = new Box();
+							add(box, new VarmenuConstraints(150, 100, 0, 0));
+						}
+					}
+				}""");
 	}
 
 	@Ignore
 	@Test
 	public void test_RESIZE_height() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"import ams.zpointcs.components.*;",
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new VarmenuLayout());",
-						"    {",
-						"      Box box = new Box();",
-						"      add(box, new VarmenuConstraints(150, 100, 0, 0));",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				import ams.zpointcs.components.*;
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new VarmenuLayout());
+						{
+							Box box = new Box();
+							add(box, new VarmenuConstraints(150, 100, 0, 0));
+						}
+					}
+				}""");
 		panel.refresh();
 		ComponentInfo box = panel.getChildrenComponents().get(0);
 		// drag to non-default width
 		canvas.beginResize(box, PositionConstants.SOUTH).dragOn(0, 50).endDrag();
-		assertEditor(
-				"import ams.zpointcs.components.*;",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new VarmenuLayout());",
-				"    {",
-				"      Box box = new Box();",
-				"      add(box, new VarmenuConstraints(150, 100, 0, 100));",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				import ams.zpointcs.components.*;
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new VarmenuLayout());
+						{
+							Box box = new Box();
+							add(box, new VarmenuConstraints(150, 100, 0, 100));
+						}
+					}
+				}""");
 		// drag to default width
 		canvas.beginResize(box, PositionConstants.SOUTH).dragOn(0, -50).endDrag();
-		assertEditor(
-				"import ams.zpointcs.components.*;",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new VarmenuLayout());",
-				"    {",
-				"      Box box = new Box();",
-				"      add(box, new VarmenuConstraints(150, 100, 0, 0));",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				import ams.zpointcs.components.*;
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new VarmenuLayout());
+						{
+							Box box = new Box();
+							add(box, new VarmenuConstraints(150, 100, 0, 0));
+						}
+					}
+				}""");
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/bean/ActionGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/bean/ActionGefTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -63,17 +63,16 @@ public class ActionGefTest extends SwingGefTest {
 	@Test
 	public void test_JToolBar_ActionNewEntryInfo() throws Exception {
 		createExternalAction();
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      JToolBar toolBar = new JToolBar();",
-						"      add(toolBar, BorderLayout.NORTH);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JToolBar toolBar = new JToolBar();
+							add(toolBar, BorderLayout.NORTH);
+						}
+					}
+				}""");
 		assertHierarchy(
 				"{this: javax.swing.JPanel} {this} {/setLayout(new BorderLayout())/ /add(toolBar, BorderLayout.NORTH)/}",
 				"  {new: java.awt.BorderLayout} {empty} {/setLayout(new BorderLayout())/}",
@@ -93,28 +92,28 @@ public class ActionGefTest extends SwingGefTest {
 			canvas.target(toolBar).in(20, 5).move();
 			canvas.click();
 		}
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  private final Action action = new SwingAction();",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      JToolBar toolBar = new JToolBar();",
-				"      add(toolBar, BorderLayout.NORTH);",
-				"      {",
-				"        JButton button = toolBar.add(action);",
-				"      }",
-				"    }",
-				"  }",
-				"  private class SwingAction extends AbstractAction {",
-				"    public SwingAction() {",
-				"      putValue(NAME, 'SwingAction');",
-				"      putValue(SHORT_DESCRIPTION, 'Some short description');",
-				"    }",
-				"    public void actionPerformed(ActionEvent e) {",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					private final Action action = new SwingAction();
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JToolBar toolBar = new JToolBar();
+							add(toolBar, BorderLayout.NORTH);
+							{
+								JButton button = toolBar.add(action);
+							}
+						}
+					}
+					private class SwingAction extends AbstractAction {
+						public SwingAction() {
+							putValue(NAME, "SwingAction");
+							putValue(SHORT_DESCRIPTION, "Some short description");
+						}
+						public void actionPerformed(ActionEvent e) {
+						}
+					}
+				}""");
 		assertHierarchy(
 				"{this: javax.swing.JPanel} {this} {/setLayout(new BorderLayout())/ /add(toolBar, BorderLayout.NORTH)/}",
 				"  {new: java.awt.BorderLayout} {empty} {/setLayout(new BorderLayout())/}",
@@ -133,18 +132,17 @@ public class ActionGefTest extends SwingGefTest {
 	@Test
 	public void test_JToolBar_ActionUseEntryInfo_canvas() throws Exception {
 		createExternalAction();
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  private ExternalAction action = new ExternalAction();",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      JToolBar toolBar = new JToolBar();",
-						"      add(toolBar, BorderLayout.NORTH);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					private ExternalAction action = new ExternalAction();
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JToolBar toolBar = new JToolBar();
+							add(toolBar, BorderLayout.NORTH);
+						}
+					}
+				}""");
 		assertHierarchy(
 				"{this: javax.swing.JPanel} {this} {/setLayout(new BorderLayout())/ /add(toolBar, BorderLayout.NORTH)/}",
 				"  {new: java.awt.BorderLayout} {empty} {/setLayout(new BorderLayout())/}",
@@ -159,20 +157,20 @@ public class ActionGefTest extends SwingGefTest {
 		canvas.target(toolBar).in(10, 5).move();
 		canvas.click();
 		assertNoErrors(panel);
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  private ExternalAction action = new ExternalAction();",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      JToolBar toolBar = new JToolBar();",
-				"      add(toolBar, BorderLayout.NORTH);",
-				"      {",
-				"        JButton button = toolBar.add(action);",
-				"      }",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					private ExternalAction action = new ExternalAction();
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JToolBar toolBar = new JToolBar();
+							add(toolBar, BorderLayout.NORTH);
+							{
+								JButton button = toolBar.add(action);
+							}
+						}
+					}
+				}""");
 		// ...new "JButton" created, it should be selected
 		ComponentInfo button = toolBar.getChildrenComponents().get(0);
 		tree.assertPrimarySelected(button);
@@ -185,18 +183,17 @@ public class ActionGefTest extends SwingGefTest {
 	@Test
 	public void test_JToolBar_ActionUseEntryInfo_tree() throws Exception {
 		createExternalAction();
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  private ExternalAction action = new ExternalAction();",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      JToolBar toolBar = new JToolBar();",
-						"      add(toolBar, BorderLayout.NORTH);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					private ExternalAction action = new ExternalAction();
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JToolBar toolBar = new JToolBar();
+							add(toolBar, BorderLayout.NORTH);
+						}
+					}
+				}""");
 		assertHierarchy(
 				"{this: javax.swing.JPanel} {this} {/setLayout(new BorderLayout())/ /add(toolBar, BorderLayout.NORTH)/}",
 				"  {new: java.awt.BorderLayout} {empty} {/setLayout(new BorderLayout())/}",
@@ -211,20 +208,20 @@ public class ActionGefTest extends SwingGefTest {
 		tree.moveOn(toolBar);
 		tree.click();
 		assertNoErrors(panel);
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  private ExternalAction action = new ExternalAction();",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      JToolBar toolBar = new JToolBar();",
-				"      add(toolBar, BorderLayout.NORTH);",
-				"      {",
-				"        JButton button = toolBar.add(action);",
-				"      }",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					private ExternalAction action = new ExternalAction();
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JToolBar toolBar = new JToolBar();
+							add(toolBar, BorderLayout.NORTH);
+							{
+								JButton button = toolBar.add(action);
+							}
+						}
+					}
+				}""");
 		// ...new "JButton" created, it should be selected
 		ComponentInfo button = toolBar.getChildrenComponents().get(0);
 		tree.assertPrimarySelected(button);
@@ -238,17 +235,16 @@ public class ActionGefTest extends SwingGefTest {
 	@Test
 	public void test_JToolBar_ActionExternalEntryInfo() throws Exception {
 		createExternalAction();
-		final ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      JToolBar toolBar = new JToolBar();",
-						"      add(toolBar, BorderLayout.NORTH);",
-						"    }",
-						"  }",
-						"}");
+		final ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JToolBar toolBar = new JToolBar();
+							add(toolBar, BorderLayout.NORTH);
+						}
+					}
+				}""");
 		assertHierarchy(
 				"{this: javax.swing.JPanel} {this} {/setLayout(new BorderLayout())/ /add(toolBar, BorderLayout.NORTH)/}",
 				"  {new: java.awt.BorderLayout} {empty} {/setLayout(new BorderLayout())/}",
@@ -291,20 +287,20 @@ public class ActionGefTest extends SwingGefTest {
 		canvas.target(toolBar).in(10, 5).move();
 		canvas.click();
 		assertNoErrors(panel);
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  private final ExternalAction externalAction = new ExternalAction();",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      JToolBar toolBar = new JToolBar();",
-				"      add(toolBar, BorderLayout.NORTH);",
-				"      {",
-				"        JButton button = toolBar.add(externalAction);",
-				"      }",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					private final ExternalAction externalAction = new ExternalAction();
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JToolBar toolBar = new JToolBar();
+							add(toolBar, BorderLayout.NORTH);
+							{
+								JButton button = toolBar.add(externalAction);
+							}
+						}
+					}
+				}""");
 		assertHierarchy(
 				"{this: javax.swing.JPanel} {this} {/setLayout(new BorderLayout())/ /add(toolBar, BorderLayout.NORTH)/}",
 				"  {new: java.awt.BorderLayout} {empty} {/setLayout(new BorderLayout())/}",
@@ -328,17 +324,16 @@ public class ActionGefTest extends SwingGefTest {
 	@Test
 	public void test_JButton_setAction() throws Exception {
 		createExternalAction();
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  private ExternalAction action = new ExternalAction();",
-						"  public Test() {",
-						"    {",
-						"      JButton button = new JButton();",
-						"      add(button);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					private ExternalAction action = new ExternalAction();
+					public Test() {
+						{
+							JButton button = new JButton();
+							add(button);
+						}
+					}
+				}""");
 		assertHierarchy(
 				"{this: javax.swing.JPanel} {this} {/add(button)/}",
 				"  {implicit-layout: java.awt.FlowLayout} {implicit-layout} {}",
@@ -352,17 +347,17 @@ public class ActionGefTest extends SwingGefTest {
 		loadUseAction(action);
 		canvas.target(button).in(10, 5).move();
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  private ExternalAction action = new ExternalAction();",
-				"  public Test() {",
-				"    {",
-				"      JButton button = new JButton();",
-				"      button.setAction(action);",
-				"      add(button);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					private ExternalAction action = new ExternalAction();
+					public Test() {
+						{
+							JButton button = new JButton();
+							button.setAction(action);
+							add(button);
+						}
+					}
+				}""");
 		// ...target "button" should be selected
 		canvas.assertPrimarySelected(button);
 	}
@@ -373,29 +368,28 @@ public class ActionGefTest extends SwingGefTest {
 	@Test
 	public void test_JMenu_dropBetween_JMenuItem() throws Exception {
 		createExternalAction();
-		ContainerInfo frame =
-				openContainer(
-						"public class Test extends JFrame {",
-						"  private ExternalAction action = new ExternalAction();",
-						"  public Test() {",
-						"    {",
-						"      JMenuBar menuBar = new JMenuBar();",
-						"      setJMenuBar(menuBar);",
-						"      {",
-						"        JMenu menu = new JMenu('Menu');",
-						"        menuBar.add(menu);",
-						"        {",
-						"          JMenuItem item_1 = new JMenuItem('AAA AAA AAA');",
-						"          menu.add(item_1);",
-						"        }",
-						"        {",
-						"          JMenuItem item_2 = new JMenuItem('BBB BBB BBB');",
-						"          menu.add(item_2);",
-						"        }",
-						"      }",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo frame = openContainer("""
+				public class Test extends JFrame {
+					private ExternalAction action = new ExternalAction();
+					public Test() {
+						{
+							JMenuBar menuBar = new JMenuBar();
+							setJMenuBar(menuBar);
+							{
+								JMenu menu = new JMenu("Menu");
+								menuBar.add(menu);
+								{
+									JMenuItem item_1 = new JMenuItem("AAA AAA AAA");
+									menu.add(item_1);
+								}
+								{
+									JMenuItem item_2 = new JMenuItem("BBB BBB BBB");
+									menu.add(item_2);
+								}
+							}
+						}
+					}
+				}""");
 		assertHierarchy(
 				"{this: javax.swing.JFrame} {this} {/setJMenuBar(menuBar)/}",
 				"  {method: public java.awt.Container javax.swing.JFrame.getContentPane()} {property} {}",
@@ -418,31 +412,31 @@ public class ActionGefTest extends SwingGefTest {
 		loadUseAction(action);
 		canvas.target(item_2).in(10, 1).move();
 		canvas.click();
-		assertEditor(
-				"public class Test extends JFrame {",
-				"  private ExternalAction action = new ExternalAction();",
-				"  public Test() {",
-				"    {",
-				"      JMenuBar menuBar = new JMenuBar();",
-				"      setJMenuBar(menuBar);",
-				"      {",
-				"        JMenu menu = new JMenu('Menu');",
-				"        menuBar.add(menu);",
-				"        {",
-				"          JMenuItem item_1 = new JMenuItem('AAA AAA AAA');",
-				"          menu.add(item_1);",
-				"        }",
-				"        {",
-				"          JMenuItem menuItem = menu.add(action);",
-				"        }",
-				"        {",
-				"          JMenuItem item_2 = new JMenuItem('BBB BBB BBB');",
-				"          menu.add(item_2);",
-				"        }",
-				"      }",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JFrame {
+					private ExternalAction action = new ExternalAction();
+					public Test() {
+						{
+							JMenuBar menuBar = new JMenuBar();
+							setJMenuBar(menuBar);
+							{
+								JMenu menu = new JMenu("Menu");
+								menuBar.add(menu);
+								{
+									JMenuItem item_1 = new JMenuItem("AAA AAA AAA");
+									menu.add(item_1);
+								}
+								{
+									JMenuItem menuItem = menu.add(action);
+								}
+								{
+									JMenuItem item_2 = new JMenuItem("BBB BBB BBB");
+									menu.add(item_2);
+								}
+							}
+						}
+					}
+				}""");
 		// ...new "JMenuItem" should be selected
 		JMenuItemInfo newItem = menu.getChildrenItems().get(1);
 		assertEquals("menuItem", newItem.getVariableSupport().getName());
@@ -460,15 +454,15 @@ public class ActionGefTest extends SwingGefTest {
 	private void createExternalAction() throws Exception {
 		setFileContentSrc(
 				"test/ExternalAction.java",
-				getTestSource(
-						"public class ExternalAction extends AbstractAction {",
-						"  public ExternalAction() {",
-						"    putValue(NAME, 'My name');",
-						"    putValue(SHORT_DESCRIPTION, 'My short description');",
-						"  }",
-						"  public void actionPerformed(ActionEvent e) {",
-						"  }",
-						"}"));
+				getTestSource("""
+						public class ExternalAction extends AbstractAction {
+							public ExternalAction() {
+								putValue(NAME, "My name");
+								putValue(SHORT_DESCRIPTION, "My short description");
+							}
+							public void actionPerformed(ActionEvent e) {
+							}
+						}"""));
 		waitForAutoBuild();
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/JTabbedPaneGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/JTabbedPaneGefTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -42,35 +42,34 @@ public class JTabbedPaneGefTest extends SwingGefTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_childrenForActiveTab() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    JTabbedPane tabbedPane = new JTabbedPane(JTabbedPane.TOP);",
-						"    add(tabbedPane);",
-						"    {",
-						"      JPanel panel_1 = new JPanel();",
-						"      panel_1.setLayout(null);",
-						"      tabbedPane.addTab('AAAAAA', panel_1);",
-						"      {",
-						"        JButton button_1 = new JButton();",
-						"        button_1.setBounds(10, 10, 100, 100);",
-						"        panel_1.add(button_1);",
-						"      }",
-						"    }",
-						"    {",
-						"      JPanel panel_2 = new JPanel();",
-						"      panel_2.setLayout(null);",
-						"      tabbedPane.addTab('BBBBBB', panel_2);",
-						"      {",
-						"        JButton button_2 = new JButton();",
-						"        button_2.setBounds(110, 10, 100, 100);",
-						"        panel_2.add(button_2);",
-						"      }",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						JTabbedPane tabbedPane = new JTabbedPane(JTabbedPane.TOP);
+						add(tabbedPane);
+						{
+							JPanel panel_1 = new JPanel();
+							panel_1.setLayout(null);
+							tabbedPane.addTab("AAAAAA", panel_1);
+							{
+								JButton button_1 = new JButton();
+								button_1.setBounds(10, 10, 100, 100);
+								panel_1.add(button_1);
+							}
+						}
+						{
+							JPanel panel_2 = new JPanel();
+							panel_2.setLayout(null);
+							tabbedPane.addTab("BBBBBB", panel_2);
+							{
+								JButton button_2 = new JButton();
+								button_2.setBounds(110, 10, 100, 100);
+								panel_2.add(button_2);
+							}
+						}
+					}
+				}""");
 		JTabbedPaneInfo tabbedPane = (JTabbedPaneInfo) panel.getChildrenComponents().get(0);
 		ContainerInfo panel_1 = (ContainerInfo) tabbedPane.getChildrenComponents().get(0);
 		ContainerInfo panel_2 = (ContainerInfo) tabbedPane.getChildrenComponents().get(1);
@@ -92,22 +91,21 @@ public class JTabbedPaneGefTest extends SwingGefTest {
 
 	@Test
 	public void test_tab_MOVE() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"class Test extends JPanel {",
-						"  Test() {",
-						"    JTabbedPane tabbed = new JTabbedPane();",
-						"    add(tabbed);",
-						"    {",
-						"      JLabel label = new JLabel();",
-						"      tabbed.addTab('111', label);",
-						"    }",
-						"    {",
-						"      JButton button = new JButton();",
-						"      tabbed.addTab('222', button);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				class Test extends JPanel {
+					Test() {
+						JTabbedPane tabbed = new JTabbedPane();
+						add(tabbed);
+						{
+							JLabel label = new JLabel();
+							tabbed.addTab("111", label);
+						}
+						{
+							JButton button = new JButton();
+							tabbed.addTab("222", button);
+						}
+					}
+				}""");
 		JTabbedPaneInfo tabbedPane = (JTabbedPaneInfo) panel.getChildrenComponents().get(0);
 		ComponentInfo label = tabbedPane.getChildrenComponents().get(0);
 		ComponentInfo button = tabbedPane.getChildrenComponents().get(1);
@@ -122,20 +120,20 @@ public class JTabbedPaneGefTest extends SwingGefTest {
 		// check
 		canvas.assertNullEditPart(label);
 		canvas.assertNotNullEditPart(button);
-		assertEditor(
-				"class Test extends JPanel {",
-				"  Test() {",
-				"    JTabbedPane tabbed = new JTabbedPane();",
-				"    add(tabbed);",
-				"    {",
-				"      JButton button = new JButton();",
-				"      tabbed.addTab('222', button);",
-				"    }",
-				"    {",
-				"      JLabel label = new JLabel();",
-				"      tabbed.addTab('111', label);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				class Test extends JPanel {
+					Test() {
+						JTabbedPane tabbed = new JTabbedPane();
+						add(tabbed);
+						{
+							JButton button = new JButton();
+							tabbed.addTab("222", button);
+						}
+						{
+							JLabel label = new JLabel();
+							tabbed.addTab("111", label);
+						}
+					}
+				}""");
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/menu/JMenuGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/menu/JMenuGefTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -42,51 +42,49 @@ public class JMenuGefTest extends SwingGefTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_drop_JMenuBar_onJFrame() throws Exception {
-		ContainerInfo frame =
-				openContainer(
-						"// filler filler filler filler filler",
-						"public class Test extends JFrame {",
-						"  public Test() {",
-						"  }",
-						"}");
+		ContainerInfo frame = openContainer("""
+				// filler filler filler filler filler
+				public class Test extends JFrame {
+					public Test() {
+					}
+				}""");
 		//
 		JMenuBarInfo menuBar = loadCreationTool("javax.swing.JMenuBar");
 		canvas.moveTo(frame, 100, 5).click();
-		assertEditor(
-				"// filler filler filler filler filler",
-				"public class Test extends JFrame {",
-				"  public Test() {",
-				"    {",
-				"      JMenuBar menuBar = new JMenuBar();",
-				"      setJMenuBar(menuBar);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				// filler filler filler filler filler
+				public class Test extends JFrame {
+					public Test() {
+						{
+							JMenuBar menuBar = new JMenuBar();
+							setJMenuBar(menuBar);
+						}
+					}
+				}""");
 		canvas.assertPrimarySelected(menuBar);
 	}
 
 	@Test
 	public void test_drop_JMenuBar_onJInternalFrame() throws Exception {
-		ContainerInfo frame =
-				openContainer(
-						"// filler filler filler filler filler",
-						"public class Test extends JInternalFrame {",
-						"  public Test() {",
-						"  }",
-						"}");
+		ContainerInfo frame = openContainer("""
+				// filler filler filler filler filler
+				public class Test extends JInternalFrame {
+					public Test() {
+					}
+				}""");
 		//
 		JMenuBarInfo menuBar = loadCreationTool("javax.swing.JMenuBar");
 		canvas.moveTo(frame, 100, 5).click();
-		assertEditor(
-				"// filler filler filler filler filler",
-				"public class Test extends JInternalFrame {",
-				"  public Test() {",
-				"    {",
-				"      JMenuBar menuBar = new JMenuBar();",
-				"      setJMenuBar(menuBar);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				// filler filler filler filler filler
+				public class Test extends JInternalFrame {
+					public Test() {
+						{
+							JMenuBar menuBar = new JMenuBar();
+							setJMenuBar(menuBar);
+						}
+					}
+				}""");
 		canvas.assertPrimarySelected(menuBar);
 	}
 
@@ -95,18 +93,18 @@ public class JMenuGefTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_dontMoveMove_onItsItem() throws Exception {
-		openContainer(
-				"// filler filler filler filler filler",
-				"public class Test extends JFrame {",
-				"  public Test() {",
-				"    JMenuBar menuBar = new JMenuBar();",
-				"    setJMenuBar(menuBar);",
-				"    {",
-				"      JMenu menu = new JMenu('Test');",
-				"      menuBar.add(menu);",
-				"    }",
-				"  }",
-				"}");
+		openContainer("""
+				// filler filler filler filler filler
+				public class Test extends JFrame {
+					public Test() {
+						JMenuBar menuBar = new JMenuBar();
+						setJMenuBar(menuBar);
+						{
+							JMenu menu = new JMenu("Test");
+							menuBar.add(menu);
+						}
+					}
+				}""");
 		JavaInfo menu = getJavaInfoByName("menu");
 		//
 		canvas.moveTo(menu, 0.5, -1).beginDrag().dragOn(0, 20);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/AbsoluteLayoutGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/AbsoluteLayoutGefTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -44,48 +44,46 @@ public class AbsoluteLayoutGefTest extends SwingGefTest {
 	@Test
 	public void test_canvas_CREATE() throws Exception {
 		prepareBox();
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(null);",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+						public class Test extends JPanel {
+							public Test() {
+								setLayout(null);
+							}
+						}""");
 		// create Box
 		loadCreationBox();
 		// use canvas
 		canvas.sideMode().create(100, 50);
 		canvas.target(panel).in(30, 40).move();
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(null);",
-				"    {",
-				"      Box box = new Box();",
-				"      box.setBounds(30, 40, 100, 50);",
-				"      add(box);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(null);
+						{
+							Box box = new Box();
+							box.setBounds(30, 40, 100, 50);
+							add(box);
+						}
+					}
+				}""");
 	}
 
 	@Ignore
 	@Test
 	public void test_canvas_PASTE() throws Exception {
 		prepareBox();
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(null);",
-						"    {",
-						"      Box boxA = new Box();",
-						"      boxA.setBounds(10, 20, 100, 50);",
-						"      add(boxA);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(null);
+						{
+							Box boxA = new Box();
+							boxA.setBounds(10, 20, 100, 50);
+							add(boxA);
+						}
+					}
+				}""");
 		// copy "boxA"
 		{
 			// select "boxA"
@@ -106,102 +104,100 @@ public class AbsoluteLayoutGefTest extends SwingGefTest {
 		canvas.sideMode().create(100, 50);
 		canvas.target(panel).inX(50).inY(100).move();
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(null);",
-				"    {",
-				"      Box boxA = new Box();",
-				"      boxA.setBounds(10, 20, 100, 50);",
-				"      add(boxA);",
-				"    }",
-				"    {",
-				"      Box box = new Box();",
-				"      box.setBounds(50, 100, 100, 50);",
-				"      add(box);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(null);
+						{
+							Box boxA = new Box();
+							boxA.setBounds(10, 20, 100, 50);
+							add(boxA);
+						}
+						{
+							Box box = new Box();
+							box.setBounds(50, 100, 100, 50);
+							add(box);
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_canvas_MOVE() throws Exception {
 		prepareBox();
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(null);",
-						"    {",
-						"      Box box = new Box();",
-						"      box.setBounds(30, 40, 100, 50);",
-						"      add(box);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(null);
+						{
+							Box box = new Box();
+							box.setBounds(30, 40, 100, 50);
+							add(box);
+						}
+					}
+				}""");
 		ComponentInfo box = panel.getChildrenComponents().get(0);
 		// move
 		canvas.sideMode().beginMove(box);
 		canvas.target(panel).inX(50).inY(80).drag();
 		canvas.endDrag();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(null);",
-				"    {",
-				"      Box box = new Box();",
-				"      box.setBounds(50, 80, 100, 50);",
-				"      add(box);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(null);
+						{
+							Box box = new Box();
+							box.setBounds(50, 80, 100, 50);
+							add(box);
+						}
+					}
+				}""");
 	}
 
 	@Ignore
 	@Test
 	public void test_canvas_ADD() throws Exception {
 		prepareBox();
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(null);",
-						"    {",
-						"      JPanel inner = new JPanel();",
-						"      inner.setLayout(null);",
-						"      add(inner);",
-						"      inner.setBounds(20, 100, 200, 150);",
-						"      {",
-						"        Box box = new Box();",
-						"        box.setBounds(10, 20, 100, 50);",
-						"        inner.add(box);",
-						"      }",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(null);
+						{
+							JPanel inner = new JPanel();
+							inner.setLayout(null);
+							add(inner);
+							inner.setBounds(20, 100, 200, 150);
+							{
+								Box box = new Box();
+								box.setBounds(10, 20, 100, 50);
+								inner.add(box);
+							}
+						}
+					}
+				}""");
 		ContainerInfo inner = (ContainerInfo) panel.getChildrenComponents().get(0);
 		ComponentInfo box = inner.getChildrenComponents().get(0);
 		// move
 		canvas.sideMode().beginMove(box);
 		canvas.target(panel).in(50, 25).drag();
 		canvas.endDrag();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(null);",
-				"    {",
-				"      JPanel inner = new JPanel();",
-				"      inner.setLayout(null);",
-				"      add(inner);",
-				"      inner.setBounds(20, 100, 200, 150);",
-				"    }",
-				"    {",
-				"      Box box = new Box();",
-				"      box.setBounds(50, 25, 100, 50);",
-				"      add(box);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(null);
+						{
+							JPanel inner = new JPanel();
+							inner.setLayout(null);
+							add(inner);
+							inner.setBounds(20, 100, 200, 150);
+						}
+						{
+							Box box = new Box();
+							box.setBounds(50, 25, 100, 50);
+							add(box);
+						}
+					}
+				}""");
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -212,30 +208,29 @@ public class AbsoluteLayoutGefTest extends SwingGefTest {
 	@Test
 	public void test_tree_CREATE() throws Exception {
 		prepareBox();
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(null);",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(null);
+					}
+				}""");
 		// create Box
 		ComponentInfo newBox = loadCreationBox();
 		// use tree
 		tree.moveOn(panel);
 		tree.assertFeedback_on(panel);
 		tree.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(null);",
-				"    {",
-				"      Box box = new Box();",
-				"      box.setBounds(0, 0, 100, 50);",
-				"      add(box);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(null);
+						{
+							Box box = new Box();
+							box.setBounds(0, 0, 100, 50);
+							add(box);
+						}
+					}
+				}""");
 		tree.assertPrimarySelected(newBox);
 	}
 
@@ -243,18 +238,17 @@ public class AbsoluteLayoutGefTest extends SwingGefTest {
 	@Test
 	public void test_tree_PASTE() throws Exception {
 		prepareBox();
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(null);",
-						"    {",
-						"      Box boxA = new Box();",
-						"      boxA.setBounds(10, 20, 100, 50);",
-						"      add(boxA);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(null);
+						{
+							Box boxA = new Box();
+							boxA.setBounds(10, 20, 100, 50);
+							add(boxA);
+						}
+					}
+				}""");
 		// copy "boxA"
 		{
 			// select "boxA"
@@ -275,44 +269,43 @@ public class AbsoluteLayoutGefTest extends SwingGefTest {
 		tree.moveOn(panel);
 		tree.assertFeedback_on(panel);
 		tree.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(null);",
-				"    {",
-				"      Box boxA = new Box();",
-				"      boxA.setBounds(10, 20, 100, 50);",
-				"      add(boxA);",
-				"    }",
-				"    {",
-				"      Box box = new Box();",
-				"      box.setBounds(0, 0, 100, 50);",
-				"      add(box);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(null);
+						{
+							Box boxA = new Box();
+							boxA.setBounds(10, 20, 100, 50);
+							add(boxA);
+						}
+						{
+							Box box = new Box();
+							box.setBounds(0, 0, 100, 50);
+							add(box);
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_tree_MOVE() throws Exception {
 		prepareBox();
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(null);",
-						"    {",
-						"      Box boxA = new Box();",
-						"      boxA.setBounds(10, 20, 100, 50);",
-						"      add(boxA);",
-						"    }",
-						"    {",
-						"      Box boxB = new Box();",
-						"      boxB.setBounds(20, 100, 100, 50);",
-						"      add(boxB);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(null);
+						{
+							Box boxA = new Box();
+							boxA.setBounds(10, 20, 100, 50);
+							add(boxA);
+						}
+						{
+							Box boxB = new Box();
+							boxB.setBounds(20, 100, 100, 50);
+							add(boxB);
+						}
+					}
+				}""");
 		ComponentInfo boxA = panel.getChildrenComponents().get(0);
 		ComponentInfo boxB = panel.getChildrenComponents().get(1);
 		// use tree
@@ -320,46 +313,45 @@ public class AbsoluteLayoutGefTest extends SwingGefTest {
 		tree.dragBefore(boxA);
 		tree.assertFeedback_before(boxA);
 		tree.endDrag();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(null);",
-				"    {",
-				"      Box boxB = new Box();",
-				"      boxB.setBounds(20, 100, 100, 50);",
-				"      add(boxB);",
-				"    }",
-				"    {",
-				"      Box boxA = new Box();",
-				"      boxA.setBounds(10, 20, 100, 50);",
-				"      add(boxA);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(null);
+						{
+							Box boxB = new Box();
+							boxB.setBounds(20, 100, 100, 50);
+							add(boxB);
+						}
+						{
+							Box boxA = new Box();
+							boxA.setBounds(10, 20, 100, 50);
+							add(boxA);
+						}
+					}
+				}""");
 		tree.assertPrimarySelected(boxB);
 	}
 
 	@Test
 	public void test_tree_ADD() throws Exception {
 		prepareBox();
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(null);",
-						"    {",
-						"      JPanel inner = new JPanel();",
-						"      inner.setLayout(null);",
-						"      add(inner);",
-						"      inner.setBounds(20, 100, 200, 150);",
-						"      {",
-						"        Box box = new Box();",
-						"        box.setBounds(10, 20, 100, 50);",
-						"        inner.add(box);",
-						"      }",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(null);
+						{
+							JPanel inner = new JPanel();
+							inner.setLayout(null);
+							add(inner);
+							inner.setBounds(20, 100, 200, 150);
+							{
+								Box box = new Box();
+								box.setBounds(10, 20, 100, 50);
+								inner.add(box);
+							}
+						}
+					}
+				}""");
 		ContainerInfo inner = (ContainerInfo) panel.getChildrenComponents().get(0);
 		ComponentInfo box = inner.getChildrenComponents().get(0);
 		// use tree
@@ -367,22 +359,22 @@ public class AbsoluteLayoutGefTest extends SwingGefTest {
 		tree.dragOn(panel);
 		tree.assertFeedback_on(panel);
 		tree.endDrag();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(null);",
-				"    {",
-				"      JPanel inner = new JPanel();",
-				"      inner.setLayout(null);",
-				"      add(inner);",
-				"      inner.setBounds(20, 100, 200, 150);",
-				"    }",
-				"    {",
-				"      Box box = new Box();",
-				"      box.setBounds(0, 0, 100, 50);",
-				"      add(box);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(null);
+						{
+							JPanel inner = new JPanel();
+							inner.setLayout(null);
+							add(inner);
+							inner.setBounds(20, 100, 200, 150);
+						}
+						{
+							Box box = new Box();
+							box.setBounds(0, 0, 100, 50);
+							add(box);
+						}
+					}
+				}""");
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/FormLayout/FormLayoutGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/FormLayout/FormLayoutGefTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,6 @@ package org.eclipse.wb.tests.designer.swing.model.layout.FormLayout;
 
 import org.eclipse.wb.core.gef.policy.layout.grid.IGridInfo;
 import org.eclipse.wb.gef.graphical.policies.LayoutEditPolicy;
-import org.eclipse.wb.internal.core.utils.jdt.core.CodeUtils;
 import org.eclipse.wb.internal.swing.FormLayout.model.FormColumnInfo;
 import org.eclipse.wb.internal.swing.FormLayout.model.FormLayoutInfo;
 import org.eclipse.wb.internal.swing.FormLayout.model.FormRowInfo;
@@ -89,25 +88,25 @@ public class FormLayoutGefTest extends SwingGefTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_setLayout_empty() throws Exception {
-		openPanel(
-				"// filler filler filler filler filler",
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"  }",
-				"}");
+		openPanel("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+					}
+				}""");
 		//
 		loadCreationTool("com.jgoodies.forms.layout.FormLayout");
 		canvas.moveTo(panel, 0.5, 0.5).click();
-		assertEditor(
-				"// filler filler filler filler filler",
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {},",
-				"      new RowSpec[] {}));",
-				"  }",
-				"}");
+		assertEditor("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {},
+							new RowSpec[] {}));
+					}
+				}""");
 	}
 
 	/**
@@ -117,18 +116,18 @@ public class FormLayoutGefTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_setLayout_replaceGridBagLayout() throws Exception {
-		openPanel(
-				"// filler filler filler filler filler",
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new GridBagLayout());",
-				"    {",
-				"      JButton button = new JButton();",
-				"      add(button);",
-				"    }",
-				"  }",
-				"}");
+		openPanel("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new GridBagLayout());
+						{
+							JButton button = new JButton();
+							add(button);
+						}
+					}
+				}""");
 		canvas.select(panel);
 		//
 		loadCreationTool("com.jgoodies.forms.layout.FormLayout");
@@ -147,18 +146,18 @@ public class FormLayoutGefTest extends SwingGefTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_CREATE_filled() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"    add(new JButton('Existing JButton'), '2, 2');",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+						add(new JButton("Existing JButton"), "2, 2");
+					}
+				}""");
 		//
 		loadButtonWithText();
 		canvas.moveTo(panel, COLUMN_GAP, ROW_GAP);
@@ -167,523 +166,523 @@ public class FormLayoutGefTest extends SwingGefTest {
 
 	@Test
 	public void test_CREATE_empty() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+					}
+				}""");
 		//
 		loadButtonWithText();
 		canvas.moveTo(panel, COLUMN_GAP, ROW_GAP);
 		canvas.assertCommandNotNull();
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, '2, 2');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+						{
+							JButton button = new JButton("New button");
+							add(button, "2, 2");
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_virtual_2x2() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout());",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout());
+					}
+				}""");
 		//
 		loadButtonWithText();
 		canvas.moveTo(panel, COLUMN_GAP, ROW_GAP);
 		canvas.assertCommandNotNull();
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, '2, 2');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+						{
+							JButton button = new JButton("New button");
+							add(button, "2, 2");
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_virtual_4x2() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout());",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout());
+					}
+				}""");
 		//
 		loadButtonWithText();
 		canvas.moveTo(panel, COLUMN_GAP + V_COLUMN_SIZE + COLUMN_GAP, ROW_GAP);
 		canvas.assertCommandNotNull();
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, '4, 2');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+						{
+							JButton button = new JButton("New button");
+							add(button, "4, 2");
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_virtual_2x4() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout());",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout());
+					}
+				}""");
 		//
 		loadButtonWithText();
 		canvas.moveTo(panel, COLUMN_GAP, ROW_GAP + V_ROW_SIZE + ROW_GAP);
 		canvas.assertCommandNotNull();
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, '2, 4');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+						{
+							JButton button = new JButton("New button");
+							add(button, "2, 4");
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_appendToColumn_2x4() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"    {",
-				"      JButton existing = new JButton('Existing JButton');",
-				"      add(existing, '2, 2');",
-				"    }",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+						{
+							JButton existing = new JButton("Existing JButton");
+							add(existing, "2, 2");
+						}
+					}
+				}""");
 		ComponentInfo existing = getJavaInfoByName("existing");
 		//
 		loadButtonWithText();
 		canvas.target(existing).inX(0.5).outY(ROW_GAP + 1).move();
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"    {",
-				"      JButton existing = new JButton('Existing JButton');",
-				"      add(existing, '2, 2');",
-				"    }",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, '2, 4');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+						{
+							JButton existing = new JButton("Existing JButton");
+							add(existing, "2, 2");
+						}
+						{
+							JButton button = new JButton("New button");
+							add(button, "2, 4");
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_appendToRow_4x2() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"    {",
-				"      JButton existing = new JButton('Existing JButton');",
-				"      add(existing, '2, 2');",
-				"    }",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+						{
+							JButton existing = new JButton("Existing JButton");
+							add(existing, "2, 2");
+						}
+					}
+				}""");
 		ComponentInfo existing = getJavaInfoByName("existing");
 		//
 		loadButtonWithText();
 		canvas.target(existing).inY(0.5).outX(COLUMN_GAP + 1).move();
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"    {",
-				"      JButton existing = new JButton('Existing JButton');",
-				"      add(existing, '2, 2');",
-				"    }",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, '4, 2');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+						{
+							JButton existing = new JButton("Existing JButton");
+							add(existing, "2, 2");
+						}
+						{
+							JButton button = new JButton("New button");
+							add(button, "4, 2");
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_beforeFirstRow() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"    {",
-				"      JButton existing = new JButton('Existing JButton');",
-				"      add(existing, '2, 2');",
-				"    }",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+						{
+							JButton existing = new JButton("Existing JButton");
+							add(existing, "2, 2");
+						}
+					}
+				}""");
 		ComponentInfo existing = getJavaInfoByName("existing");
 		//
 		loadButtonWithText();
 		canvas.target(existing).inX(0.5).outY(-2).move();
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, '2, 2');",
-				"    }",
-				"    {",
-				"      JButton existing = new JButton('Existing JButton');",
-				"      add(existing, '2, 4');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+						{
+							JButton button = new JButton("New button");
+							add(button, "2, 2");
+						}
+						{
+							JButton existing = new JButton("Existing JButton");
+							add(existing, "2, 4");
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_beforeFirstColumn() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"    {",
-				"      JButton existing = new JButton('Existing JButton');",
-				"      add(existing, '2, 2');",
-				"    }",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+						{
+							JButton existing = new JButton("Existing JButton");
+							add(existing, "2, 2");
+						}
+					}
+				}""");
 		ComponentInfo existing = getJavaInfoByName("existing");
 		//
 		loadButtonWithText();
 		canvas.target(existing).inY(0.5).outX(-2).move();
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, '2, 2');",
-				"    }",
-				"    {",
-				"      JButton existing = new JButton('Existing JButton');",
-				"      add(existing, '4, 2');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+						{
+							JButton button = new JButton("New button");
+							add(button, "2, 2");
+						}
+						{
+							JButton existing = new JButton("Existing JButton");
+							add(existing, "4, 2");
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_insertRow_endOfComponent_noGapNext() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.DEFAULT_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"    {",
-				"      JButton button_1 = new JButton('JButton 1');",
-				"      add(button_1, '2, 1');",
-				"    }",
-				"    {",
-				"      JButton button_2 = new JButton('JButton 2');",
-				"      add(button_2, '2, 2');",
-				"    }",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.DEFAULT_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+						{
+							JButton button_1 = new JButton("JButton 1");
+							add(button_1, "2, 1");
+						}
+						{
+							JButton button_2 = new JButton("JButton 2");
+							add(button_2, "2, 2");
+						}
+					}
+				}""");
 		ComponentInfo button_1 = getJavaInfoByName("button_1");
 		//
 		loadButtonWithText();
 		canvas.target(button_1).inX(0.5).inY(-2).move();
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.DEFAULT_ROWSPEC,",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"    {",
-				"      JButton button_1 = new JButton('JButton 1');",
-				"      add(button_1, '2, 1');",
-				"    }",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, '2, 3');",
-				"    }",
-				"    {",
-				"      JButton button_2 = new JButton('JButton 2');",
-				"      add(button_2, '2, 4');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.DEFAULT_ROWSPEC,
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+						{
+							JButton button_1 = new JButton("JButton 1");
+							add(button_1, "2, 1");
+						}
+						{
+							JButton button = new JButton("New button");
+							add(button, "2, 3");
+						}
+						{
+							JButton button_2 = new JButton("JButton 2");
+							add(button_2, "2, 4");
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_insertRow_beginOfComponent_noGapPrev() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.DEFAULT_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"    {",
-				"      JButton button_1 = new JButton('JButton 1');",
-				"      add(button_1, '2, 1');",
-				"    }",
-				"    {",
-				"      JButton button_2 = new JButton('JButton 2');",
-				"      add(button_2, '2, 2');",
-				"    }",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.DEFAULT_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+						{
+							JButton button_1 = new JButton("JButton 1");
+							add(button_1, "2, 1");
+						}
+						{
+							JButton button_2 = new JButton("JButton 2");
+							add(button_2, "2, 2");
+						}
+					}
+				}""");
 		ComponentInfo button_2 = getJavaInfoByName("button_2");
 		//
 		loadButtonWithText();
 		canvas.target(button_2).inX(0.5).inY(2).move();
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.DEFAULT_ROWSPEC,",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"    {",
-				"      JButton button_1 = new JButton('JButton 1');",
-				"      add(button_1, '2, 1');",
-				"    }",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, '2, 3');",
-				"    }",
-				"    {",
-				"      JButton button_2 = new JButton('JButton 2');",
-				"      add(button_2, '2, 4');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.DEFAULT_ROWSPEC,
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+						{
+							JButton button_1 = new JButton("JButton 1");
+							add(button_1, "2, 1");
+						}
+						{
+							JButton button = new JButton("New button");
+							add(button, "2, 3");
+						}
+						{
+							JButton button_2 = new JButton("JButton 2");
+							add(button_2, "2, 4");
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_insertColumn_endOfComponent_noGapNext() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.DEFAULT_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"    {",
-				"      JButton button_1 = new JButton('JButton 1');",
-				"      add(button_1, '1, 2');",
-				"    }",
-				"    {",
-				"      JButton button_2 = new JButton('JButton 2');",
-				"      add(button_2, '2, 2');",
-				"    }",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.DEFAULT_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+						{
+							JButton button_1 = new JButton("JButton 1");
+							add(button_1, "1, 2");
+						}
+						{
+							JButton button_2 = new JButton("JButton 2");
+							add(button_2, "2, 2");
+						}
+					}
+				}""");
 		ComponentInfo button_1 = getJavaInfoByName("button_1");
 		//
 		loadButtonWithText();
 		canvas.target(button_1).inY(0.5).inX(-2).move();
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.DEFAULT_COLSPEC,",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"    {",
-				"      JButton button_1 = new JButton('JButton 1');",
-				"      add(button_1, '1, 2');",
-				"    }",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, '3, 2');",
-				"    }",
-				"    {",
-				"      JButton button_2 = new JButton('JButton 2');",
-				"      add(button_2, '4, 2');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.DEFAULT_COLSPEC,
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+						{
+							JButton button_1 = new JButton("JButton 1");
+							add(button_1, "1, 2");
+						}
+						{
+							JButton button = new JButton("New button");
+							add(button, "3, 2");
+						}
+						{
+							JButton button_2 = new JButton("JButton 2");
+							add(button_2, "4, 2");
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_insertColumn_beginOfComponent_noGapPrev() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.DEFAULT_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"    {",
-				"      JButton button_1 = new JButton('JButton 1');",
-				"      add(button_1, '1, 2');",
-				"    }",
-				"    {",
-				"      JButton button_2 = new JButton('JButton 2');",
-				"      add(button_2, '2, 2');",
-				"    }",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.DEFAULT_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+						{
+							JButton button_1 = new JButton("JButton 1");
+							add(button_1, "1, 2");
+						}
+						{
+							JButton button_2 = new JButton("JButton 2");
+							add(button_2, "2, 2");
+						}
+					}
+				}""");
 		ComponentInfo button_2 = getJavaInfoByName("button_2");
 		//
 		loadButtonWithText();
 		canvas.target(button_2).inY(0.5).inX(2).move();
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.DEFAULT_COLSPEC,",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"    {",
-				"      JButton button_1 = new JButton('JButton 1');",
-				"      add(button_1, '1, 2');",
-				"    }",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, '3, 2');",
-				"    }",
-				"    {",
-				"      JButton button_2 = new JButton('JButton 2');",
-				"      add(button_2, '4, 2');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.DEFAULT_COLSPEC,
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+						{
+							JButton button_1 = new JButton("JButton 1");
+							add(button_1, "1, 2");
+						}
+						{
+							JButton button = new JButton("New button");
+							add(button, "3, 2");
+						}
+						{
+							JButton button_2 = new JButton("JButton 2");
+							add(button_2, "4, 2");
+						}
+					}
+				}""");
 	}
 
 	/**
@@ -691,35 +690,35 @@ public class FormLayoutGefTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_CREATE_whenNoRows() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {}));",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {}));
+					}
+				}""");
 		//
 		loadButtonWithText();
 		canvas.moveTo(panel, COLUMN_GAP, ROW_GAP);
 		canvas.assertCommandNotNull();
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, '2, 2');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+						{
+							JButton button = new JButton("New button");
+							add(button, "2, 2");
+						}
+					}
+				}""");
 	}
 
 	/**
@@ -727,35 +726,35 @@ public class FormLayoutGefTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_CREATE_whenNoColumns() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {},",
-				"      new RowSpec[] {",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {},
+							new RowSpec[] {
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+					}
+				}""");
 		//
 		loadButtonWithText();
 		canvas.moveTo(panel, COLUMN_GAP, ROW_GAP);
 		canvas.assertCommandNotNull();
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, '2, 2');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+						{
+							JButton button = new JButton("New button");
+							add(button, "2, 2");
+						}
+					}
+				}""");
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -770,35 +769,35 @@ public class FormLayoutGefTest extends SwingGefTest {
 	public void test_CREATE_inherited_columnOperations() throws Exception {
 		setFileContentSrc(
 				"test/MyPanel.java",
-				getTestSource(
-						"// filler filler filler filler filler",
-						"// filler filler filler filler filler",
-						"public class MyPanel extends JPanel {",
-						"  public MyPanel() {",
-						"    setLayout(new FormLayout(new ColumnSpec[] {",
-						"        FormSpecs.DEFAULT_COLSPEC,",
-						"        FormSpecs.DEFAULT_COLSPEC,},",
-						"      new RowSpec[] {",
-						"        FormSpecs.DEFAULT_ROWSPEC,}));",
-						"  }",
-						"}"));
+				getTestSource("""
+						// filler filler filler filler filler
+						// filler filler filler filler filler
+						public class MyPanel extends JPanel {
+							public MyPanel() {
+								setLayout(new FormLayout(new ColumnSpec[] {
+										FormSpecs.DEFAULT_COLSPEC,
+										FormSpecs.DEFAULT_COLSPEC,},
+									new RowSpec[] {
+										FormSpecs.DEFAULT_ROWSPEC,}));
+							}
+						}"""));
 		waitForAutoBuild();
 		// parse
-		openPanel(
-				"// filler filler filler filler filler",
-				"// filler filler filler filler filler",
-				"public class Test extends MyPanel {",
-				"  public Test() {",
-				"    {",
-				"      JButton button_1 = new JButton('JButton 1');",
-				"      add(button_1, '1, 1');",
-				"    }",
-				"    {",
-				"      JButton button_2 = new JButton('JButton 2');",
-				"      add(button_2, '2, 1');",
-				"    }",
-				"  }",
-				"}");
+		openPanel("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends MyPanel {
+					public Test() {
+						{
+							JButton button_1 = new JButton("JButton 1");
+							add(button_1, "1, 1");
+						}
+						{
+							JButton button_2 = new JButton("JButton 2");
+							add(button_2, "2, 1");
+						}
+					}
+				}""");
 		loadButton();
 		// can not insert column
 		{
@@ -821,35 +820,35 @@ public class FormLayoutGefTest extends SwingGefTest {
 	public void test_CREATE_inherited_rowOperations() throws Exception {
 		setFileContentSrc(
 				"test/MyPanel.java",
-				getTestSource(
-						"// filler filler filler filler filler",
-						"// filler filler filler filler filler",
-						"public class MyPanel extends JPanel {",
-						"  public MyPanel() {",
-						"    setLayout(new FormLayout(new ColumnSpec[] {",
-						"        FormSpecs.DEFAULT_COLSPEC,},",
-						"      new RowSpec[] {",
-						"        FormSpecs.DEFAULT_ROWSPEC,",
-						"        FormSpecs.DEFAULT_ROWSPEC,}));",
-						"  }",
-						"}"));
+				getTestSource("""
+						// filler filler filler filler filler
+						// filler filler filler filler filler
+						public class MyPanel extends JPanel {
+							public MyPanel() {
+								setLayout(new FormLayout(new ColumnSpec[] {
+										FormSpecs.DEFAULT_COLSPEC,},
+									new RowSpec[] {
+										FormSpecs.DEFAULT_ROWSPEC,
+										FormSpecs.DEFAULT_ROWSPEC,}));
+							}
+						}"""));
 		waitForAutoBuild();
 		// parse
-		openPanel(
-				"// filler filler filler filler filler",
-				"// filler filler filler filler filler",
-				"public class Test extends MyPanel {",
-				"  public Test() {",
-				"    {",
-				"      JButton button_1 = new JButton('JButton 1');",
-				"      add(button_1, '1, 1');",
-				"    }",
-				"    {",
-				"      JButton button_2 = new JButton('JButton 2');",
-				"      add(button_2, '1, 2');",
-				"    }",
-				"  }",
-				"}");
+		openPanel("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends MyPanel {
+					public Test() {
+						{
+							JButton button_1 = new JButton("JButton 1");
+							add(button_1, "1, 1");
+						}
+						{
+							JButton button_2 = new JButton("JButton 2");
+							add(button_2, "1, 2");
+						}
+					}
+				}""");
 		loadButton();
 		// can not insert row
 		{
@@ -874,21 +873,21 @@ public class FormLayoutGefTest extends SwingGefTest {
 	@Ignore
 	@Test
 	public void test_PASTE_virtual_4x2() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"    {",
-				"      JButton existing = new JButton('My JButton');",
-				"      add(existing, '2, 2');",
-				"    }",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+						{
+							JButton existing = new JButton("My JButton");
+							add(existing, "2, 2");
+						}
+					}
+				}""");
 		ComponentInfo existing = getJavaInfoByName("existing");
 		// do copy/paste
 		doCopyPaste(existing);
@@ -902,27 +901,27 @@ public class FormLayoutGefTest extends SwingGefTest {
 			canvas.target(existing).inY(0.5).outX(ROW_GAP + 1).move();
 			canvas.click();
 		}
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"    {",
-				"      JButton existing = new JButton('My JButton');",
-				"      add(existing, '2, 2');",
-				"    }",
-				"    {",
-				"      JButton button = new JButton('My JButton');",
-				"      add(button, '4, 2');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+						{
+							JButton existing = new JButton("My JButton");
+							add(existing, "2, 2");
+						}
+						{
+							JButton button = new JButton("My JButton");
+							add(button, "4, 2");
+						}
+					}
+				}""");
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -932,88 +931,88 @@ public class FormLayoutGefTest extends SwingGefTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_MOVE_virtual_4x2() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"    {",
-				"      JButton button = new JButton('My JButton');",
-				"      add(button, '2, 2');",
-				"    }",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+						{
+							JButton button = new JButton("My JButton");
+							add(button, "2, 2");
+						}
+					}
+				}""");
 		ComponentInfo button = getJavaInfoByName("button");
 		//
 		canvas.beginDrag(button);
 		canvas.target(button).inY(0.5).outX(ROW_GAP + 1).drag();
 		canvas.endDrag();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"    {",
-				"      JButton button = new JButton('My JButton');",
-				"      add(button, '4, 2');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,
+								FormSpecs.RELATED_GAP_COLSPEC,
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								FormSpecs.DEFAULT_ROWSPEC,}));
+						{
+							JButton button = new JButton("My JButton");
+							add(button, "4, 2");
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_ADD_virtual_2x2() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      JButton button = new JButton('My JButton');",
-				"      add(button, BorderLayout.NORTH);",
-				"    }",
-				"    {",
-				"      JPanel inner = new JPanel();",
-				"      add(inner, BorderLayout.CENTER);",
-				"      inner.setLayout(new FormLayout());",
-				"    }",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JButton button = new JButton("My JButton");
+							add(button, BorderLayout.NORTH);
+						}
+						{
+							JPanel inner = new JPanel();
+							add(inner, BorderLayout.CENTER);
+							inner.setLayout(new FormLayout());
+						}
+					}
+				}""");
 		ComponentInfo button = getJavaInfoByName("button");
 		panel = getJavaInfoByName("inner");
 		//
 		canvas.beginDrag(button);
 		canvas.target(panel).in(COLUMN_GAP, ROW_GAP).drag();
 		canvas.endDrag();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      JPanel inner = new JPanel();",
-				"      add(inner, BorderLayout.CENTER);",
-				"      inner.setLayout(new FormLayout(new ColumnSpec[] {",
-				"          FormSpecs.RELATED_GAP_COLSPEC,",
-				"          FormSpecs.DEFAULT_COLSPEC,},",
-				"        new RowSpec[] {",
-				"          FormSpecs.RELATED_GAP_ROWSPEC,",
-				"          FormSpecs.DEFAULT_ROWSPEC,}));",
-				"      {",
-				"        JButton button = new JButton('My JButton');",
-				"        inner.add(button, '2, 2');",
-				"      }",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JPanel inner = new JPanel();
+							add(inner, BorderLayout.CENTER);
+							inner.setLayout(new FormLayout(new ColumnSpec[] {
+									FormSpecs.RELATED_GAP_COLSPEC,
+									FormSpecs.DEFAULT_COLSPEC,},
+								new RowSpec[] {
+									FormSpecs.RELATED_GAP_ROWSPEC,
+									FormSpecs.DEFAULT_ROWSPEC,}));
+							{
+								JButton button = new JButton("My JButton");
+								inner.add(button, "2, 2");
+							}
+						}
+					}
+				}""");
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -1028,27 +1027,27 @@ public class FormLayoutGefTest extends SwingGefTest {
 	public void test_headerColumn_MOVE_inherited() throws Exception {
 		setFileContentSrc(
 				"test/MyPanel.java",
-				getTestSource(
-						"// filler filler filler filler filler",
-						"// filler filler filler filler filler",
-						"public class MyPanel extends JPanel {",
-						"  public MyPanel() {",
-						"    setLayout(new FormLayout(new ColumnSpec[] {",
-						"        ColumnSpec.decode('150px'),",
-						"        ColumnSpec.decode('100px'),},",
-						"      new RowSpec[] {",
-						"        FormSpecs.DEFAULT_ROWSPEC,}));",
-						"  }",
-						"}"));
+				getTestSource("""
+						// filler filler filler filler filler
+						// filler filler filler filler filler
+						public class MyPanel extends JPanel {
+							public MyPanel() {
+								setLayout(new FormLayout(new ColumnSpec[] {
+										ColumnSpec.decode("150px"),
+										ColumnSpec.decode("100px"),},
+									new RowSpec[] {
+										FormSpecs.DEFAULT_ROWSPEC,}));
+							}
+						}"""));
 		waitForAutoBuild();
 		// parse
-		openPanel(
-				"// filler filler filler filler filler",
-				"// filler filler filler filler filler",
-				"public class Test extends MyPanel {",
-				"  public Test() {",
-				"  }",
-				"}");
+		openPanel("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends MyPanel {
+					public Test() {
+					}
+				}""");
 		// select panel to show headers
 		canvas.select(panel);
 		// animate headers
@@ -1063,20 +1062,20 @@ public class FormLayoutGefTest extends SwingGefTest {
 
 	@Test
 	public void test_headerColumn_MOVE_forward_targetGap() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        new ColumnSpec('150px'),",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        new ColumnSpec('100px'),",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        new ColumnSpec('50px'),},",
-				"      new RowSpec[] {",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.RELATED_GAP_COLSPEC,
+								new ColumnSpec("150px"),
+								FormSpecs.RELATED_GAP_COLSPEC,
+								new ColumnSpec("100px"),
+								FormSpecs.RELATED_GAP_COLSPEC,
+								new ColumnSpec("50px"),},
+							new RowSpec[] {
+								FormSpecs.DEFAULT_ROWSPEC,}));
+					}
+				}""");
 		// select panel to show headers
 		canvas.select(panel);
 		// animate headers
@@ -1087,35 +1086,35 @@ public class FormLayoutGefTest extends SwingGefTest {
 			horizontalRobot.beginDrag(sourceColumn).dragTo(relativeColumn, -5, 0.5);
 			horizontalRobot.endDrag();
 		}
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        ColumnSpec.decode('100px'),",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        ColumnSpec.decode('150px'),",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        ColumnSpec.decode('50px'),},",
-				"      new RowSpec[] {",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.RELATED_GAP_COLSPEC,
+								ColumnSpec.decode("100px"),
+								FormSpecs.RELATED_GAP_COLSPEC,
+								ColumnSpec.decode("150px"),
+								FormSpecs.RELATED_GAP_COLSPEC,
+								ColumnSpec.decode("50px"),},
+							new RowSpec[] {
+								FormSpecs.DEFAULT_ROWSPEC,}));
+					}
+				}""");
 	}
 
 	@Test
 	public void test_headerColumn_MOVE_forward_targetNotGap() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        new ColumnSpec('150px'),",
-				"        new ColumnSpec('100px'),",
-				"        new ColumnSpec('50px'),},",
-				"      new RowSpec[] {",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								new ColumnSpec("150px"),
+								new ColumnSpec("100px"),
+								new ColumnSpec("50px"),},
+							new RowSpec[] {
+								FormSpecs.DEFAULT_ROWSPEC,}));
+					}
+				}""");
 		// select panel to show headers
 		canvas.select(panel);
 		// animate headers
@@ -1126,33 +1125,33 @@ public class FormLayoutGefTest extends SwingGefTest {
 			horizontalRobot.beginDrag(sourceColumn).dragTo(relativeColumn, -5, 0.5);
 			horizontalRobot.endDrag();
 		}
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        ColumnSpec.decode('100px'),",
-				"        ColumnSpec.decode('150px'),",
-				"        ColumnSpec.decode('50px'),},",
-				"      new RowSpec[] {",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								ColumnSpec.decode("100px"),
+								ColumnSpec.decode("150px"),
+								ColumnSpec.decode("50px"),},
+							new RowSpec[] {
+								FormSpecs.DEFAULT_ROWSPEC,}));
+					}
+				}""");
 	}
 
 	@Test
 	public void test_headerColumn_MOVE_forward_targetBeforeGap() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        new ColumnSpec('150px'),",
-				"        new ColumnSpec('100px'),",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        new ColumnSpec('50px'),},",
-				"      new RowSpec[] {",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								new ColumnSpec("150px"),
+								new ColumnSpec("100px"),
+								FormSpecs.RELATED_GAP_COLSPEC,
+								new ColumnSpec("50px"),},
+							new RowSpec[] {
+								FormSpecs.DEFAULT_ROWSPEC,}));
+					}
+				}""");
 		// select panel to show headers
 		canvas.select(panel);
 		// animate headers
@@ -1163,33 +1162,33 @@ public class FormLayoutGefTest extends SwingGefTest {
 			horizontalRobot.beginDrag(sourceColumn).dragTo(relativeColumn, +5, 0.5);
 			horizontalRobot.endDrag();
 		}
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        ColumnSpec.decode('100px'),",
-				"        ColumnSpec.decode('150px'),",
-				"        FormSpecs.RELATED_GAP_COLSPEC,",
-				"        ColumnSpec.decode('50px'),},",
-				"      new RowSpec[] {",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								ColumnSpec.decode("100px"),
+								ColumnSpec.decode("150px"),
+								FormSpecs.RELATED_GAP_COLSPEC,
+								ColumnSpec.decode("50px"),},
+							new RowSpec[] {
+								FormSpecs.DEFAULT_ROWSPEC,}));
+					}
+				}""");
 	}
 
 	@Test
 	public void test_headerColumn_MOVE_forward_targetLast() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        new ColumnSpec('150px'),",
-				"        new ColumnSpec('100px'),",
-				"        new ColumnSpec('50px'),},",
-				"      new RowSpec[] {",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								new ColumnSpec("150px"),
+								new ColumnSpec("100px"),
+								new ColumnSpec("50px"),},
+							new RowSpec[] {
+								FormSpecs.DEFAULT_ROWSPEC,}));
+					}
+				}""");
 		// select panel to show headers
 		canvas.select(panel);
 		// animate headers
@@ -1200,17 +1199,17 @@ public class FormLayoutGefTest extends SwingGefTest {
 			horizontalRobot.beginDrag(sourceColumn).dragTo(relativeColumn, -5, 0.5);
 			horizontalRobot.endDrag();
 		}
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        ColumnSpec.decode('100px'),",
-				"        ColumnSpec.decode('50px'),",
-				"        ColumnSpec.decode('150px'),},",
-				"      new RowSpec[] {",
-				"        FormSpecs.DEFAULT_ROWSPEC,}));",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								ColumnSpec.decode("100px"),
+								ColumnSpec.decode("50px"),
+								ColumnSpec.decode("150px"),},
+							new RowSpec[] {
+								FormSpecs.DEFAULT_ROWSPEC,}));
+					}
+				}""");
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -1225,27 +1224,27 @@ public class FormLayoutGefTest extends SwingGefTest {
 	public void test_headerRow_MOVE_inherited() throws Exception {
 		setFileContentSrc(
 				"test/MyPanel.java",
-				getTestSource(
-						"// filler filler filler filler filler",
-						"// filler filler filler filler filler",
-						"public class MyPanel extends JPanel {",
-						"  public MyPanel() {",
-						"    setLayout(new FormLayout(new ColumnSpec[] {",
-						"        FormSpecs.DEFAULT_COLSPEC,},",
-						"      new RowSpec[] {",
-						"        RowSpec.decode('100px'),",
-						"        RowSpec.decode('75px'),}));",
-						"  }",
-						"}"));
+				getTestSource("""
+						// filler filler filler filler filler
+						// filler filler filler filler filler
+						public class MyPanel extends JPanel {
+							public MyPanel() {
+								setLayout(new FormLayout(new ColumnSpec[] {
+										FormSpecs.DEFAULT_COLSPEC,},
+									new RowSpec[] {
+										RowSpec.decode("100px"),
+										RowSpec.decode("75px"),}));
+							}
+						}"""));
 		waitForAutoBuild();
 		// parse
-		openPanel(
-				"// filler filler filler filler filler",
-				"// filler filler filler filler filler",
-				"public class Test extends MyPanel {",
-				"  public Test() {",
-				"  }",
-				"}");
+		openPanel("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends MyPanel {
+					public Test() {
+					}
+				}""");
 		// select panel to show headers
 		canvas.select(panel);
 		// animate headers
@@ -1260,20 +1259,20 @@ public class FormLayoutGefTest extends SwingGefTest {
 
 	@Test
 	public void test_headerRow_MOVE_forward_targetGap() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        new RowSpec('100px'),",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        new RowSpec('75px'),",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        new RowSpec('50px'),}));",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								new RowSpec("100px"),
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								new RowSpec("75px"),
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								new RowSpec("50px"),}));
+					}
+				}""");
 		// select panel to show headers
 		canvas.select(panel);
 		// animate headers
@@ -1284,35 +1283,35 @@ public class FormLayoutGefTest extends SwingGefTest {
 			verticalRobot.beginDrag(sourceRow).dragTo(relativeRow, 0.5, -5);
 			verticalRobot.endDrag();
 		}
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        RowSpec.decode('75px'),",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        RowSpec.decode('100px'),",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        RowSpec.decode('50px'),}));",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								RowSpec.decode("75px"),
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								RowSpec.decode("100px"),
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								RowSpec.decode("50px"),}));
+					}
+				}""");
 	}
 
 	@Test
 	public void test_headerRow_MOVE_forward_targetNotGap() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        new RowSpec('100px'),",
-				"        new RowSpec('75px'),",
-				"        new RowSpec('50px'),}));",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								new RowSpec("100px"),
+								new RowSpec("75px"),
+								new RowSpec("50px"),}));
+					}
+				}""");
 		// select panel to show headers
 		canvas.select(panel);
 		// animate headers
@@ -1323,33 +1322,33 @@ public class FormLayoutGefTest extends SwingGefTest {
 			verticalRobot.beginDrag(sourceRow).dragTo(relativeRow, 0.5, -5);
 			verticalRobot.endDrag();
 		}
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        RowSpec.decode('75px'),",
-				"        RowSpec.decode('100px'),",
-				"        RowSpec.decode('50px'),}));",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								RowSpec.decode("75px"),
+								RowSpec.decode("100px"),
+								RowSpec.decode("50px"),}));
+					}
+				}""");
 	}
 
 	@Test
 	public void test_headerRow_MOVE_forward_targetBeforeGap() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        new RowSpec('100px'),",
-				"        new RowSpec('75px'),",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        new RowSpec('50px'),}));",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								new RowSpec("100px"),
+								new RowSpec("75px"),
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								new RowSpec("50px"),}));
+					}
+				}""");
 		// select panel to show headers
 		canvas.select(panel);
 		// animate headers
@@ -1360,33 +1359,33 @@ public class FormLayoutGefTest extends SwingGefTest {
 			verticalRobot.beginDrag(sourceRow).dragTo(relativeRow, 0.5, +5);
 			verticalRobot.endDrag();
 		}
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        RowSpec.decode('75px'),",
-				"        RowSpec.decode('100px'),",
-				"        FormSpecs.RELATED_GAP_ROWSPEC,",
-				"        RowSpec.decode('50px'),}));",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								RowSpec.decode("75px"),
+								RowSpec.decode("100px"),
+								FormSpecs.RELATED_GAP_ROWSPEC,
+								RowSpec.decode("50px"),}));
+					}
+				}""");
 	}
 
 	@Test
 	public void test_headerRow_MOVE_forward_targetLast() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        new RowSpec('100px'),",
-				"        new RowSpec('75px'),",
-				"        new RowSpec('50px'),}));",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								new RowSpec("100px"),
+								new RowSpec("75px"),
+								new RowSpec("50px"),}));
+					}
+				}""");
 		// select panel to show headers
 		canvas.select(panel);
 		// animate headers
@@ -1397,17 +1396,17 @@ public class FormLayoutGefTest extends SwingGefTest {
 			verticalRobot.beginDrag(sourceRow).dragTo(relativeRow, 0.5, -5);
 			verticalRobot.endDrag();
 		}
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new FormLayout(new ColumnSpec[] {",
-				"        FormSpecs.DEFAULT_COLSPEC,},",
-				"      new RowSpec[] {",
-				"        RowSpec.decode('75px'),",
-				"        RowSpec.decode('50px'),",
-				"        RowSpec.decode('100px'),}));",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FormLayout(new ColumnSpec[] {
+								FormSpecs.DEFAULT_COLSPEC,},
+							new RowSpec[] {
+								RowSpec.decode("75px"),
+								RowSpec.decode("50px"),
+								RowSpec.decode("100px"),}));
+					}
+				}""");
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -1416,15 +1415,14 @@ public class FormLayoutGefTest extends SwingGefTest {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public String getTestSource(String... lines) {
-		lines =
-				CodeUtils.join(new String[]{
-						"import com.jgoodies.forms.layout.*;",
-				"import com.jgoodies.forms.factories.*;"}, lines);
-		return super.getTestSource(lines);
+	public String getTestSource(String code) {
+		return super.getTestSource("""
+				import com.jgoodies.forms.layout.*;
+				import com.jgoodies.forms.factories.*;
+				%s""".formatted(code));
 	}
 
-	private void openPanel(String... lines) throws Exception {
+	private void openPanel(String lines) throws Exception {
 		panel = openContainer(lines);
 		if (panel.getLayout() instanceof FormLayoutInfo) {
 			layout = (FormLayoutInfo) panel.getLayout();

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/LayoutGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/LayoutGefTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -44,13 +44,12 @@ public class LayoutGefTest extends SwingGefTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_dropLayout_canvas() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(null);",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(null);
+					}
+				}""");
 		// create BorderLayout
 		LayoutInfo newLayout = loadCreationTool("java.awt.BorderLayout");
 		// use canvas
@@ -60,24 +59,23 @@ public class LayoutGefTest extends SwingGefTest {
 		canvas.assertCommandNotNull();
 		canvas.click();
 		// assert
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout(0, 0));",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout(0, 0));
+					}
+				}""");
 		assertSame(newLayout, panel.getLayout());
 	}
 
 	@Test
 	public void test_dropLayout_tree() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(null);",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(null);
+					}
+				}""");
 		// create BorderLayout
 		LayoutInfo newLayout = loadCreationTool("java.awt.BorderLayout");
 		// use canvas
@@ -86,12 +84,12 @@ public class LayoutGefTest extends SwingGefTest {
 		tree.assertCommandNotNull();
 		tree.click();
 		// assert
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout(0, 0));",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout(0, 0));
+					}
+				}""");
 		assertSame(newLayout, panel.getLayout());
 	}
 
@@ -103,13 +101,12 @@ public class LayoutGefTest extends SwingGefTest {
 	@Test
 	public void test_dropLayout_disabledSetLayout_canvas() throws Exception {
 		ContainerTest.prepareMyPanel_disabledSetLayout();
-		ContainerInfo panel =
-				openContainer(
-						"// filler filler filler filler filler",
-						"public class Test extends MyPanel {",
-						"  public Test() {",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				// filler filler filler filler filler
+				public class Test extends MyPanel {
+					public Test() {
+					}
+				}""");
 		// load BorderLayout
 		loadCreationTool("java.awt.BorderLayout");
 		// use canvas
@@ -121,13 +118,12 @@ public class LayoutGefTest extends SwingGefTest {
 	@Test
 	public void test_dropLayout_disabledSetLayout_tree() throws Exception {
 		ContainerTest.prepareMyPanel_disabledSetLayout();
-		ContainerInfo panel =
-				openContainer(
-						"// filler filler filler filler filler",
-						"public class Test extends MyPanel {",
-						"  public Test() {",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				// filler filler filler filler filler
+				public class Test extends MyPanel {
+					public Test() {
+					}
+				}""");
 		// load BorderLayout
 		loadCreationTool("java.awt.BorderLayout");
 		// use canvas
@@ -149,30 +145,29 @@ public class LayoutGefTest extends SwingGefTest {
 	public void test_dropUnknownLayout_noTreeLayout() throws Exception {
 		setFileContentSrc(
 				"test/MyLayout.java",
-				getTestSource(
-						"public class MyLayout implements LayoutManager {",
-						"  public void addLayoutComponent(String name, Component comp) {",
-						"  }",
-						"  public  void removeLayoutComponent(Component comp) {",
-						"  }",
-						"  public Dimension preferredLayoutSize(Container parent) {",
-						"    return new Dimension(200, 100);",
-						"  }",
-						"  public Dimension minimumLayoutSize(Container parent) {",
-						"    return new Dimension(200, 100);",
-						"  }",
-						"  public void layoutContainer(Container parent) {",
-						"  }",
-						"}"));
+				getTestSource("""
+						public class MyLayout implements LayoutManager {
+							public void addLayoutComponent(String name, Component comp) {
+							}
+							public  void removeLayoutComponent(Component comp) {
+							}
+							public Dimension preferredLayoutSize(Container parent) {
+								return new Dimension(200, 100);
+							}
+							public Dimension minimumLayoutSize(Container parent) {
+								return new Dimension(200, 100);
+							}
+							public void layoutContainer(Container parent) {
+							}
+						}"""));
 		waitForAutoBuild();
 		// open editor
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(null);",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(null);
+					}
+				}""");
 		// FlowLayout has command
 		{
 			loadCreationTool("javax.swing.JButton");

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/MigLayout/MigLayoutGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/MigLayout/MigLayoutGefTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,6 @@ package org.eclipse.wb.tests.designer.swing.model.layout.MigLayout;
 
 import org.eclipse.wb.core.gef.policy.layout.grid.IGridInfo;
 import org.eclipse.wb.gef.graphical.policies.LayoutEditPolicy;
-import org.eclipse.wb.internal.core.utils.jdt.core.CodeUtils;
 import org.eclipse.wb.internal.swing.MigLayout.model.MigColumnInfo;
 import org.eclipse.wb.internal.swing.MigLayout.model.MigLayoutInfo;
 import org.eclipse.wb.internal.swing.MigLayout.model.MigRowInfo;
@@ -91,24 +90,24 @@ public class MigLayoutGefTest extends SwingGefTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_setLayout_empty() throws Exception {
-		openPanel(
-				"// filler filler filler filler filler",
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"  }",
-				"}");
+		openPanel("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+					}
+				}""");
 		//
 		loadCreationTool("net.miginfocom.swing.MigLayout");
 		canvas.moveTo(panel, 0.5, 0.5).click();
-		assertEditor(
-				"// filler filler filler filler filler",
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout('', '[]', '[]'));",
-				"  }",
-				"}");
+		assertEditor("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout("", "[]", "[]"));
+					}
+				}""");
 	}
 
 	/**
@@ -118,18 +117,18 @@ public class MigLayoutGefTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_setLayout_replaceGridBagLayout() throws Exception {
-		openPanel(
-				"// filler filler filler filler filler",
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new GridBagLayout());",
-				"    {",
-				"      JButton button = new JButton();",
-				"      add(button);",
-				"    }",
-				"  }",
-				"}");
+		openPanel("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new GridBagLayout());
+						{
+							JButton button = new JButton();
+							add(button);
+						}
+					}
+				}""");
 		canvas.select(panel);
 		//
 		loadCreationTool("net.miginfocom.swing.MigLayout");
@@ -146,371 +145,371 @@ public class MigLayoutGefTest extends SwingGefTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_CREATE_filled() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout());",
-				"    {",
-				"      JButton button = new JButton('Existing JButton');",
-				"      add(button, 'cell 0 0');",
-				"    }",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout());
+						{
+							JButton button = new JButton("Existing JButton");
+							add(button, "cell 0 0");
+						}
+					}
+				}""");
 		ComponentInfo button = getJavaInfoByName("button");
 		//
 		loadButtonWithText();
 		canvas.moveTo(button, 0.5, 0.55).click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout());",
-				"    {",
-				"      JButton button = new JButton('Existing JButton');",
-				"      add(button, 'flowy,cell 0 0');",
-				"    }",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, 'cell 0 0');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout());
+						{
+							JButton button = new JButton("Existing JButton");
+							add(button, "flowy,cell 0 0");
+						}
+						{
+							JButton button = new JButton("New button");
+							add(button, "cell 0 0");
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_empty() throws Exception {
-		openPanel(
-				"// filler filler filler filler filler",
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout());",
-				"  }",
-				"}");
+		openPanel("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout());
+					}
+				}""");
 		//
 		loadButtonWithText();
 		canvas.moveTo(panel, COL_INSET, ROW_INSET).click();
-		assertEditor(
-				"// filler filler filler filler filler",
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout());",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, 'cell 0 0');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout());
+						{
+							JButton button = new JButton("New button");
+							add(button, "cell 0 0");
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_virtual_1x1() throws Exception {
-		openPanel(
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout());",
-				"  }",
-				"}");
+		openPanel("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout());
+					}
+				}""");
 		//
 		loadButtonWithText();
 		int x = COL_INSET + COL_VIRTUAL_SIZE + COL_GAP + COL_VIRTUAL_SIZE / 2;
 		int y = ROW_INSET + ROW_VIRTUAL_SIZE + ROW_GAP + ROW_VIRTUAL_SIZE / 2;
 		canvas.moveTo(panel, x, y);
 		canvas.click();
-		assertEditor(
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout('', '[][]', '[][]'));",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, 'cell 1 1');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout("", "[][]", "[][]"));
+						{
+							JButton button = new JButton("New button");
+							add(button, "cell 1 1");
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_virtual_1x0() throws Exception {
-		openPanel(
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout());",
-				"  }",
-				"}");
+		openPanel("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout());
+					}
+				}""");
 		//
 		loadButtonWithText();
 		int x = COL_INSET + COL_VIRTUAL_SIZE + COL_GAP + COL_VIRTUAL_SIZE / 2;
 		int y = ROW_INSET + ROW_VIRTUAL_SIZE / 2;
 		canvas.moveTo(panel, x, y);
 		canvas.click();
-		assertEditor(
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout('', '[][]', '[]'));",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, 'cell 1 0');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout("", "[][]", "[]"));
+						{
+							JButton button = new JButton("New button");
+							add(button, "cell 1 0");
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_virtual_0x1() throws Exception {
-		openPanel(
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout());",
-				"  }",
-				"}");
+		openPanel("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout());
+					}
+				}""");
 		//
 		loadButtonWithText();
 		int x = COL_INSET + COL_VIRTUAL_SIZE / 2;
 		int y = ROW_INSET + ROW_VIRTUAL_SIZE + ROW_GAP + ROW_VIRTUAL_SIZE / 2;
 		canvas.moveTo(panel, x, y);
 		canvas.click();
-		assertEditor(
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout('', '[]', '[][]'));",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, 'cell 0 1');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout("", "[]", "[][]"));
+						{
+							JButton button = new JButton("New button");
+							add(button, "cell 0 1");
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_appendToColumn_0x1() throws Exception {
-		openPanel(
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout());",
-				"    {",
-				"      JButton existing = new JButton('Existing JButton');",
-				"      add(existing, 'cell 0 0');",
-				"    }",
-				"  }",
-				"}");
+		openPanel("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout());
+						{
+							JButton existing = new JButton("Existing JButton");
+							add(existing, "cell 0 0");
+						}
+					}
+				}""");
 		ComponentInfo existing = getJavaInfoByName("existing");
 		//
 		loadButtonWithText();
 		canvas.target(existing).inX(0.5).outY(ROW_GAP + 1).move();
 		canvas.click();
-		assertEditor(
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout('', '[]', '[][]'));",
-				"    {",
-				"      JButton existing = new JButton('Existing JButton');",
-				"      add(existing, 'cell 0 0');",
-				"    }",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, 'cell 0 1');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout("", "[]", "[][]"));
+						{
+							JButton existing = new JButton("Existing JButton");
+							add(existing, "cell 0 0");
+						}
+						{
+							JButton button = new JButton("New button");
+							add(button, "cell 0 1");
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_appendToRow_1x0() throws Exception {
-		openPanel(
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout());",
-				"    {",
-				"      JButton existing = new JButton('Existing JButton');",
-				"      add(existing, 'cell 0 0');",
-				"    }",
-				"  }",
-				"}");
+		openPanel("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout());
+						{
+							JButton existing = new JButton("Existing JButton");
+							add(existing, "cell 0 0");
+						}
+					}
+				}""");
 		ComponentInfo existing = getJavaInfoByName("existing");
 		//
 		loadButtonWithText();
 		canvas.target(existing).inY(0.5).outX(COL_GAP + 1).move();
 		canvas.click();
-		assertEditor(
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout('', '[][]', '[]'));",
-				"    {",
-				"      JButton existing = new JButton('Existing JButton');",
-				"      add(existing, 'cell 0 0');",
-				"    }",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, 'cell 1 0');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout("", "[][]", "[]"));
+						{
+							JButton existing = new JButton("Existing JButton");
+							add(existing, "cell 0 0");
+						}
+						{
+							JButton button = new JButton("New button");
+							add(button, "cell 1 0");
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_beforeFirstRow() throws Exception {
-		openPanel(
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout());",
-				"    {",
-				"      JButton existing = new JButton('Existing JButton');",
-				"      add(existing, 'cell 0 0');",
-				"    }",
-				"  }",
-				"}");
+		openPanel("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout());
+						{
+							JButton existing = new JButton("Existing JButton");
+							add(existing, "cell 0 0");
+						}
+					}
+				}""");
 		ComponentInfo existing = getJavaInfoByName("existing");
 		//
 		loadButtonWithText();
 		canvas.target(existing).inX(0.5).outY(-2).move();
 		canvas.click();
-		assertEditor(
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout('', '[]', '[][]'));",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, 'cell 0 0');",
-				"    }",
-				"    {",
-				"      JButton existing = new JButton('Existing JButton');",
-				"      add(existing, 'cell 0 1');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout("", "[]", "[][]"));
+						{
+							JButton button = new JButton("New button");
+							add(button, "cell 0 0");
+						}
+						{
+							JButton existing = new JButton("Existing JButton");
+							add(existing, "cell 0 1");
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_beforeFirstColumn() throws Exception {
-		openPanel(
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout());",
-				"    {",
-				"      JButton existing = new JButton('Existing JButton');",
-				"      add(existing, 'cell 0 0');",
-				"    }",
-				"  }",
-				"}");
+		openPanel("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout());
+						{
+							JButton existing = new JButton("Existing JButton");
+							add(existing, "cell 0 0");
+						}
+					}
+				}""");
 		ComponentInfo existing = getJavaInfoByName("existing");
 		//
 		loadButtonWithText();
 		canvas.target(existing).inY(0.5).outX(-2).move();
 		canvas.click();
-		assertEditor(
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout('', '[][]', '[]'));",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, 'cell 0 0');",
-				"    }",
-				"    {",
-				"      JButton existing = new JButton('Existing JButton');",
-				"      add(existing, 'cell 1 0');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout("", "[][]", "[]"));
+						{
+							JButton button = new JButton("New button");
+							add(button, "cell 0 0");
+						}
+						{
+							JButton existing = new JButton("Existing JButton");
+							add(existing, "cell 1 0");
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_insertRow_endOfComponent() throws Exception {
-		openPanel(
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout());",
-				"    {",
-				"      JButton button_1 = new JButton('Button 1');",
-				"      add(button_1, 'cell 0 0');",
-				"    }",
-				"    {",
-				"      JButton button_2 = new JButton('Button 2');",
-				"      add(button_2, 'cell 0 1');",
-				"    }",
-				"  }",
-				"}");
+		openPanel("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout());
+						{
+							JButton button_1 = new JButton("Button 1");
+							add(button_1, "cell 0 0");
+						}
+						{
+							JButton button_2 = new JButton("Button 2");
+							add(button_2, "cell 0 1");
+						}
+					}
+				}""");
 		ComponentInfo button_1 = getJavaInfoByName("button_1");
 		//
 		loadButtonWithText();
 		canvas.target(button_1).inX(0.5).inY(-2).move();
 		canvas.click();
-		assertEditor(
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout('', '[]', '[][][]'));",
-				"    {",
-				"      JButton button_1 = new JButton('Button 1');",
-				"      add(button_1, 'cell 0 0');",
-				"    }",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, 'cell 0 1');",
-				"    }",
-				"    {",
-				"      JButton button_2 = new JButton('Button 2');",
-				"      add(button_2, 'cell 0 2');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout("", "[]", "[][][]"));
+						{
+							JButton button_1 = new JButton("Button 1");
+							add(button_1, "cell 0 0");
+						}
+						{
+							JButton button = new JButton("New button");
+							add(button, "cell 0 1");
+						}
+						{
+							JButton button_2 = new JButton("Button 2");
+							add(button_2, "cell 0 2");
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_insertColumn_endOfComponent() throws Exception {
-		openPanel(
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout());",
-				"    {",
-				"      JButton button_1 = new JButton('Button 1');",
-				"      add(button_1, 'cell 0 0');",
-				"    }",
-				"    {",
-				"      JButton button_2 = new JButton('Button 2');",
-				"      add(button_2, 'cell 1 0');",
-				"    }",
-				"  }",
-				"}");
+		openPanel("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout());
+						{
+							JButton button_1 = new JButton("Button 1");
+							add(button_1, "cell 0 0");
+						}
+						{
+							JButton button_2 = new JButton("Button 2");
+							add(button_2, "cell 1 0");
+						}
+					}
+				}""");
 		ComponentInfo button_1 = getJavaInfoByName("button_1");
 		//
 		loadButtonWithText();
 		canvas.target(button_1).inY(0.5).inX(-2).move();
 		canvas.click();
-		assertEditor(
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout('', '[][][]', '[]'));",
-				"    {",
-				"      JButton button_1 = new JButton('Button 1');",
-				"      add(button_1, 'cell 0 0');",
-				"    }",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, 'cell 1 0');",
-				"    }",
-				"    {",
-				"      JButton button_2 = new JButton('Button 2');",
-				"      add(button_2, 'cell 2 0');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout("", "[][][]", "[]"));
+						{
+							JButton button_1 = new JButton("Button 1");
+							add(button_1, "cell 0 0");
+						}
+						{
+							JButton button = new JButton("New button");
+							add(button, "cell 1 0");
+						}
+						{
+							JButton button_2 = new JButton("Button 2");
+							add(button_2, "cell 2 0");
+						}
+					}
+				}""");
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -525,31 +524,31 @@ public class MigLayoutGefTest extends SwingGefTest {
 	public void test_CREATE_inherited_columnOperations() throws Exception {
 		setFileContentSrc(
 				"test/MyPanel.java",
-				getTestSource(
-						"// filler filler filler filler filler",
-						"// filler filler filler filler filler",
-						"public class MyPanel extends JPanel {",
-						"  public MyPanel() {",
-						"    setLayout(new MigLayout('', '[][]', '[]'));",
-						"  }",
-						"}"));
+				getTestSource("""
+						// filler filler filler filler filler
+						// filler filler filler filler filler
+						public class MyPanel extends JPanel {
+							public MyPanel() {
+								setLayout(new MigLayout("", "[][]", "[]"));
+							}
+						}"""));
 		waitForAutoBuild();
 		// parse
-		openPanel(
-				"// filler filler filler filler filler",
-				"// filler filler filler filler filler",
-				"public class Test extends MyPanel {",
-				"  public Test() {",
-				"    {",
-				"      JButton button_1 = new JButton('JButton 1');",
-				"      add(button_1, 'cell 0 0');",
-				"    }",
-				"    {",
-				"      JButton button_2 = new JButton('JButton 2');",
-				"      add(button_2, 'cell 1 0');",
-				"    }",
-				"  }",
-				"}");
+		openPanel("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends MyPanel {
+					public Test() {
+						{
+							JButton button_1 = new JButton("JButton 1");
+							add(button_1, "cell 0 0");
+						}
+						{
+							JButton button_2 = new JButton("JButton 2");
+							add(button_2, "cell 1 0");
+						}
+					}
+				}""");
 		loadButton();
 		// can not insert column
 		{
@@ -572,31 +571,31 @@ public class MigLayoutGefTest extends SwingGefTest {
 	public void test_CREATE_inherited_rowOperations() throws Exception {
 		setFileContentSrc(
 				"test/MyPanel.java",
-				getTestSource(
-						"// filler filler filler filler filler",
-						"// filler filler filler filler filler",
-						"public class MyPanel extends JPanel {",
-						"  public MyPanel() {",
-						"    setLayout(new MigLayout('', '[]', '[][]'));",
-						"  }",
-						"}"));
+				getTestSource("""
+						// filler filler filler filler filler
+						// filler filler filler filler filler
+						public class MyPanel extends JPanel {
+							public MyPanel() {
+								setLayout(new MigLayout("", "[]", "[][]"));
+							}
+						}"""));
 		waitForAutoBuild();
 		// parse
-		openPanel(
-				"// filler filler filler filler filler",
-				"// filler filler filler filler filler",
-				"public class Test extends MyPanel {",
-				"  public Test() {",
-				"    {",
-				"      JButton button_1 = new JButton('JButton 1');",
-				"      add(button_1, 'cell 0 0');",
-				"    }",
-				"    {",
-				"      JButton button_2 = new JButton('JButton 2');",
-				"      add(button_2, 'cell 0 1');",
-				"    }",
-				"  }",
-				"}");
+		openPanel("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends MyPanel {
+					public Test() {
+						{
+							JButton button_1 = new JButton("JButton 1");
+							add(button_1, "cell 0 0");
+						}
+						{
+							JButton button_2 = new JButton("JButton 2");
+							add(button_2, "cell 0 1");
+						}
+					}
+				}""");
 		loadButton();
 		// can not insert row
 		{
@@ -621,17 +620,17 @@ public class MigLayoutGefTest extends SwingGefTest {
 	@Ignore
 	@Test
 	public void test_PASTE_virtual_1x0() throws Exception {
-		openPanel(
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout());",
-				"    {",
-				"      JButton existing = new JButton('My JButton');",
-				"      add(existing, 'cell 0 0');",
-				"    }",
-				"  }",
-				"}");
+		openPanel("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout());
+						{
+							JButton existing = new JButton("My JButton");
+							add(existing, "cell 0 0");
+						}
+					}
+				}""");
 		ComponentInfo existing = getJavaInfoByName("existing");
 		// do copy/paste
 		doCopyPaste(existing);
@@ -639,21 +638,21 @@ public class MigLayoutGefTest extends SwingGefTest {
 			canvas.target(existing).inY(0.5).outX(COL_GAP + 1).move();
 			canvas.click();
 		}
-		assertEditor(
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout('', '[][]', '[]'));",
-				"    {",
-				"      JButton existing = new JButton('My JButton');",
-				"      add(existing, 'cell 0 0');",
-				"    }",
-				"    {",
-				"      JButton button = new JButton('My JButton');",
-				"      add(button, 'cell 1 0');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout("", "[][]", "[]"));
+						{
+							JButton existing = new JButton("My JButton");
+							add(existing, "cell 0 0");
+						}
+						{
+							JButton button = new JButton("My JButton");
+							add(button, "cell 1 0");
+						}
+					}
+				}""");
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -663,73 +662,73 @@ public class MigLayoutGefTest extends SwingGefTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_MOVE_virtual_1x0() throws Exception {
-		openPanel(
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout());",
-				"    {",
-				"      JButton button = new JButton('My JButton');",
-				"      add(button, 'cell 0 0');",
-				"    }",
-				"  }",
-				"}");
+		openPanel("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout());
+						{
+							JButton button = new JButton("My JButton");
+							add(button, "cell 0 0");
+						}
+					}
+				}""");
 		ComponentInfo button = getJavaInfoByName("button");
 		//
 		canvas.beginDrag(button);
 		canvas.target(button).inY(0.5).outX(COL_GAP + 1).drag();
 		canvas.endDrag();
-		assertEditor(
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout('', '[][]', '[]'));",
-				"    {",
-				"      JButton button = new JButton('My JButton');",
-				"      add(button, 'cell 1 0');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout("", "[][]", "[]"));
+						{
+							JButton button = new JButton("My JButton");
+							add(button, "cell 1 0");
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_ADD_virtual_0x0() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      JButton button = new JButton('My JButton');",
-				"      add(button, BorderLayout.NORTH);",
-				"    }",
-				"    {",
-				"      JPanel inner = new JPanel();",
-				"      add(inner, BorderLayout.CENTER);",
-				"      inner.setLayout(new MigLayout());",
-				"    }",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JButton button = new JButton("My JButton");
+							add(button, BorderLayout.NORTH);
+						}
+						{
+							JPanel inner = new JPanel();
+							add(inner, BorderLayout.CENTER);
+							inner.setLayout(new MigLayout());
+						}
+					}
+				}""");
 		ComponentInfo button = getJavaInfoByName("button");
 		panel = getJavaInfoByName("inner");
 		//
 		canvas.beginDrag(button);
 		canvas.target(panel).in(COL_INSET, ROW_INSET).drag();
 		canvas.endDrag();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      JPanel inner = new JPanel();",
-				"      add(inner, BorderLayout.CENTER);",
-				"      inner.setLayout(new MigLayout());",
-				"      {",
-				"        JButton button = new JButton('My JButton');",
-				"        inner.add(button, 'cell 0 0');",
-				"      }",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JPanel inner = new JPanel();
+							add(inner, BorderLayout.CENTER);
+							inner.setLayout(new MigLayout());
+							{
+								JButton button = new JButton("My JButton");
+								inner.add(button, "cell 0 0");
+							}
+						}
+					}
+				}""");
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -744,23 +743,23 @@ public class MigLayoutGefTest extends SwingGefTest {
 	public void test_headerColumn_MOVE_inherited() throws Exception {
 		setFileContentSrc(
 				"test/MyPanel.java",
-				getTestSource(
-						"// filler filler filler filler filler",
-						"// filler filler filler filler filler",
-						"public class MyPanel extends JPanel {",
-						"  public MyPanel() {",
-						"    setLayout(new MigLayout('', '[150px][100px]', ''));",
-						"  }",
-						"}"));
+				getTestSource("""
+						// filler filler filler filler filler
+						// filler filler filler filler filler
+						public class MyPanel extends JPanel {
+							public MyPanel() {
+								setLayout(new MigLayout("", "[150px][100px]", ""));
+							}
+						}"""));
 		waitForAutoBuild();
 		// parse
-		openPanel(
-				"// filler filler filler filler filler",
-				"// filler filler filler filler filler",
-				"public class Test extends MyPanel {",
-				"  public Test() {",
-				"  }",
-				"}");
+		openPanel("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends MyPanel {
+					public Test() {
+					}
+				}""");
 		// select panel to show headers
 		canvas.select(panel);
 		// animate headers
@@ -775,12 +774,12 @@ public class MigLayoutGefTest extends SwingGefTest {
 
 	@Test
 	public void test_headerColumn_MOVE_forward_beforeOther() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout('', '[150px][100px][50px]', ''));",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout("", "[150px][100px][50px]", ""));
+					}
+				}""");
 		// select panel to show headers
 		canvas.select(panel);
 		// animate headers
@@ -791,22 +790,22 @@ public class MigLayoutGefTest extends SwingGefTest {
 			horizontalRobot.beginDrag(sourceColumn).dragTo(relativeColumn, -5, 0.5);
 			horizontalRobot.endDrag();
 		}
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout('', '[100px][150px][50px]', '[]'));",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout("", "[100px][150px][50px]", "[]"));
+					}
+				}""");
 	}
 
 	@Test
 	public void test_headerColumn_MOVE_forward_afterLast() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout('', '[150px][100px][50px]', ''));",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout("", "[150px][100px][50px]", ""));
+					}
+				}""");
 		// select panel to show headers
 		canvas.select(panel);
 		// animate headers
@@ -817,12 +816,12 @@ public class MigLayoutGefTest extends SwingGefTest {
 			horizontalRobot.beginDrag(sourceColumn).dragTo(relativeColumn, -5, 0.5);
 			horizontalRobot.endDrag();
 		}
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout('', '[100px][50px][150px]', '[]'));",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout("", "[100px][50px][150px]", "[]"));
+					}
+				}""");
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -837,23 +836,23 @@ public class MigLayoutGefTest extends SwingGefTest {
 	public void test_headerRow_MOVE_inherited() throws Exception {
 		setFileContentSrc(
 				"test/MyPanel.java",
-				getTestSource(
-						"// filler filler filler filler filler",
-						"// filler filler filler filler filler",
-						"public class MyPanel extends JPanel {",
-						"  public MyPanel() {",
-						"    setLayout(new MigLayout('', '', '[100px][75px]'));",
-						"  }",
-						"}"));
+				getTestSource("""
+						// filler filler filler filler filler
+						// filler filler filler filler filler
+						public class MyPanel extends JPanel {
+							public MyPanel() {
+								setLayout(new MigLayout("", "", "[100px][75px]"));
+							}
+						}"""));
 		waitForAutoBuild();
 		// parse
-		openPanel(
-				"// filler filler filler filler filler",
-				"// filler filler filler filler filler",
-				"public class Test extends MyPanel {",
-				"  public Test() {",
-				"  }",
-				"}");
+		openPanel("""
+				// filler filler filler filler filler
+				// filler filler filler filler filler
+				public class Test extends MyPanel {
+					public Test() {
+					}
+				}""");
 		// select panel to show headers
 		canvas.select(panel);
 		// animate headers
@@ -868,12 +867,12 @@ public class MigLayoutGefTest extends SwingGefTest {
 
 	@Test
 	public void test_headerRow_MOVE_forward_beforeOther() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout('', '', '[100px][75px][50px]'));",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout("", "", "[100px][75px][50px]"));
+					}
+				}""");
 		// select panel to show headers
 		canvas.select(panel);
 		// animate headers
@@ -884,22 +883,22 @@ public class MigLayoutGefTest extends SwingGefTest {
 			verticalRobot.beginDrag(sourceRow).dragTo(relativeRow, 0.5, -5);
 			verticalRobot.endDrag();
 		}
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout('', '[]', '[75px][100px][50px]'));",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout("", "[]", "[75px][100px][50px]"));
+					}
+				}""");
 	}
 
 	@Test
 	public void test_headerRow_MOVE_forward_afterLast() throws Exception {
-		openPanel(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout('', '', '[100px][75px][50px]'));",
-				"  }",
-				"}");
+		openPanel("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout("", "", "[100px][75px][50px]"));
+					}
+				}""");
 		// select panel to show headers
 		canvas.select(panel);
 		// animate headers
@@ -910,12 +909,12 @@ public class MigLayoutGefTest extends SwingGefTest {
 			verticalRobot.beginDrag(sourceRow).dragTo(relativeRow, 0.5, -5);
 			verticalRobot.endDrag();
 		}
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new MigLayout('', '[]', '[75px][50px][100px]'));",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new MigLayout("", "[]", "[75px][50px][100px]"));
+					}
+				}""");
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -924,15 +923,14 @@ public class MigLayoutGefTest extends SwingGefTest {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public String getTestSource(String... lines) {
-		lines =
-				CodeUtils.join(new String[]{
-						"import net.miginfocom.layout.*;",
-				"import net.miginfocom.swing.*;"}, lines);
-		return super.getTestSource(lines);
+	public String getTestSource(String code) {
+		return super.getTestSource("""
+				import net.miginfocom.layout.*;
+				import net.miginfocom.swing.*;
+				%s""".formatted(code));
 	}
 
-	private void openPanel(String... lines) throws Exception {
+	private void openPanel(String lines) throws Exception {
 		panel = openContainer(lines);
 		if (panel.getLayout() instanceof MigLayoutInfo) {
 			layout = (MigLayoutInfo) panel.getLayout();

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/gbl/GridBagLayoutGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/gbl/GridBagLayoutGefTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -74,20 +74,19 @@ public class GridBagLayoutGefTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_replaceWithOther_andPaintDuringThis() throws Exception {
-		mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    GridBagLayout gridBagLayout = new GridBagLayout();",
-						"    gridBagLayout.columnWeights = new double[]{1.0};",
-						"    gridBagLayout.rowWeights = new double[]{1.0};",
-						"    setLayout(gridBagLayout);",
-						"    {",
-						"      JButton button = new JButton('New JButton');",
-						"      add(button);",
-						"    }",
-						"  }",
-						"}");
+		mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						GridBagLayout gridBagLayout = new GridBagLayout();
+						gridBagLayout.columnWeights = new double[]{1.0};
+						gridBagLayout.rowWeights = new double[]{1.0};
+						setLayout(gridBagLayout);
+						{
+							JButton button = new JButton("New JButton");
+							add(button);
+						}
+					}
+				}""");
 		button = getJavaInfoByName("button");
 		canvas.select(button);
 		waitEventLoop(0);
@@ -123,22 +122,22 @@ public class GridBagLayoutGefTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_JPopupMenu_select() throws Exception {
-		openContainer(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new GridBagLayout());",
-				"    {",
-				"      JButton button = new JButton('button');",
-				"      add(button, new GridBagConstraints());",
-				"    }",
-				"    {",
-				"      JPopupMenu popupMenu = new JPopupMenu();",
-				"      addPopup(this, popupMenu);",
-				"    }",
-				"  }",
-				"  private static void addPopup(Component component, JPopupMenu popup) {",
-				"  }",
-				"}");
+		openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new GridBagLayout());
+						{
+							JButton button = new JButton("button");
+							add(button, new GridBagConstraints());
+						}
+						{
+							JPopupMenu popupMenu = new JPopupMenu();
+							addPopup(this, popupMenu);
+						}
+					}
+					private static void addPopup(Component component, JPopupMenu popup) {
+					}
+				}""");
 		ComponentInfo popup = getJavaInfoByName("popupMenu");
 		//
 		canvas.select(popup);
@@ -150,15 +149,14 @@ public class GridBagLayoutGefTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_JPopupMenu_drop() throws Exception {
-		mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new GridBagLayout());",
-						"  }",
-						"  private static void addPopup(Component component, JPopupMenu popup) {",
-						"  }",
-						"}");
+		mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new GridBagLayout());
+					}
+					private static void addPopup(Component component, JPopupMenu popup) {
+					}
+				}""");
 		//
 		ComponentInfo newPopup = loadCreationTool("javax.swing.JPopupMenu");
 		{
@@ -166,18 +164,18 @@ public class GridBagLayoutGefTest extends SwingGefTest {
 			canvas.assertFeedbacks(canvas.getTargetPredicate(mainPanel));
 			canvas.click();
 		}
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    {",
-				"      JPopupMenu popupMenu = new JPopupMenu();",
-				"      addPopup(this, popupMenu);",
-				"    }",
-				"    setLayout(new GridBagLayout());",
-				"  }",
-				"  private static void addPopup(Component component, JPopupMenu popup) {",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						{
+							JPopupMenu popupMenu = new JPopupMenu();
+							addPopup(this, popupMenu);
+						}
+						setLayout(new GridBagLayout());
+					}
+					private static void addPopup(Component component, JPopupMenu popup) {
+					}
+				}""");
 		canvas.assertPrimarySelected(newPopup);
 	}
 
@@ -192,62 +190,61 @@ public class GridBagLayoutGefTest extends SwingGefTest {
 
 	@Test
 	public void test_CREATE_inTree_empty() throws Exception {
-		mainPanel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new GridBagLayout());",
-						"  }",
-						"}");
+		mainPanel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new GridBagLayout());
+					}
+				}""");
 		// create JButton
 		loadCreationTool("javax.swing.JButton", "empty");
 		tree.moveOn(mainPanel);
 		tree.assertCommandNotNull();
 		tree.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new GridBagLayout());",
-				"    {",
-				"      JButton button = new JButton();",
-				"      GridBagConstraints gbc = new GridBagConstraints();",
-				"      gbc.gridx = 0;",
-				"      gbc.gridy = 0;",
-				"      add(button, gbc);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new GridBagLayout());
+						{
+							JButton button = new JButton();
+							GridBagConstraints gbc = new GridBagConstraints();
+							gbc.gridx = 0;
+							gbc.gridy = 0;
+							add(button, gbc);
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_DELETE_afterSelect() throws Exception {
 		final ContainerInfo panel = openContainer("""
 				public class Test extends JPanel {
-				  public Test() {
-				    setSize(50, 50);
-				    GridBagLayout gridBagLayout = new GridBagLayout();
-				    setLayout(gridBagLayout);
+					public Test() {
+						setSize(50, 50);
+						GridBagLayout gridBagLayout = new GridBagLayout();
+						setLayout(gridBagLayout);
 
-				    JPanel panel = new JPanel();
-				    GridBagConstraints gbc_panel = new GridBagConstraints();
-				    gbc_panel.ipady = 10;
-				    gbc_panel.ipadx = 10;
-				    gbc_panel.fill = GridBagConstraints.BOTH;
-				    gbc_panel.gridx = 0;
-				    gbc_panel.gridy = 0;
-				    add(panel, gbc_panel);
-				    panel.setLayout(null);
+						JPanel panel = new JPanel();
+						GridBagConstraints gbc_panel = new GridBagConstraints();
+						gbc_panel.ipady = 10;
+						gbc_panel.ipadx = 10;
+						gbc_panel.fill = GridBagConstraints.BOTH;
+						gbc_panel.gridx = 0;
+						gbc_panel.gridy = 0;
+						add(panel, gbc_panel);
+						panel.setLayout(null);
 
-				    JPanel panel_1 = new JPanel();
-				    GridBagConstraints gbc_panel_1 = new GridBagConstraints();
-				    gbc_panel_1.ipady = 10;
-				    gbc_panel_1.ipadx = 10;
-				    gbc_panel_1.fill = GridBagConstraints.BOTH;
-				    gbc_panel_1.gridx = 1;
-				    gbc_panel_1.gridy = 1;
-				    add(panel_1, gbc_panel_1);
-				    panel_1.setLayout(null);
-				  }
+						JPanel panel_1 = new JPanel();
+						GridBagConstraints gbc_panel_1 = new GridBagConstraints();
+						gbc_panel_1.ipady = 10;
+						gbc_panel_1.ipadx = 10;
+						gbc_panel_1.fill = GridBagConstraints.BOTH;
+						gbc_panel_1.gridx = 1;
+						gbc_panel_1.gridy = 1;
+						add(panel_1, gbc_panel_1);
+						panel_1.setLayout(null);
+					}
 				}
 				""");
 		panel.refresh();
@@ -263,21 +260,21 @@ public class GridBagLayoutGefTest extends SwingGefTest {
 		assertEquals(1, layout.getRows().size());
 		assertEditor("""
 				public class Test extends JPanel {
-				  public Test() {
-				    setSize(50, 50);
-				    GridBagLayout gridBagLayout = new GridBagLayout();
-				    setLayout(gridBagLayout);
+					public Test() {
+						setSize(50, 50);
+						GridBagLayout gridBagLayout = new GridBagLayout();
+						setLayout(gridBagLayout);
 
-				    JPanel panel = new JPanel();
-				    GridBagConstraints gbc_panel = new GridBagConstraints();
-				    gbc_panel.ipady = 10;
-				    gbc_panel.ipadx = 10;
-				    gbc_panel.fill = GridBagConstraints.BOTH;
-				    gbc_panel.gridx = 0;
-				    gbc_panel.gridy = 0;
-				    add(panel, gbc_panel);
-				    panel.setLayout(null);
-				  }
+						JPanel panel = new JPanel();
+						GridBagConstraints gbc_panel = new GridBagConstraints();
+						gbc_panel.ipady = 10;
+						gbc_panel.ipadx = 10;
+						gbc_panel.fill = GridBagConstraints.BOTH;
+						gbc_panel.gridx = 0;
+						gbc_panel.gridy = 0;
+						add(panel, gbc_panel);
+						panel.setLayout(null);
+					}
 				}
 				""");
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/gef/AbstractLayoutPolicyTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/gef/AbstractLayoutPolicyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,9 +27,9 @@ public abstract class AbstractLayoutPolicyTest extends SwingGefTest {
 	/**
 	 * Check for drop given layout on root container.
 	 */
-	protected final void check_setLayout(String[] source,
+	protected final void check_setLayout(String source,
 			String layoutClassName,
-			String[] source2,
+			String source2,
 			int clickOffsetX,
 			int clickOffsetY) throws Exception {
 		openContainer(source);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/gef/BorderLayoutPolicyTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/gef/BorderLayoutPolicyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.swing.model.layout.gef;
 
-import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.swing.gef.policy.layout.BorderLayoutEditPolicy;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
@@ -42,21 +41,19 @@ public class BorderLayoutPolicyTest extends AbstractLayoutPolicyTest {
 	 */
 	@Test
 	public void test_canvas_setLayout() throws Exception {
-		String[] source =
-				new String[]{
-						"// filler filler filler",
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"  }",
-		"}"};
-		String[] source2 =
-				new String[]{
-						"// filler filler filler",
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout(0, 0));",
-						"  }",
-		"}"};
+		String source = """
+				// filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+					}
+				}""";
+		String source2 = """
+				// filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout(0, 0));
+					}
+				}""";
 		check_setLayout(source, "java.awt.BorderLayout", source2, 10, 10);
 	}
 
@@ -70,12 +67,12 @@ public class BorderLayoutPolicyTest extends AbstractLayoutPolicyTest {
 	 */
 	@Test
 	public void test_canvas_CREATE() throws Exception {
-		openContainer(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"  }",
-				"}");
+		openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+					}
+				}""");
 		//
 		loadCreationTool("javax.swing.JButton", "empty");
 		canvas.moveTo(m_contentEditPart, 10, 10);
@@ -86,16 +83,16 @@ public class BorderLayoutPolicyTest extends AbstractLayoutPolicyTest {
 		canvas.assertNoFeedbackFigures();
 		waitEventLoop(10);
 		//
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      JButton button = new JButton();",
-				"      add(button, BorderLayout.NORTH);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JButton button = new JButton();
+							add(button, BorderLayout.NORTH);
+						}
+					}
+				}""");
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -108,16 +105,16 @@ public class BorderLayoutPolicyTest extends AbstractLayoutPolicyTest {
 	 */
 	@Test
 	public void test_canvas_MOVE_1() throws Exception {
-		check_MOVE(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      JButton button = new JButton('Button');",
-				"      add(button, BorderLayout.NORTH);",
-				"    }",
-				"  }",
-				"}");
+		check_MOVE("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JButton button = new JButton("Button");
+							add(button, BorderLayout.NORTH);
+						}
+					}
+				}""");
 	}
 
 	/**
@@ -125,20 +122,20 @@ public class BorderLayoutPolicyTest extends AbstractLayoutPolicyTest {
 	 */
 	@Test
 	public void test_canvas_MOVE_2() throws Exception {
-		check_MOVE(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    add(getButton(), BorderLayout.NORTH);",
-				"  }",
-				"  private JButton button;",
-				"  private JButton getButton() {",
-				"    if (button == null) {",
-				"      button = new JButton();",
-				"    }",
-				"    return button;",
-				"  }",
-				"}");
+		check_MOVE("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						add(getButton(), BorderLayout.NORTH);
+					}
+					private JButton button;
+					private JButton getButton() {
+						if (button == null) {
+							button = new JButton();
+						}
+						return button;
+					}
+				}""");
 	}
 
 	/**
@@ -146,34 +143,32 @@ public class BorderLayoutPolicyTest extends AbstractLayoutPolicyTest {
 	 */
 	@Test
 	public void test_canvas_MOVE_3() throws Exception {
-		String[] source =
-				new String[]{
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      final JButton button = new JButton();",
-						"      add(button);",
-						"    }",
-						"  }",
-		"}"};
-		String[] expectedSource =
-				StringUtilities.replace(source, "add(button);", "add(button, BorderLayout.SOUTH);");
+		String source = """
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							final JButton button = new JButton();
+							add(button);
+						}
+					}
+				}""";
+		String expectedSource = source.replace("add(button);", "add(button, BorderLayout.SOUTH);");
 		check_MOVE(source, expectedSource);
 	}
 
 	/**
 	 * Test for moving component from NORTH to SOUTH.
 	 */
-	private void check_MOVE(String... lines) throws Exception {
-		String[] expectedSource = StringUtilities.replace(lines, "NORTH", "SOUTH");
+	private void check_MOVE(String lines) throws Exception {
+		String expectedSource = lines.replace("NORTH", "SOUTH");
 		check_MOVE(lines, expectedSource);
 	}
 
 	/**
 	 * Test for moving component at (10,10) - usually NORTH, may be CENTER/WEST; to SOUTH.
 	 */
-	private void check_MOVE(String[] source, String[] expectedSource) throws Exception,
+	private void check_MOVE(String source, String expectedSource) throws Exception,
 	InterruptedException {
 		ContainerInfo panel = openContainer(source);
 		ComponentInfo button = panel.getChildrenComponents().get(0);
@@ -200,48 +195,46 @@ public class BorderLayoutPolicyTest extends AbstractLayoutPolicyTest {
 	 */
 	@Test
 	public void test_canvas_ADD_1() throws Exception {
-		String[] source =
-				new String[]{
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      JPanel panel = new JPanel();",
-						"      panel.setBackground(Color.PINK);",
-						"      panel.setPreferredSize(new Dimension(0, 150));",
-						"      add(panel, BorderLayout.SOUTH);",
-						"      {",
-						"        JButton button_1 = new JButton('Button 1');",
-						"        panel.add(button_1);",
-						"      }",
-						"      {",
-						"        JButton button_2 = new JButton('Button 2');",
-						"        panel.add(button_2);",
-						"      }",
-						"    }",
-						"  }",
-		"}"};
-		String[] source2 =
-				new String[]{
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      JPanel panel = new JPanel();",
-						"      panel.setBackground(Color.PINK);",
-						"      panel.setPreferredSize(new Dimension(0, 150));",
-						"      add(panel, BorderLayout.SOUTH);",
-						"      {",
-						"        JButton button_2 = new JButton('Button 2');",
-						"        panel.add(button_2);",
-						"      }",
-						"    }",
-						"    {",
-						"      JButton button_1 = new JButton('Button 1');",
-						"      add(button_1, BorderLayout.NORTH);",
-						"    }",
-						"  }",
-		"}"};
+		String source = """
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JPanel panel = new JPanel();
+							panel.setBackground(Color.PINK);
+							panel.setPreferredSize(new Dimension(0, 150));
+							add(panel, BorderLayout.SOUTH);
+							{
+								JButton button_1 = new JButton("Button 1");
+								panel.add(button_1);
+							}
+							{
+								JButton button_2 = new JButton("Button 2");
+								panel.add(button_2);
+							}
+						}
+					}
+				}""";
+		String source2 = """
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JPanel panel = new JPanel();
+							panel.setBackground(Color.PINK);
+							panel.setPreferredSize(new Dimension(0, 150));
+							add(panel, BorderLayout.SOUTH);
+							{
+								JButton button_2 = new JButton("Button 2");
+								panel.add(button_2);
+							}
+						}
+						{
+							JButton button_1 = new JButton("Button 1");
+							add(button_1, BorderLayout.NORTH);
+						}
+					}
+				}""";
 		check_ADD(source, source2);
 	}
 
@@ -250,79 +243,77 @@ public class BorderLayoutPolicyTest extends AbstractLayoutPolicyTest {
 	 */
 	@Test
 	public void test_canvas_ADD_2() throws Exception {
-		String[] source =
-				new String[]{
-						"public class Test extends JPanel {",
-						"  private JPanel panel;",
-						"  private JButton button_1;",
-						"  private JButton button_2;",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    add(getPanel(), BorderLayout.SOUTH);",
-						"  }",
-						"  private JPanel getPanel() {",
-						"    if (panel == null) {",
-						"      panel = new JPanel();",
-						"      panel.setBackground(Color.PINK);",
-						"      panel.setPreferredSize(new Dimension(0, 150));",
-						"      panel.add(getButton_1());",
-						"      panel.add(getButton_2());",
-						"    }",
-						"    return panel;",
-						"  }",
-						"  private JButton getButton_1() {",
-						"    if (button_1 == null) {",
-						"      button_1 = new JButton('Button 1');",
-						"    }",
-						"    return button_1;",
-						"  }",
-						"  private JButton getButton_2() {",
-						"    if (button_2 == null) {",
-						"      button_2 = new JButton('button 2');",
-						"    }",
-						"    return button_2;",
-						"  }",
-		"}"};
-		String[] source2 =
-				new String[]{
-						"public class Test extends JPanel {",
-						"  private JPanel panel;",
-						"  private JButton button_1;",
-						"  private JButton button_2;",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    add(getPanel(), BorderLayout.SOUTH);",
-						"    add(getButton_1(), BorderLayout.NORTH);",
-						"  }",
-						"  private JPanel getPanel() {",
-						"    if (panel == null) {",
-						"      panel = new JPanel();",
-						"      panel.setBackground(Color.PINK);",
-						"      panel.setPreferredSize(new Dimension(0, 150));",
-						"      panel.add(getButton_2());",
-						"    }",
-						"    return panel;",
-						"  }",
-						"  private JButton getButton_1() {",
-						"    if (button_1 == null) {",
-						"      button_1 = new JButton('Button 1');",
-						"    }",
-						"    return button_1;",
-						"  }",
-						"  private JButton getButton_2() {",
-						"    if (button_2 == null) {",
-						"      button_2 = new JButton('button 2');",
-						"    }",
-						"    return button_2;",
-						"  }",
-		"}"};
+		String source = """
+				public class Test extends JPanel {
+					private JPanel panel;
+					private JButton button_1;
+					private JButton button_2;
+					public Test() {
+						setLayout(new BorderLayout());
+						add(getPanel(), BorderLayout.SOUTH);
+					}
+					private JPanel getPanel() {
+						if (panel == null) {
+							panel = new JPanel();
+							panel.setBackground(Color.PINK);
+							panel.setPreferredSize(new Dimension(0, 150));
+							panel.add(getButton_1());
+							panel.add(getButton_2());
+						}
+						return panel;
+					}
+					private JButton getButton_1() {
+						if (button_1 == null) {
+							button_1 = new JButton("Button 1");
+						}
+						return button_1;
+					}
+					private JButton getButton_2() {
+						if (button_2 == null) {
+							button_2 = new JButton("button 2");
+						}
+						return button_2;
+					}
+				}""";
+		String source2 = """
+				public class Test extends JPanel {
+					private JPanel panel;
+					private JButton button_1;
+					private JButton button_2;
+					public Test() {
+						setLayout(new BorderLayout());
+						add(getPanel(), BorderLayout.SOUTH);
+						add(getButton_1(), BorderLayout.NORTH);
+					}
+					private JPanel getPanel() {
+						if (panel == null) {
+							panel = new JPanel();
+							panel.setBackground(Color.PINK);
+							panel.setPreferredSize(new Dimension(0, 150));
+							panel.add(getButton_2());
+						}
+						return panel;
+					}
+					private JButton getButton_1() {
+						if (button_1 == null) {
+							button_1 = new JButton("Button 1");
+						}
+						return button_1;
+					}
+					private JButton getButton_2() {
+						if (button_2 == null) {
+							button_2 = new JButton("button 2");
+						}
+						return button_2;
+					}
+				}""";
 		check_ADD(source, source2);
 	}
 
 	/**
 	 * Test for ADD (reparenting) of "first component of first child" to root container.
 	 */
-	private void check_ADD(String[] source, String[] source2) throws Exception {
+	private void check_ADD(String source, String source2) throws Exception {
 		ContainerInfo panel = openContainer(source);
 		ContainerInfo inner = (ContainerInfo) panel.getChildrenComponents().get(0);
 		ComponentInfo button = inner.getChildrenComponents().get(0);
@@ -348,45 +339,43 @@ public class BorderLayoutPolicyTest extends AbstractLayoutPolicyTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_tree_CREATE_hasEmptyRegion() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+					}
+				}""");
 		//
 		loadCreationTool("javax.swing.JButton", "empty");
 		tree.moveOn(panel);
 		tree.assertFeedback_on(panel);
 		tree.assertCommandNotNull();
 		tree.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      JButton button = new JButton();",
-				"      add(button, BorderLayout.NORTH);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JButton button = new JButton();
+							add(button, BorderLayout.NORTH);
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_tree_CREATE_noEmptyRegion() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    add(new JButton(), BorderLayout.NORTH);",
-						"    add(new JButton(), BorderLayout.SOUTH);",
-						"    add(new JButton(), BorderLayout.WEST);",
-						"    add(new JButton(), BorderLayout.EAST);",
-						"    add(new JButton(), BorderLayout.CENTER);",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						add(new JButton(), BorderLayout.NORTH);
+						add(new JButton(), BorderLayout.SOUTH);
+						add(new JButton(), BorderLayout.WEST);
+						add(new JButton(), BorderLayout.EAST);
+						add(new JButton(), BorderLayout.CENTER);
+					}
+				}""");
 		//
 		loadCreationTool("javax.swing.JButton", "empty");
 		tree.moveOn(panel);
@@ -396,79 +385,77 @@ public class BorderLayoutPolicyTest extends AbstractLayoutPolicyTest {
 
 	@Test
 	public void test_tree_MOVE() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      JButton button_1 = new JButton();",
-						"      add(button_1, BorderLayout.NORTH);",
-						"    }",
-						"    {",
-						"      JButton button_2 = new JButton();",
-						"      add(button_2, BorderLayout.SOUTH);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JButton button_1 = new JButton();
+							add(button_1, BorderLayout.NORTH);
+						}
+						{
+							JButton button_2 = new JButton();
+							add(button_2, BorderLayout.SOUTH);
+						}
+					}
+				}""");
 		ComponentInfo button_1 = panel.getChildrenComponents().get(0);
 		ComponentInfo button_2 = panel.getChildrenComponents().get(1);
 		//
 		tree.startDrag(button_2).dragBefore(button_1);
 		tree.assertCommandNotNull();
 		tree.endDrag();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      JButton button_2 = new JButton();",
-				"      add(button_2, BorderLayout.SOUTH);",
-				"    }",
-				"    {",
-				"      JButton button_1 = new JButton();",
-				"      add(button_1, BorderLayout.NORTH);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JButton button_2 = new JButton();
+							add(button_2, BorderLayout.SOUTH);
+						}
+						{
+							JButton button_1 = new JButton();
+							add(button_1, BorderLayout.NORTH);
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_tree_ADD() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      JPanel inner = new JPanel();",
-						"      add(inner, BorderLayout.CENTER);",
-						"      {",
-						"        JButton button = new JButton();",
-						"        inner.add(button);",
-						"      }",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JPanel inner = new JPanel();
+							add(inner, BorderLayout.CENTER);
+							{
+								JButton button = new JButton();
+								inner.add(button);
+							}
+						}
+					}
+				}""");
 		ContainerInfo inner = (ContainerInfo) panel.getChildrenComponents().get(0);
 		ComponentInfo button = inner.getChildrenComponents().get(0);
 		//
 		tree.startDrag(button).dragBefore(inner);
 		tree.assertCommandNotNull();
 		tree.endDrag();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      JButton button = new JButton();",
-				"      add(button, BorderLayout.NORTH);",
-				"    }",
-				"    {",
-				"      JPanel inner = new JPanel();",
-				"      add(inner, BorderLayout.CENTER);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JButton button = new JButton();
+							add(button, BorderLayout.NORTH);
+						}
+						{
+							JPanel inner = new JPanel();
+							add(inner, BorderLayout.CENTER);
+						}
+					}
+				}""");
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/gef/GridLayoutPolicyTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/gef/GridLayoutPolicyTest.java
@@ -38,21 +38,19 @@ public class GridLayoutPolicyTest extends AbstractLayoutPolicyTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_setLayout() throws Exception {
-		String[] source =
-				new String[]{
-						"// filler filler filler",
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"  }",
-		"}"};
-		String[] source2 =
-				new String[]{
-						"// filler filler filler",
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new GridLayout(1, 0, 0, 0));",
-						"  }",
-		"}"};
+		String source = """
+				// filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+					}
+				}""";
+		String source2 = """
+				// filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new GridLayout(1, 0, 0, 0));
+					}
+				}""";
 		check_setLayout(source, "java.awt.GridLayout", source2, 10, 10);
 	}
 
@@ -63,28 +61,27 @@ public class GridLayoutPolicyTest extends AbstractLayoutPolicyTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_CREATE() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new GridLayout(0, 3));",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new GridLayout(0, 3));
+					}
+				}""");
 		//
 		loadCreationTool("javax.swing.JButton", "empty");
 		canvas.moveTo(panel, 10, 10);
 		canvas.click();
 		canvas.assertFeedbackFigures(0);
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new GridLayout(0, 3));",
-				"    {",
-				"      JButton button = new JButton();",
-				"      add(button);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new GridLayout(0, 3));
+						{
+							JButton button = new JButton();
+							add(button);
+						}
+					}
+				}""");
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -94,21 +91,20 @@ public class GridLayoutPolicyTest extends AbstractLayoutPolicyTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_MOVE() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new GridLayout(0, 3));",
-						"    {",
-						"      JButton button = new JButton('Button 1');",
-						"      add(button);",
-						"    }",
-						"    {",
-						"      JButton button = new JButton('Button 2');",
-						"      add(button);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new GridLayout(0, 3));
+						{
+							JButton button = new JButton("Button 1");
+							add(button);
+						}
+						{
+							JButton button = new JButton("Button 2");
+							add(button);
+						}
+					}
+				}""");
 		ComponentInfo button_1 = panel.getChildrenComponents().get(0);
 		ComponentInfo button_2 = panel.getChildrenComponents().get(1);
 		// move
@@ -116,20 +112,20 @@ public class GridLayoutPolicyTest extends AbstractLayoutPolicyTest {
 		canvas.dragTo(button_1, 10, 0);
 		canvas.endDrag();
 		canvas.assertNoFeedbackFigures();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new GridLayout(0, 3));",
-				"    {",
-				"      JButton button = new JButton('Button 2');",
-				"      add(button);",
-				"    }",
-				"    {",
-				"      JButton button = new JButton('Button 1');",
-				"      add(button);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new GridLayout(0, 3));
+						{
+							JButton button = new JButton("Button 2");
+							add(button);
+						}
+						{
+							JButton button = new JButton("Button 1");
+							add(button);
+						}
+					}
+				}""");
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -139,24 +135,23 @@ public class GridLayoutPolicyTest extends AbstractLayoutPolicyTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_ADD() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      JButton button = new JButton('Button');",
-						"      add(button, BorderLayout.NORTH);",
-						"    }",
-						"    {",
-						"      JPanel panel = new JPanel();",
-						"      panel.setLayout(new GridLayout(0, 3));",
-						"      panel.setBackground(Color.PINK);",
-						"      panel.setPreferredSize(new Dimension(0, 150));",
-						"      add(panel, BorderLayout.SOUTH);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JButton button = new JButton("Button");
+							add(button, BorderLayout.NORTH);
+						}
+						{
+							JPanel panel = new JPanel();
+							panel.setLayout(new GridLayout(0, 3));
+							panel.setBackground(Color.PINK);
+							panel.setPreferredSize(new Dimension(0, 150));
+							add(panel, BorderLayout.SOUTH);
+						}
+					}
+				}""");
 		ComponentInfo button = panel.getChildrenComponents().get(0);
 		ComponentInfo inner = panel.getChildrenComponents().get(1);
 		//
@@ -164,22 +159,22 @@ public class GridLayoutPolicyTest extends AbstractLayoutPolicyTest {
 		canvas.dragTo(inner, 10, 10);
 		canvas.endDrag();
 		canvas.assertNoFeedbackFigures();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      JPanel panel = new JPanel();",
-				"      panel.setLayout(new GridLayout(0, 3));",
-				"      panel.setBackground(Color.PINK);",
-				"      panel.setPreferredSize(new Dimension(0, 150));",
-				"      add(panel, BorderLayout.SOUTH);",
-				"      {",
-				"        JButton button = new JButton('Button');",
-				"        panel.add(button);",
-				"      }",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JPanel panel = new JPanel();
+							panel.setLayout(new GridLayout(0, 3));
+							panel.setBackground(Color.PINK);
+							panel.setPreferredSize(new Dimension(0, 150));
+							add(panel, BorderLayout.SOUTH);
+							{
+								JButton button = new JButton("Button");
+								panel.add(button);
+							}
+						}
+					}
+				}""");
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/group/GroupLayoutGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/group/GroupLayoutGefTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -36,61 +36,60 @@ public class GroupLayoutGefTest extends SwingGefTest {
 	@Test
 	public void test_reparent_while_child_created_after_layout() throws Exception {
 		prepareBox(50, 25);
-		ContainerInfo panel =
-				openContainer(
-						"import javax.swing.GroupLayout.Alignment;",
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(null);",
-						"    JPanel panel = new JPanel();",
-						"    panel.setBounds(50, 50, 200, 200);",
-						"    add(panel);",
-						"    GroupLayout groupLayout_1_1 = new GroupLayout(panel);",
-						"    groupLayout_1_1.setHorizontalGroup(",
-						"      groupLayout_1_1.createParallelGroup(Alignment.LEADING)",
-						"        .addGap(0, 200, Short.MAX_VALUE)",
-						"    );",
-						"    groupLayout_1_1.setVerticalGroup(",
-						"      groupLayout_1_1.createParallelGroup(Alignment.LEADING)",
-						"        .addGap(0, 200, Short.MAX_VALUE)",
-						"    );",
-						"    panel.setLayout(groupLayout_1_1);",
-						"    Box box_1 = new Box();",
-						"    box_1.setBounds(0, 0, 60, 30);",
-						"    add(box_1);",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				import javax.swing.GroupLayout.Alignment;
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(null);
+						JPanel panel = new JPanel();
+						panel.setBounds(50, 50, 200, 200);
+						add(panel);
+						GroupLayout groupLayout_1_1 = new GroupLayout(panel);
+						groupLayout_1_1.setHorizontalGroup(
+							groupLayout_1_1.createParallelGroup(Alignment.LEADING)
+								.addGap(0, 200, Short.MAX_VALUE)
+						);
+						groupLayout_1_1.setVerticalGroup(
+							groupLayout_1_1.createParallelGroup(Alignment.LEADING)
+								.addGap(0, 200, Short.MAX_VALUE)
+						);
+						panel.setLayout(groupLayout_1_1);
+						Box box_1 = new Box();
+						box_1.setBounds(0, 0, 60, 30);
+						add(box_1);
+					}
+				}""");
 		ContainerInfo panel1 = (ContainerInfo) panel.getChildrenComponents().get(0);
 		ComponentInfo box = panel.getChildrenComponents().get(1);
 		// do move
 		canvas.sideMode();
 		canvas.beginMove(box).target(panel1).in(40, 30).drag().endDrag();
-		assertEditor(
-				"import javax.swing.GroupLayout.Alignment;",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(null);",
-				"    JPanel panel = new JPanel();",
-				"    panel.setBounds(50, 50, 200, 200);",
-				"    add(panel);",
-				"    Box box_1 = new Box();",
-				"    GroupLayout groupLayout_1_1 = new GroupLayout(panel);",
-				"    groupLayout_1_1.setHorizontalGroup(",
-				"      groupLayout_1_1.createParallelGroup(Alignment.LEADING)",
-				"        .addGroup(groupLayout_1_1.createSequentialGroup()",
-				"          .addGap(40)",
-				"          .addComponent(box_1, GroupLayout.PREFERRED_SIZE, 60, GroupLayout.PREFERRED_SIZE)",
-				"          .addContainerGap(100, Short.MAX_VALUE))",
-				"    );",
-				"    groupLayout_1_1.setVerticalGroup(",
-				"      groupLayout_1_1.createParallelGroup(Alignment.LEADING)",
-				"        .addGroup(groupLayout_1_1.createSequentialGroup()",
-				"          .addGap(30)",
-				"          .addComponent(box_1, GroupLayout.PREFERRED_SIZE, 30, GroupLayout.PREFERRED_SIZE)",
-				"          .addContainerGap(140, Short.MAX_VALUE))",
-				"    );",
-				"    panel.setLayout(groupLayout_1_1);",
-				"  }",
-				"}");
+		assertEditor("""
+				import javax.swing.GroupLayout.Alignment;
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(null);
+						JPanel panel = new JPanel();
+						panel.setBounds(50, 50, 200, 200);
+						add(panel);
+						Box box_1 = new Box();
+						GroupLayout groupLayout_1_1 = new GroupLayout(panel);
+						groupLayout_1_1.setHorizontalGroup(
+							groupLayout_1_1.createParallelGroup(Alignment.LEADING)
+								.addGroup(groupLayout_1_1.createSequentialGroup()
+									.addGap(40)
+									.addComponent(box_1, GroupLayout.PREFERRED_SIZE, 60, GroupLayout.PREFERRED_SIZE)
+									.addContainerGap(100, Short.MAX_VALUE))
+						);
+						groupLayout_1_1.setVerticalGroup(
+							groupLayout_1_1.createParallelGroup(Alignment.LEADING)
+								.addGroup(groupLayout_1_1.createSequentialGroup()
+									.addGap(30)
+									.addComponent(box_1, GroupLayout.PREFERRED_SIZE, 30, GroupLayout.PREFERRED_SIZE)
+									.addContainerGap(140, Short.MAX_VALUE))
+						);
+						panel.setLayout(groupLayout_1_1);
+					}
+				}""");
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/model/CardLayoutGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/model/CardLayoutGefTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -40,96 +40,93 @@ public class CardLayoutGefTest extends AbstractLayoutPolicyTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_CREATE_onCanvas_empty() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new CardLayout());",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new CardLayout());
+					}
+				}""");
 		//
 		ComponentInfo newButton = loadCreationTool("javax.swing.JButton");
 		canvas.moveTo(panel, 100, 100).click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new CardLayout());",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, '" + CardLayoutTest.getAssociationName(newButton) + "');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new CardLayout());
+						{
+							JButton button = new JButton("New button");
+							add(button, "%s");
+						}
+					}
+				}""".formatted(CardLayoutTest.getAssociationName(newButton)));
 	}
 
 	@Test
 	public void test_CREATE_onCanvas_beforeExisting() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new CardLayout());",
-						"    {",
-						"      JButton button_1 = new JButton();",
-						"      add(button_1, '111');",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new CardLayout());
+						{
+							JButton button_1 = new JButton();
+							add(button_1, "111");
+						}
+					}
+				}""");
 		ComponentInfo button_1 = getJavaInfoByName("button_1");
 		// select "panel", so "button_1" will be transparent on borders
 		canvas.select(panel);
 		// create new JButton
 		ComponentInfo newButton = loadCreationTool("javax.swing.JButton");
 		canvas.moveTo(button_1, 2, 100).click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new CardLayout());",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, '" + CardLayoutTest.getAssociationName(newButton) + "');",
-				"    }",
-				"    {",
-				"      JButton button_1 = new JButton();",
-				"      add(button_1, '111');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new CardLayout());
+						{
+							JButton button = new JButton("New button");
+							add(button, "%s");
+						}
+						{
+							JButton button_1 = new JButton();
+							add(button_1, "111");
+						}
+					}
+				}""".formatted(CardLayoutTest.getAssociationName(newButton)));
 	}
 
 	@Test
 	public void test_CREATE_onCanvas_afterExisting() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new CardLayout());",
-						"    {",
-						"      JButton button_1 = new JButton();",
-						"      add(button_1, '111');",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new CardLayout());
+						{
+							JButton button_1 = new JButton();
+							add(button_1, "111");
+						}
+					}
+				}""");
 		ComponentInfo button_1 = getJavaInfoByName("button_1");
 		// select "panel", so "button_1" will be transparent on borders
 		canvas.select(panel);
 		// create new JButton
 		ComponentInfo newButton = loadCreationTool("javax.swing.JButton");
 		canvas.moveTo(button_1, -2, 100).click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new CardLayout());",
-				"    {",
-				"      JButton button_1 = new JButton();",
-				"      add(button_1, '111');",
-				"    }",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, '" + CardLayoutTest.getAssociationName(newButton) + "');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new CardLayout());
+						{
+							JButton button_1 = new JButton();
+							add(button_1, "111");
+						}
+						{
+							JButton button = new JButton("New button");
+							add(button, "%s");
+						}
+					}
+				}""".formatted(CardLayoutTest.getAssociationName(newButton)));
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -139,92 +136,91 @@ public class CardLayoutGefTest extends AbstractLayoutPolicyTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_CREATE_inTree_empty() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new CardLayout());",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new CardLayout());
+					}
+				}""");
 		//
 		ComponentInfo newButton = loadCreationTool("javax.swing.JButton");
 		tree.moveOn(panel);
 		tree.assertCommandNotNull();
 		tree.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new CardLayout());",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, '" + CardLayoutTest.getAssociationName(newButton) + "');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new CardLayout());
+						{
+							JButton button = new JButton("New button");
+							add(button, "%s");
+						}
+					}
+				}""".formatted(CardLayoutTest.getAssociationName(newButton)));
 	}
 
 	@Test
 	public void test_CREATE_inTree_beforeExisting() throws Exception {
-		openContainer(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new CardLayout());",
-				"    {",
-				"      JButton button_1 = new JButton();",
-				"      add(button_1, '111');",
-				"    }",
-				"  }",
-				"}");
+		openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new CardLayout());
+						{
+							JButton button_1 = new JButton();
+							add(button_1, "111");
+						}
+					}
+				}""");
 		ComponentInfo button_1 = getJavaInfoByName("button_1");
 		// create new JButton
 		ComponentInfo newButton = loadCreationTool("javax.swing.JButton");
 		tree.moveBefore(button_1).click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new CardLayout());",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, '" + CardLayoutTest.getAssociationName(newButton) + "');",
-				"    }",
-				"    {",
-				"      JButton button_1 = new JButton();",
-				"      add(button_1, '111');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new CardLayout());
+						{
+							JButton button = new JButton("New button");
+							add(button, "%s");
+						}
+						{
+							JButton button_1 = new JButton();
+							add(button_1, "111");
+						}
+					}
+				}""".formatted(CardLayoutTest.getAssociationName(newButton)));
 	}
 
 	@Test
 	public void test_CREATE_inTree_afterExisting() throws Exception {
-		openContainer(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new CardLayout());",
-				"    {",
-				"      JButton button_1 = new JButton();",
-				"      add(button_1, '111');",
-				"    }",
-				"  }",
-				"}");
+		openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new CardLayout());
+						{
+							JButton button_1 = new JButton();
+							add(button_1, "111");
+						}
+					}
+				}""");
 		ComponentInfo button_1 = getJavaInfoByName("button_1");
 		// create new JButton
 		ComponentInfo newButton = loadCreationTool("javax.swing.JButton");
 		tree.moveAfter(button_1).click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new CardLayout());",
-				"    {",
-				"      JButton button_1 = new JButton();",
-				"      add(button_1, '111');",
-				"    }",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button, '" + CardLayoutTest.getAssociationName(newButton) + "');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new CardLayout());
+						{
+							JButton button_1 = new JButton();
+							add(button_1, "111");
+						}
+						{
+							JButton button = new JButton("New button");
+							add(button, "%s");
+						}
+					}
+				}""".formatted(CardLayoutTest.getAssociationName(newButton)));
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -234,38 +230,38 @@ public class CardLayoutGefTest extends AbstractLayoutPolicyTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_MOVE_inTree() throws Exception {
-		openContainer(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new CardLayout());",
-				"    {",
-				"      JButton button_1 = new JButton();",
-				"      add(button_1, '111');",
-				"    }",
-				"    {",
-				"      JButton button_2 = new JButton();",
-				"      add(button_2, '222');",
-				"    }",
-				"  }",
-				"}");
+		openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new CardLayout());
+						{
+							JButton button_1 = new JButton();
+							add(button_1, "111");
+						}
+						{
+							JButton button_2 = new JButton();
+							add(button_2, "222");
+						}
+					}
+				}""");
 		ComponentInfo button_1 = getJavaInfoByName("button_1");
 		ComponentInfo button_2 = getJavaInfoByName("button_2");
 		//
 		tree.startDrag(button_2).dragBefore(button_1).endDrag();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new CardLayout());",
-				"    {",
-				"      JButton button_2 = new JButton();",
-				"      add(button_2, '222');",
-				"    }",
-				"    {",
-				"      JButton button_1 = new JButton();",
-				"      add(button_1, '111');",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new CardLayout());
+						{
+							JButton button_2 = new JButton();
+							add(button_2, "222");
+						}
+						{
+							JButton button_1 = new JButton();
+							add(button_1, "111");
+						}
+					}
+				}""");
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -275,24 +271,24 @@ public class CardLayoutGefTest extends AbstractLayoutPolicyTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_navigation_next() throws Exception {
-		openContainer(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new CardLayout());",
-				"    {",
-				"      JButton button_1 = new JButton('111');",
-				"      add(button_1, '111');",
-				"    }",
-				"    {",
-				"      JButton button_2 = new JButton('222');",
-				"      add(button_2, '222');",
-				"    }",
-				"    {",
-				"      JButton button_3 = new JButton('333');",
-				"      add(button_3, '333');",
-				"    }",
-				"  }",
-				"}");
+		openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new CardLayout());
+						{
+							JButton button_1 = new JButton("111");
+							add(button_1, "111");
+						}
+						{
+							JButton button_2 = new JButton("222");
+							add(button_2, "222");
+						}
+						{
+							JButton button_3 = new JButton("333");
+							add(button_3, "333");
+						}
+					}
+				}""");
 		ComponentInfo button_1 = getJavaInfoByName("button_1");
 		ComponentInfo button_2 = getJavaInfoByName("button_2");
 		ComponentInfo button_3 = getJavaInfoByName("button_3");
@@ -320,24 +316,24 @@ public class CardLayoutGefTest extends AbstractLayoutPolicyTest {
 
 	@Test
 	public void test_navigation_prev() throws Exception {
-		openContainer(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new CardLayout());",
-				"    {",
-				"      JButton button_1 = new JButton('111');",
-				"      add(button_1, '111');",
-				"    }",
-				"    {",
-				"      JButton button_2 = new JButton('222');",
-				"      add(button_2, '222');",
-				"    }",
-				"    {",
-				"      JButton button_3 = new JButton('333');",
-				"      add(button_3, '333');",
-				"    }",
-				"  }",
-				"}");
+		openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new CardLayout());
+						{
+							JButton button_1 = new JButton("111");
+							add(button_1, "111");
+						}
+						{
+							JButton button_2 = new JButton("222");
+							add(button_2, "222");
+						}
+						{
+							JButton button_3 = new JButton("333");
+							add(button_3, "333");
+						}
+					}
+				}""");
 		ComponentInfo button_1 = getJavaInfoByName("button_1");
 		ComponentInfo button_2 = getJavaInfoByName("button_2");
 		ComponentInfo button_3 = getJavaInfoByName("button_3");

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/model/FlowLayoutGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/model/FlowLayoutGefTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -45,28 +45,26 @@ public class FlowLayoutGefTest extends AbstractLayoutPolicyTest {
 	 */
 	@Test
 	public void test_setLayout() throws Exception {
-		String[] source =
-				new String[]{
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new BorderLayout());",
-						"    {",
-						"      final JButton button = new JButton('New button');",
-						"      add(button, BorderLayout.SOUTH);",
-						"    }",
-						"  }",
-		"}"};
-		String[] source2 =
-				new String[]{
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setLayout(new FlowLayout(FlowLayout.CENTER, 5, 5));",
-						"    {",
-						"      final JButton button = new JButton('New button');",
-						"      add(button);",
-						"    }",
-						"  }",
-		"}"};
+		String source = """
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							final JButton button = new JButton("New button");
+							add(button, BorderLayout.SOUTH);
+						}
+					}
+				}""";
+		String source2 = """
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new FlowLayout(FlowLayout.CENTER, 5, 5));
+						{
+							final JButton button = new JButton("New button");
+							add(button);
+						}
+					}
+				}""";
 		check_setLayout(source, "java.awt.FlowLayout", source2, 10, 10);
 	}
 
@@ -75,27 +73,25 @@ public class FlowLayoutGefTest extends AbstractLayoutPolicyTest {
 	 */
 	@Test
 	public void test_setLayout2() throws Exception {
-		String[] source =
-				new String[]{
-						"public class Test extends JFrame {",
-						"  public Test() {",
-						"    {",
-						"      final JButton button = new JButton('New button');",
-						"      getContentPane().add(button, BorderLayout.SOUTH);",
-						"    }",
-						"  }",
-		"}"};
-		String[] source2 =
-				new String[]{
-						"public class Test extends JFrame {",
-						"  public Test() {",
-						"    getContentPane().setLayout(new FlowLayout(FlowLayout.CENTER, 5, 5));",
-						"    {",
-						"      final JButton button = new JButton('New button');",
-						"      getContentPane().add(button);",
-						"    }",
-						"  }",
-		"}"};
+		String source = """
+				public class Test extends JFrame {
+					public Test() {
+						{
+							final JButton button = new JButton("New button");
+							getContentPane().add(button, BorderLayout.SOUTH);
+						}
+					}
+				}""";
+		String source2 = """
+				public class Test extends JFrame {
+					public Test() {
+						getContentPane().setLayout(new FlowLayout(FlowLayout.CENTER, 5, 5));
+						{
+							final JButton button = new JButton("New button");
+							getContentPane().add(button);
+						}
+					}
+				}""";
 		check_setLayout(source, "java.awt.FlowLayout", source2, 10, 50);
 	}
 
@@ -106,89 +102,86 @@ public class FlowLayoutGefTest extends AbstractLayoutPolicyTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_CREATE_onEmpty() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"// filler filler filler filler filler",
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+					}
+				}""");
 		//
 		loadCreationTool("javax.swing.JButton");
 		canvas.moveTo(panel, 10, 10);
 		canvas.click();
-		assertEditor(
-				"// filler filler filler filler filler",
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				// filler filler filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+						{
+							JButton button = new JButton("New button");
+							add(button);
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_beforeExisting() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    {",
-						"      JButton button = new JButton('Button');",
-						"      add(button);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						{
+							JButton button = new JButton("Button");
+							add(button);
+						}
+					}
+				}""");
 		//
 		loadCreationTool("javax.swing.JButton");
 		canvas.moveTo(panel, 10, 10);
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button);",
-				"    }",
-				"    {",
-				"      JButton button = new JButton('Button');",
-				"      add(button);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						{
+							JButton button = new JButton("New button");
+							add(button);
+						}
+						{
+							JButton button = new JButton("Button");
+							add(button);
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_afterExisting() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    {",
-						"      JButton button = new JButton('Button');",
-						"      add(button);",
-						"    }",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						{
+							JButton button = new JButton("Button");
+							add(button);
+						}
+					}
+				}""");
 		//
 		loadCreationTool("javax.swing.JButton");
 		canvas.moveTo(panel, -10, 10);
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    {",
-				"      JButton button = new JButton('Button');",
-				"      add(button);",
-				"    }",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						{
+							JButton button = new JButton("Button");
+							add(button);
+						}
+						{
+							JButton button = new JButton("New button");
+							add(button);
+						}
+					}
+				}""");
 	}
 
 	/**
@@ -198,39 +191,38 @@ public class FlowLayoutGefTest extends AbstractLayoutPolicyTest {
 	public void test_CREATE_hasExposed() throws Exception {
 		setFileContentSrc(
 				"test/MyPanel.java",
-				getTestSource(
-						"public class MyPanel extends JPanel {",
-						"  protected final JButton m_button;",
-						"  public MyPanel() {",
-						"    {",
-						"      m_button = new JButton('Button');",
-						"      add(m_button);",
-						"    }",
-						"  }",
-						"}"));
+				getTestSource("""
+						public class MyPanel extends JPanel {
+							protected final JButton m_button;
+							public MyPanel() {
+								{
+									m_button = new JButton("Button");
+									add(m_button);
+								}
+							  }
+						}"""));
 		waitForAutoBuild();
 		// parse
-		ContainerInfo panel =
-				openContainer(
-						"// filler filler filler",
-						"public class Test extends MyPanel {",
-						"  public Test() {",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				// filler filler filler
+				public class Test extends MyPanel {
+					public Test() {
+					}
+				}""");
 		//
 		loadCreationTool("javax.swing.JButton");
 		canvas.moveTo(panel, 10, 10);
 		canvas.click();
-		assertEditor(
-				"// filler filler filler",
-				"public class Test extends MyPanel {",
-				"  public Test() {",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				// filler filler filler
+				public class Test extends MyPanel {
+					public Test() {
+						{
+							JButton button = new JButton("New button");
+							add(button);
+						}
+					}
+				}""");
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -240,134 +232,133 @@ public class FlowLayoutGefTest extends AbstractLayoutPolicyTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_CREATE_RTL_onEmpty() throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
+					}
+				}""");
 		//
 		loadCreationTool("javax.swing.JButton");
 		canvas.moveTo(panel, 10, 10);
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
+						{
+							JButton button = new JButton("New button");
+							add(button);
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_RTL_last() throws Exception {
-		openContainer(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);",
-				"    {",
-				"      JButton existing = new JButton('Button');",
-				"      add(existing);",
-				"    }",
-				"  }",
-				"}");
+		openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
+						{
+							JButton existing = new JButton("Button");
+							add(existing);
+						}
+					}
+				}""");
 		ComponentInfo existing = getJavaInfoByName("existing");
 		//
 		loadCreationTool("javax.swing.JButton");
 		canvas.target(existing).outX(-5).inY(5).move();
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);",
-				"    {",
-				"      JButton existing = new JButton('Button');",
-				"      add(existing);",
-				"    }",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
+						{
+							JButton existing = new JButton("Button");
+							add(existing);
+						}
+						{
+							JButton button = new JButton("New button");
+							add(button);
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_RTL_beforeExisting() throws Exception {
-		openContainer(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);",
-				"    {",
-				"      JButton existing = new JButton('Button');",
-				"      add(existing);",
-				"    }",
-				"  }",
-				"}");
+		openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
+						{
+							JButton existing = new JButton("Button");
+							add(existing);
+						}
+					}
+				}""");
 		ComponentInfo existing = getJavaInfoByName("existing");
 		//
 		loadCreationTool("javax.swing.JButton");
 		canvas.target(existing).in(-5, 5).move();
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button);",
-				"    }",
-				"    {",
-				"      JButton existing = new JButton('Button');",
-				"      add(existing);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
+						{
+							JButton button = new JButton("New button");
+							add(button);
+						}
+						{
+							JButton existing = new JButton("Button");
+							add(existing);
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_RTL_betweenExisting() throws Exception {
-		openContainer(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);",
-				"    {",
-				"      JButton buttonA = new JButton('ButtonA');",
-				"      add(buttonA);",
-				"    }",
-				"    {",
-				"      JButton buttonB = new JButton('ButtonB');",
-				"      add(buttonB);",
-				"    }",
-				"  }",
-				"}");
+		openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
+						{
+							JButton buttonA = new JButton("ButtonA");
+							add(buttonA);
+						}
+						{
+							JButton buttonB = new JButton("ButtonB");
+							add(buttonB);
+						}
+					}
+				}""");
 		ComponentInfo button = getJavaInfoByName("buttonA");
 		//
 		loadCreationTool("javax.swing.JButton");
 		canvas.target(button).outX(-5).inY(5).move();
 		canvas.click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);",
-				"    {",
-				"      JButton buttonA = new JButton('ButtonA');",
-				"      add(buttonA);",
-				"    }",
-				"    {",
-				"      JButton button = new JButton('New button');",
-				"      add(button);",
-				"    }",
-				"    {",
-				"      JButton buttonB = new JButton('ButtonB');",
-				"      add(buttonB);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
+						{
+							JButton buttonA = new JButton("ButtonA");
+							add(buttonA);
+						}
+						{
+							JButton button = new JButton("New button");
+							add(button);
+						}
+						{
+							JButton buttonB = new JButton("ButtonB");
+							add(buttonB);
+						}
+					}
+				}""");
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -380,20 +371,19 @@ public class FlowLayoutGefTest extends AbstractLayoutPolicyTest {
 	 */
 	@Test
 	public void test_MOVE_twoComponents() throws Exception {
-		String[] lines =
-				new String[]{
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    {",
-						"      JButton buttonA = new JButton('Button A');",
-						"      add(buttonA);",
-						"    }",
-						"    {",
-						"      JButton buttonB = new JButton('Button B');",
-						"      add(buttonB);",
-						"    }",
-						"  }",
-		"}"};
+		String lines = """
+				public class Test extends JPanel {
+					public Test() {
+						{
+							JButton buttonA = new JButton("Button A");
+							add(buttonA);
+						}
+						{
+							JButton buttonB = new JButton("Button B");
+							add(buttonB);
+						}
+					}
+				}""";
 		openContainer(lines);
 		ComponentInfo buttonA = getJavaInfoByName("buttonA");
 		ComponentInfo buttonB = getJavaInfoByName("buttonB");
@@ -413,87 +403,83 @@ public class FlowLayoutGefTest extends AbstractLayoutPolicyTest {
 
 	@Test
 	public void test_MOVE_localVariable() throws Exception {
-		String[] source =
-				new String[]{
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    {",
-						"      JButton button = new JButton('Button 1');",
-						"      add(button);",
-						"    }",
-						"    {",
-						"      JButton button = new JButton('Button 2');",
-						"      add(button);",
-						"    }",
-						"  }",
-		"}"};
-		String[] source2 =
-				new String[]{
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    {",
-						"      JButton button = new JButton('Button 2');",
-						"      add(button);",
-						"    }",
-						"    {",
-						"      JButton button = new JButton('Button 1');",
-						"      add(button);",
-						"    }",
-						"  }",
-		"}"};
+		String source = """
+				public class Test extends JPanel {
+					public Test() {
+						{
+							JButton button = new JButton("Button 1");
+							add(button);
+						}
+						{
+							JButton button = new JButton("Button 2");
+							add(button);
+						}
+					}
+				}""";
+		String source2 = """
+				public class Test extends JPanel {
+					public Test() {
+						{
+							JButton button = new JButton("Button 2");
+							add(button);
+						}
+						{
+							JButton button = new JButton("Button 1");
+							add(button);
+						}
+					}
+				}""";
 		check_MOVE(source, source2);
 	}
 
 	@Test
 	public void test_MOVE_lazy() throws Exception {
-		String[] source =
-				new String[]{
-						"public class Test extends JPanel {",
-						"  private JButton button_1;",
-						"  private JButton button_2;",
-						"  public Test() {",
-						"    add(getButton_1());",
-						"    add(getButton_2());",
-						"  }",
-						"  private JButton getButton_1() {",
-						"    if (button_1 == null) {",
-						"      button_1 = new JButton('Button 1');",
-						"    }",
-						"    return button_1;",
-						"  }",
-						"  private JButton getButton_2() {",
-						"    if (button_2 == null) {",
-						"      button_2 = new JButton('button 2');",
-						"    }",
-						"    return button_2;",
-						"  }",
-		"}"};
-		String[] source2 =
-				new String[]{
-						"public class Test extends JPanel {",
-						"  private JButton button_1;",
-						"  private JButton button_2;",
-						"  public Test() {",
-						"    add(getButton_2());",
-						"    add(getButton_1());",
-						"  }",
-						"  private JButton getButton_1() {",
-						"    if (button_1 == null) {",
-						"      button_1 = new JButton('Button 1');",
-						"    }",
-						"    return button_1;",
-						"  }",
-						"  private JButton getButton_2() {",
-						"    if (button_2 == null) {",
-						"      button_2 = new JButton('button 2');",
-						"    }",
-						"    return button_2;",
-						"  }",
-		"}"};
+		String source = """
+				public class Test extends JPanel {
+					private JButton button_1;
+					private JButton button_2;
+					public Test() {
+						add(getButton_1());
+						add(getButton_2());
+					}
+					private JButton getButton_1() {
+						if (button_1 == null) {
+							button_1 = new JButton("Button 1");
+						}
+						return button_1;
+					}
+					private JButton getButton_2() {
+						if (button_2 == null) {
+							button_2 = new JButton("button 2");
+						}
+						return button_2;
+					}
+				}""";
+		String source2 = """
+				public class Test extends JPanel {
+					private JButton button_1;
+					private JButton button_2;
+					public Test() {
+						add(getButton_2());
+						add(getButton_1());
+					}
+					private JButton getButton_1() {
+						if (button_1 == null) {
+							button_1 = new JButton("Button 1");
+						}
+						return button_1;
+					}
+					private JButton getButton_2() {
+						if (button_2 == null) {
+							button_2 = new JButton("button 2");
+						}
+						return button_2;
+					}
+				}""";
 		check_MOVE(source, source2);
 	}
 
-	private void check_MOVE(String[] source, String[] source2) throws Exception {
+	private void check_MOVE(String source, String source2) throws Exception {
 		ContainerInfo panel = openContainer(source);
 		ComponentInfo button_1 = panel.getChildrenComponents().get(0);
 		ComponentInfo button_2 = panel.getChildrenComponents().get(1);
@@ -530,22 +516,22 @@ public class FlowLayoutGefTest extends AbstractLayoutPolicyTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_ADD() throws Exception {
-		openContainer(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      JButton button = new JButton('Button');",
-				"      add(button, BorderLayout.NORTH);",
-				"    }",
-				"    {",
-				"      JPanel panel = new JPanel();",
-				"      panel.setBackground(Color.PINK);",
-				"      panel.setPreferredSize(new Dimension(0, 150));",
-				"      add(panel, BorderLayout.SOUTH);",
-				"    }",
-				"  }",
-				"}");
+		openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JButton button = new JButton("Button");
+							add(button, BorderLayout.NORTH);
+						}
+						{
+							JPanel panel = new JPanel();
+							panel.setBackground(Color.PINK);
+							panel.setPreferredSize(new Dimension(0, 150));
+							add(panel, BorderLayout.SOUTH);
+						}
+					}
+				}""");
 		ComponentInfo button = getJavaInfoByName("button");
 		ComponentInfo inner = getJavaInfoByName("panel");
 		//
@@ -553,47 +539,46 @@ public class FlowLayoutGefTest extends AbstractLayoutPolicyTest {
 		canvas.dragTo(inner, 10, 10);
 		canvas.endDrag();
 		canvas.assertFeedbackFigures(0);
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setLayout(new BorderLayout());",
-				"    {",
-				"      JPanel panel = new JPanel();",
-				"      panel.setBackground(Color.PINK);",
-				"      panel.setPreferredSize(new Dimension(0, 150));",
-				"      add(panel, BorderLayout.SOUTH);",
-				"      {",
-				"        JButton button = new JButton('Button');",
-				"        panel.add(button);",
-				"      }",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JPanel panel = new JPanel();
+							panel.setBackground(Color.PINK);
+							panel.setPreferredSize(new Dimension(0, 150));
+							add(panel, BorderLayout.SOUTH);
+							{
+								JButton button = new JButton("Button");
+								panel.add(button);
+							}
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_ADD_twoComponents() throws Exception {
-		String[] lines =
-			{
-					"public class Test extends JPanel {",
-					"  public Test() {",
-					"    setLayout(new BorderLayout());",
-					"    {",
-					"      JButton buttonA = new JButton('ButtonA');",
-					"      add(buttonA, BorderLayout.NORTH);",
-					"    }",
-					"    {",
-					"      JButton buttonB = new JButton('ButtonB');",
-					"      add(buttonB, BorderLayout.SOUTH);",
-					"    }",
-					"    {",
-					"      JPanel panel = new JPanel();",
-					"      panel.setBackground(Color.PINK);",
-					"      panel.setPreferredSize(new Dimension(0, 150));",
-					"      add(panel, BorderLayout.CENTER);",
-					"    }",
-					"  }",
-			"}"};
+		String lines = """
+				public class Test extends JPanel {
+					public Test() {
+						setLayout(new BorderLayout());
+						{
+							JButton buttonA = new JButton("ButtonA");
+							add(buttonA, BorderLayout.NORTH);
+						}
+						{
+							JButton buttonB = new JButton("ButtonB");
+							add(buttonB, BorderLayout.SOUTH);
+						}
+						{
+							JPanel panel = new JPanel();
+							panel.setBackground(Color.PINK);
+							panel.setPreferredSize(new Dimension(0, 150));
+							add(panel, BorderLayout.CENTER);
+						}
+					}
+				}""";
 		openContainer(lines);
 		ComponentInfo buttonA = getJavaInfoByName("buttonA");
 		ComponentInfo buttonB = getJavaInfoByName("buttonB");

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/spring/SpringLayoutGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/spring/SpringLayoutGefTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,6 @@
 package org.eclipse.wb.tests.designer.swing.model.layout.spring;
 
 import org.eclipse.wb.internal.core.model.layout.absolute.IPreferenceConstants;
-import org.eclipse.wb.internal.core.utils.jdt.core.CodeUtils;
 import org.eclipse.wb.internal.swing.Activator;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
@@ -22,6 +21,7 @@ import org.eclipse.wb.tests.designer.swing.SwingGefTest;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.jface.preference.IPreferenceStore;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -101,190 +101,190 @@ public class SpringLayoutGefTest extends SwingGefTest {
 	public void test_CREATE_absoluteNoSnap_topLeft() throws Exception {
 		prepare_CREATE_emptyPanel();
 		canvas.target(panel).inX(30).inY(50).move().click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    SpringLayout layout = new SpringLayout();",
-				"    setLayout(layout);",
-				"    {",
-				"      Box box = new Box();",
-				"      layout.putConstraint(SpringLayout.NORTH, box, 50, SpringLayout.NORTH, this);",
-				"      layout.putConstraint(SpringLayout.WEST, box, 30, SpringLayout.WEST, this);",
-				"      add(box);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						SpringLayout layout = new SpringLayout();
+						setLayout(layout);
+						{
+							Box box = new Box();
+							layout.putConstraint(SpringLayout.NORTH, box, 50, SpringLayout.NORTH, this);
+							layout.putConstraint(SpringLayout.WEST, box, 30, SpringLayout.WEST, this);
+							add(box);
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_absoluteNoSnap_bottomRight() throws Exception {
 		prepare_CREATE_emptyPanel();
 		canvas.target(panel).inX(250).inY(200).move().click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    SpringLayout layout = new SpringLayout();",
-				"    setLayout(layout);",
-				"    {",
-				"      Box box = new Box();",
-				"      layout.putConstraint(SpringLayout.SOUTH, box, -50, SpringLayout.SOUTH, this);",
-				"      layout.putConstraint(SpringLayout.EAST, box, -100, SpringLayout.EAST, this);",
-				"      add(box);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						SpringLayout layout = new SpringLayout();
+						setLayout(layout);
+						{
+							Box box = new Box();
+							layout.putConstraint(SpringLayout.SOUTH, box, -50, SpringLayout.SOUTH, this);
+							layout.putConstraint(SpringLayout.EAST, box, -100, SpringLayout.EAST, this);
+							add(box);
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_absoluteSnap_leftOffset() throws Exception {
 		prepare_CREATE_emptyPanel();
 		canvas.target(panel).inX(2).inY(50).move().click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    SpringLayout layout = new SpringLayout();",
-				"    setLayout(layout);",
-				"    {",
-				"      Box box = new Box();",
-				"      layout.putConstraint(SpringLayout.NORTH, box, 50, SpringLayout.NORTH, this);",
-				"      layout.putConstraint(SpringLayout.WEST, box, 10, SpringLayout.WEST, this);",
-				"      add(box);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						SpringLayout layout = new SpringLayout();
+						setLayout(layout);
+						{
+							Box box = new Box();
+							layout.putConstraint(SpringLayout.NORTH, box, 50, SpringLayout.NORTH, this);
+							layout.putConstraint(SpringLayout.WEST, box, 10, SpringLayout.WEST, this);
+							add(box);
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_absoluteSnap_leftZero() throws Exception {
 		prepare_CREATE_emptyPanel();
 		canvas.target(panel).outX(-2).inY(50).move().click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    SpringLayout layout = new SpringLayout();",
-				"    setLayout(layout);",
-				"    {",
-				"      Box box = new Box();",
-				"      layout.putConstraint(SpringLayout.NORTH, box, 50, SpringLayout.NORTH, this);",
-				"      layout.putConstraint(SpringLayout.WEST, box, 0, SpringLayout.WEST, this);",
-				"      add(box);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						SpringLayout layout = new SpringLayout();
+						setLayout(layout);
+						{
+							Box box = new Box();
+							layout.putConstraint(SpringLayout.NORTH, box, 50, SpringLayout.NORTH, this);
+							layout.putConstraint(SpringLayout.WEST, box, 0, SpringLayout.WEST, this);
+							add(box);
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_absoluteSnap_rightOffset() throws Exception {
 		prepare_CREATE_emptyPanel();
 		canvas.target(panel).rightSide().inX(-2).inY(50).move().click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    SpringLayout layout = new SpringLayout();",
-				"    setLayout(layout);",
-				"    {",
-				"      Box box = new Box();",
-				"      layout.putConstraint(SpringLayout.NORTH, box, 50, SpringLayout.NORTH, this);",
-				"      layout.putConstraint(SpringLayout.EAST, box, -10, SpringLayout.EAST, this);",
-				"      add(box);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						SpringLayout layout = new SpringLayout();
+						setLayout(layout);
+						{
+							Box box = new Box();
+							layout.putConstraint(SpringLayout.NORTH, box, 50, SpringLayout.NORTH, this);
+							layout.putConstraint(SpringLayout.EAST, box, -10, SpringLayout.EAST, this);
+							add(box);
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_absoluteSnap_rightZero() throws Exception {
 		prepare_CREATE_emptyPanel();
 		canvas.target(panel).rightSide().outX(2).inY(50).move().click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    SpringLayout layout = new SpringLayout();",
-				"    setLayout(layout);",
-				"    {",
-				"      Box box = new Box();",
-				"      layout.putConstraint(SpringLayout.NORTH, box, 50, SpringLayout.NORTH, this);",
-				"      layout.putConstraint(SpringLayout.EAST, box, 0, SpringLayout.EAST, this);",
-				"      add(box);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						SpringLayout layout = new SpringLayout();
+						setLayout(layout);
+						{
+							Box box = new Box();
+							layout.putConstraint(SpringLayout.NORTH, box, 50, SpringLayout.NORTH, this);
+							layout.putConstraint(SpringLayout.EAST, box, 0, SpringLayout.EAST, this);
+							add(box);
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_absoluteSnap_topOffset() throws Exception {
 		prepare_CREATE_emptyPanel();
 		canvas.target(panel).inX(30).inY(2).move().click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    SpringLayout layout = new SpringLayout();",
-				"    setLayout(layout);",
-				"    {",
-				"      Box box = new Box();",
-				"      layout.putConstraint(SpringLayout.NORTH, box, 10, SpringLayout.NORTH, this);",
-				"      layout.putConstraint(SpringLayout.WEST, box, 30, SpringLayout.WEST, this);",
-				"      add(box);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						SpringLayout layout = new SpringLayout();
+						setLayout(layout);
+						{
+							Box box = new Box();
+							layout.putConstraint(SpringLayout.NORTH, box, 10, SpringLayout.NORTH, this);
+							layout.putConstraint(SpringLayout.WEST, box, 30, SpringLayout.WEST, this);
+							add(box);
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_absoluteSnap_topZero() throws Exception {
 		prepare_CREATE_emptyPanel();
 		canvas.target(panel).inX(30).outY(-2).move().click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    SpringLayout layout = new SpringLayout();",
-				"    setLayout(layout);",
-				"    {",
-				"      Box box = new Box();",
-				"      layout.putConstraint(SpringLayout.NORTH, box, 0, SpringLayout.NORTH, this);",
-				"      layout.putConstraint(SpringLayout.WEST, box, 30, SpringLayout.WEST, this);",
-				"      add(box);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						SpringLayout layout = new SpringLayout();
+						setLayout(layout);
+						{
+							Box box = new Box();
+							layout.putConstraint(SpringLayout.NORTH, box, 0, SpringLayout.NORTH, this);
+							layout.putConstraint(SpringLayout.WEST, box, 30, SpringLayout.WEST, this);
+							add(box);
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_absoluteSnap_bottomOffset() throws Exception {
 		prepare_CREATE_emptyPanel();
 		canvas.target(panel).inX(30).bottomSide().inY(-2).move().click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    SpringLayout layout = new SpringLayout();",
-				"    setLayout(layout);",
-				"    {",
-				"      Box box = new Box();",
-				"      layout.putConstraint(SpringLayout.WEST, box, 30, SpringLayout.WEST, this);",
-				"      layout.putConstraint(SpringLayout.SOUTH, box, -10, SpringLayout.SOUTH, this);",
-				"      add(box);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						SpringLayout layout = new SpringLayout();
+						setLayout(layout);
+						{
+							Box box = new Box();
+							layout.putConstraint(SpringLayout.WEST, box, 30, SpringLayout.WEST, this);
+							layout.putConstraint(SpringLayout.SOUTH, box, -10, SpringLayout.SOUTH, this);
+							add(box);
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_CREATE_absoluteSnap_bottomZero() throws Exception {
 		prepare_CREATE_emptyPanel();
 		canvas.target(panel).inX(30).bottomSide().outY(2).move().click();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    SpringLayout layout = new SpringLayout();",
-				"    setLayout(layout);",
-				"    {",
-				"      Box box = new Box();",
-				"      layout.putConstraint(SpringLayout.WEST, box, 30, SpringLayout.WEST, this);",
-				"      layout.putConstraint(SpringLayout.SOUTH, box, 0, SpringLayout.SOUTH, this);",
-				"      add(box);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						SpringLayout layout = new SpringLayout();
+						setLayout(layout);
+						{
+							Box box = new Box();
+							layout.putConstraint(SpringLayout.WEST, box, 30, SpringLayout.WEST, this);
+							layout.putConstraint(SpringLayout.SOUTH, box, 0, SpringLayout.SOUTH, this);
+							add(box);
+						}
+					}
+				}""");
 	}
 
 	@Test
@@ -292,37 +292,37 @@ public class SpringLayoutGefTest extends SwingGefTest {
 		prepare_CREATE_emptyPanel();
 		canvas.target(panel).inX(30).inY(50).move();
 		canvas.beginDrag().dragOn(100, 50).endDrag();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    SpringLayout layout = new SpringLayout();",
-				"    setLayout(layout);",
-				"    {",
-				"      Box box = new Box();",
-				"      layout.putConstraint(SpringLayout.NORTH, box, 50, SpringLayout.NORTH, this);",
-				"      layout.putConstraint(SpringLayout.WEST, box, 30, SpringLayout.WEST, this);",
-				"      layout.putConstraint(SpringLayout.SOUTH, box, 125, SpringLayout.NORTH, this);",
-				"      layout.putConstraint(SpringLayout.EAST, box, 180, SpringLayout.WEST, this);",
-				"      add(box);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						SpringLayout layout = new SpringLayout();
+						setLayout(layout);
+						{
+							Box box = new Box();
+							layout.putConstraint(SpringLayout.NORTH, box, 50, SpringLayout.NORTH, this);
+							layout.putConstraint(SpringLayout.WEST, box, 30, SpringLayout.WEST, this);
+							layout.putConstraint(SpringLayout.SOUTH, box, 125, SpringLayout.NORTH, this);
+							layout.putConstraint(SpringLayout.EAST, box, 180, SpringLayout.WEST, this);
+							add(box);
+						}
+					}
+				}""");
 	}
 
 	private void prepare_CREATE_emptyPanel() throws Exception {
 		prepareBox();
-		parse_forCREATE(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    SpringLayout layout = new SpringLayout();",
-				"    setLayout(layout);",
-				"  }",
-				"}");
+		parse_forCREATE("""
+				public class Test extends JPanel {
+					public Test() {
+						SpringLayout layout = new SpringLayout();
+						setLayout(layout);
+					}
+				}""");
 		// begin CREATE
 		loadCreationBox();
 	}
 
-	private void parse_forCREATE(String... lines) throws Exception {
+	private void parse_forCREATE(String lines) throws Exception {
 		panel = openContainer(lines);
 		// configure for CREATE
 		canvas.create(100, 50).sideMode();
@@ -339,8 +339,8 @@ public class SpringLayoutGefTest extends SwingGefTest {
 		canvas.mouseMode().target(panel).inX(-1).inY(-1).move();
 		canvas.sideMode().target(anchor).outX(2).inY(2).move().click();
 		assert_CREATE_singlePanel(
-				"      layout.putConstraint(SpringLayout.NORTH, box, 0, SpringLayout.NORTH, anchor);",
-				"      layout.putConstraint(SpringLayout.WEST, box, 5, SpringLayout.EAST, anchor);");
+				"			layout.putConstraint(SpringLayout.NORTH, box, 0, SpringLayout.NORTH, anchor);",
+				"			layout.putConstraint(SpringLayout.WEST, box, 5, SpringLayout.EAST, anchor);");
 	}
 
 	@Test
@@ -349,8 +349,8 @@ public class SpringLayoutGefTest extends SwingGefTest {
 		canvas.mouseMode().target(panel).inX(-1).inY(-1).move();
 		canvas.sideMode().target(anchor).outX(-2).outY(2).move().click();
 		assert_CREATE_singlePanel(
-				"      layout.putConstraint(SpringLayout.NORTH, box, 5, SpringLayout.SOUTH, anchor);",
-				"      layout.putConstraint(SpringLayout.WEST, box, 0, SpringLayout.WEST, anchor);");
+				"			layout.putConstraint(SpringLayout.NORTH, box, 5, SpringLayout.SOUTH, anchor);",
+				"			layout.putConstraint(SpringLayout.WEST, box, 0, SpringLayout.WEST, anchor);");
 	}
 
 	@Test
@@ -359,8 +359,8 @@ public class SpringLayoutGefTest extends SwingGefTest {
 		canvas.mouseMode().target(panel).inX(-1).inY(-1).move();
 		canvas.sideMode().target(anchor).inX(10).outY(2).move().click();
 		assert_CREATE_singlePanel(
-				"      layout.putConstraint(SpringLayout.NORTH, box, 5, SpringLayout.SOUTH, anchor);",
-				"      layout.putConstraint(SpringLayout.WEST, box, 10, SpringLayout.WEST, anchor);");
+				"			layout.putConstraint(SpringLayout.NORTH, box, 5, SpringLayout.SOUTH, anchor);",
+				"			layout.putConstraint(SpringLayout.WEST, box, 10, SpringLayout.WEST, anchor);");
 	}
 
 	@Test
@@ -373,8 +373,8 @@ public class SpringLayoutGefTest extends SwingGefTest {
 		// finish
 		canvas.click();
 		assert_CREATE_singlePanel(
-				"      layout.putConstraint(SpringLayout.NORTH, box, 5, SpringLayout.SOUTH, anchor);",
-				"      layout.putConstraint(SpringLayout.WEST, box, 10, SpringLayout.WEST, anchor);");
+				"			layout.putConstraint(SpringLayout.NORTH, box, 5, SpringLayout.SOUTH, anchor);",
+				"			layout.putConstraint(SpringLayout.WEST, box, 10, SpringLayout.WEST, anchor);");
 	}
 
 	@Test
@@ -383,8 +383,8 @@ public class SpringLayoutGefTest extends SwingGefTest {
 		canvas.mouseMode().target(panel).inX(1).inY(-1).move();
 		canvas.sideMode().target(anchor).rightSide().outX(-2).inY(2).move().click();
 		assert_CREATE_singlePanel(
-				"      layout.putConstraint(SpringLayout.NORTH, box, 0, SpringLayout.NORTH, anchor);",
-				"      layout.putConstraint(SpringLayout.EAST, box, -5, SpringLayout.WEST, anchor);");
+				"			layout.putConstraint(SpringLayout.NORTH, box, 0, SpringLayout.NORTH, anchor);",
+				"			layout.putConstraint(SpringLayout.EAST, box, -5, SpringLayout.WEST, anchor);");
 	}
 
 	@Test
@@ -393,8 +393,8 @@ public class SpringLayoutGefTest extends SwingGefTest {
 		canvas.mouseMode().target(panel).inX(-1).inY(1).move();
 		canvas.sideMode().target(anchor).outX(2).bottomSide().inY(-2).move().click();
 		assert_CREATE_singlePanel(
-				"      layout.putConstraint(SpringLayout.WEST, box, 5, SpringLayout.EAST, anchor);",
-				"      layout.putConstraint(SpringLayout.SOUTH, box, 0, SpringLayout.SOUTH, anchor);");
+				"			layout.putConstraint(SpringLayout.WEST, box, 5, SpringLayout.EAST, anchor);",
+				"			layout.putConstraint(SpringLayout.SOUTH, box, 0, SpringLayout.SOUTH, anchor);");
 	}
 
 	@Test
@@ -403,8 +403,8 @@ public class SpringLayoutGefTest extends SwingGefTest {
 		canvas.mouseMode().target(panel).inX(-1).inY(1).move();
 		canvas.sideMode().target(anchor).inX(2).bottomSide().outY(-2).move().click();
 		assert_CREATE_singlePanel(
-				"      layout.putConstraint(SpringLayout.WEST, box, 0, SpringLayout.WEST, anchor);",
-				"      layout.putConstraint(SpringLayout.SOUTH, box, -5, SpringLayout.NORTH, anchor);");
+				"			layout.putConstraint(SpringLayout.WEST, box, 0, SpringLayout.WEST, anchor);",
+				"			layout.putConstraint(SpringLayout.SOUTH, box, -5, SpringLayout.NORTH, anchor);");
 	}
 
 	@Test
@@ -413,8 +413,8 @@ public class SpringLayoutGefTest extends SwingGefTest {
 		canvas.mouseMode().target(panel).inX(1).inY(1).move();
 		canvas.sideMode().target(anchor).rightSide().outX(-2).bottomSide().inY(-2).move().click();
 		assert_CREATE_singlePanel(
-				"      layout.putConstraint(SpringLayout.SOUTH, box, 0, SpringLayout.SOUTH, anchor);",
-				"      layout.putConstraint(SpringLayout.EAST, box, -5, SpringLayout.WEST, anchor);");
+				"			layout.putConstraint(SpringLayout.SOUTH, box, 0, SpringLayout.SOUTH, anchor);",
+				"			layout.putConstraint(SpringLayout.EAST, box, -5, SpringLayout.WEST, anchor);");
 	}
 
 	@Test
@@ -423,45 +423,48 @@ public class SpringLayoutGefTest extends SwingGefTest {
 		canvas.target(panel).inX(10).inY(10).move();
 		canvas.target(anchor).rightSide().inX(-2).bottomSide().outY(-2).move().click();
 		assert_CREATE_singlePanel(
-				"      layout.putConstraint(SpringLayout.SOUTH, box, -5, SpringLayout.NORTH, anchor);",
-				"      layout.putConstraint(SpringLayout.EAST, box, 0, SpringLayout.EAST, anchor);");
+				"			layout.putConstraint(SpringLayout.SOUTH, box, -5, SpringLayout.NORTH, anchor);",
+				"			layout.putConstraint(SpringLayout.EAST, box, 0, SpringLayout.EAST, anchor);");
 	}
 
 	private void prepare_CREATE_singlePanel() throws Exception {
 		prepareBox();
 		// open editor
-		parse_forCREATE(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    SpringLayout layout = new SpringLayout();",
-				"    setLayout(layout);",
-				"    //",
-				"    Box anchor = new Box();",
-				"    layout.putConstraint(SpringLayout.NORTH, anchor, 120, SpringLayout.NORTH, this);",
-				"    layout.putConstraint(SpringLayout.WEST, anchor, 170, SpringLayout.WEST, this);",
-				"    add(anchor);",
-				"  }",
-				"}");
+		parse_forCREATE("""
+				public class Test extends JPanel {
+					public Test() {
+						SpringLayout layout = new SpringLayout();
+						setLayout(layout);
+						//
+						Box anchor = new Box();
+						layout.putConstraint(SpringLayout.NORTH, anchor, 120, SpringLayout.NORTH, this);
+						layout.putConstraint(SpringLayout.WEST, anchor, 170, SpringLayout.WEST, this);
+						add(anchor);
+					}
+				}""");
 		anchor = panel.getChildrenComponents().get(0);
 		// begin CREATE
 		loadCreationBox();
 	}
 
 	private void assert_CREATE_singlePanel(String... constraints) throws Exception {
-		String[] lines =
-				CodeUtils.join(new String[]{
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    SpringLayout layout = new SpringLayout();",
-						"    setLayout(layout);",
-						"    //",
-						"    Box anchor = new Box();",
-						"    layout.putConstraint(SpringLayout.NORTH, anchor, 120, SpringLayout.NORTH, this);",
-						"    layout.putConstraint(SpringLayout.WEST, anchor, 170, SpringLayout.WEST, this);",
-						"    add(anchor);",
-						"    {",
-				"      Box box = new Box();"}, constraints);
-		lines = CodeUtils.join(lines, new String[]{"      add(box);", "    }", "  }", "}"});
+		String lines = """
+				public class Test extends JPanel {
+					public Test() {
+						SpringLayout layout = new SpringLayout();
+						setLayout(layout);
+						//
+						Box anchor = new Box();
+						layout.putConstraint(SpringLayout.NORTH, anchor, 120, SpringLayout.NORTH, this);
+						layout.putConstraint(SpringLayout.WEST, anchor, 170, SpringLayout.WEST, this);
+						add(anchor);
+						{
+							Box box = new Box();
+				%s
+							add(box);
+						}
+					}
+				}""".formatted(StringUtils.join(constraints, '\n'));
 		assertEditor(lines);
 	}
 
@@ -474,14 +477,14 @@ public class SpringLayoutGefTest extends SwingGefTest {
 	public void test_CREATE_withBorder() throws Exception {
 		{
 			prepareBox();
-			parse_forCREATE(
-					"public class Test extends JPanel {",
-					"  public Test() {",
-					"    setBorder(new EmptyBorder(20, 30, 5, 5));",
-					"    SpringLayout layout = new SpringLayout();",
-					"    setLayout(layout);",
-					"  }",
-					"}");
+			parse_forCREATE("""
+					public class Test extends JPanel {
+						public Test() {
+							setBorder(new EmptyBorder(20, 30, 5, 5));
+							SpringLayout layout = new SpringLayout();
+							setLayout(layout);
+						}
+					}""");
 			loadCreationBox();
 			canvas.create(100, 50).sideMode();
 		}
@@ -494,24 +497,20 @@ public class SpringLayoutGefTest extends SwingGefTest {
 				Expectations.get(50, new IntValue[]{
 						new IntValue("sablin-aa", 50),
 						new IntValue("flanker-windows", 50)});
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    setBorder(new EmptyBorder(20, 30, 5, 5));",
-				"    SpringLayout layout = new SpringLayout();",
-				"    setLayout(layout);",
-				"    {",
-				"      Box box = new Box();",
-				"      layout.putConstraint(SpringLayout.NORTH, box, "
-						+ expectedNorth
-						+ ", SpringLayout.NORTH, this);",
-						"      layout.putConstraint(SpringLayout.WEST, box, "
-								+ expectedWest
-								+ ", SpringLayout.WEST, this);",
-								"      add(box);",
-								"    }",
-								"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						setBorder(new EmptyBorder(20, 30, 5, 5));
+						SpringLayout layout = new SpringLayout();
+						setLayout(layout);
+						{
+							Box box = new Box();
+							layout.putConstraint(SpringLayout.NORTH, box, %d, SpringLayout.NORTH, this);
+							layout.putConstraint(SpringLayout.WEST, box, %d, SpringLayout.WEST, this);
+							add(box);
+						}
+					}
+				}""".formatted(expectedNorth, expectedWest));
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -521,107 +520,107 @@ public class SpringLayoutGefTest extends SwingGefTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_MOVE_topLeft() throws Exception {
-		prepare_MOVE(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    SpringLayout layout = new SpringLayout();",
-				"    setLayout(layout);",
-				"    {",
-				"      Box box = new Box();",
-				"      layout.putConstraint(SpringLayout.NORTH, box, 20, SpringLayout.NORTH, this);",
-				"      layout.putConstraint(SpringLayout.WEST, box, 10, SpringLayout.WEST, this);",
-				"      add(box);",
-				"    }",
-				"  }",
-				"}");
+		prepare_MOVE("""
+				public class Test extends JPanel {
+					public Test() {
+						SpringLayout layout = new SpringLayout();
+						setLayout(layout);
+						{
+							Box box = new Box();
+							layout.putConstraint(SpringLayout.NORTH, box, 20, SpringLayout.NORTH, this);
+							layout.putConstraint(SpringLayout.WEST, box, 10, SpringLayout.WEST, this);
+							add(box);
+						}
+					}
+				}""");
 		ComponentInfo source = panel.getChildrenComponents().get(0);
 		canvas.beginMove(source);
 		canvas.target(panel).inX(20).inY(40).drag();
 		canvas.endDrag();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    SpringLayout layout = new SpringLayout();",
-				"    setLayout(layout);",
-				"    {",
-				"      Box box = new Box();",
-				"      layout.putConstraint(SpringLayout.NORTH, box, 40, SpringLayout.NORTH, this);",
-				"      layout.putConstraint(SpringLayout.WEST, box, 20, SpringLayout.WEST, this);",
-				"      add(box);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						SpringLayout layout = new SpringLayout();
+						setLayout(layout);
+						{
+							Box box = new Box();
+							layout.putConstraint(SpringLayout.NORTH, box, 40, SpringLayout.NORTH, this);
+							layout.putConstraint(SpringLayout.WEST, box, 20, SpringLayout.WEST, this);
+							add(box);
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_MOVE_topRight() throws Exception {
-		prepare_MOVE(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    SpringLayout layout = new SpringLayout();",
-				"    setLayout(layout);",
-				"    {",
-				"      Box box = new Box();",
-				"      layout.putConstraint(SpringLayout.NORTH, box, 20, SpringLayout.NORTH, this);",
-				"      layout.putConstraint(SpringLayout.WEST, box, 10, SpringLayout.WEST, this);",
-				"      add(box);",
-				"    }",
-				"  }",
-				"}");
+		prepare_MOVE("""
+				public class Test extends JPanel {
+					public Test() {
+						SpringLayout layout = new SpringLayout();
+						setLayout(layout);
+						{
+							Box box = new Box();
+							layout.putConstraint(SpringLayout.NORTH, box, 20, SpringLayout.NORTH, this);
+							layout.putConstraint(SpringLayout.WEST, box, 10, SpringLayout.WEST, this);
+							add(box);
+						}
+					}
+				}""");
 		ComponentInfo source = panel.getChildrenComponents().get(0);
 		canvas.beginMove(source);
 		canvas.target(panel).rightSide().inX(-30).inY(40).drag();
 		canvas.endDrag();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    SpringLayout layout = new SpringLayout();",
-				"    setLayout(layout);",
-				"    {",
-				"      Box box = new Box();",
-				"      layout.putConstraint(SpringLayout.NORTH, box, 40, SpringLayout.NORTH, this);",
-				"      layout.putConstraint(SpringLayout.EAST, box, -30, SpringLayout.EAST, this);",
-				"      add(box);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						SpringLayout layout = new SpringLayout();
+						setLayout(layout);
+						{
+							Box box = new Box();
+							layout.putConstraint(SpringLayout.NORTH, box, 40, SpringLayout.NORTH, this);
+							layout.putConstraint(SpringLayout.EAST, box, -30, SpringLayout.EAST, this);
+							add(box);
+						}
+					}
+				}""");
 	}
 
 	@Test
 	public void test_MOVE_bottomLeft() throws Exception {
-		prepare_MOVE(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    SpringLayout layout = new SpringLayout();",
-				"    setLayout(layout);",
-				"    {",
-				"      Box box = new Box();",
-				"      layout.putConstraint(SpringLayout.NORTH, box, 20, SpringLayout.NORTH, this);",
-				"      layout.putConstraint(SpringLayout.WEST, box, 10, SpringLayout.WEST, this);",
-				"      add(box);",
-				"    }",
-				"  }",
-				"}");
+		prepare_MOVE("""
+				public class Test extends JPanel {
+					public Test() {
+						SpringLayout layout = new SpringLayout();
+						setLayout(layout);
+						{
+							Box box = new Box();
+							layout.putConstraint(SpringLayout.NORTH, box, 20, SpringLayout.NORTH, this);
+							layout.putConstraint(SpringLayout.WEST, box, 10, SpringLayout.WEST, this);
+							add(box);
+						}
+					}
+				}""");
 		ComponentInfo source = panel.getChildrenComponents().get(0);
 		canvas.beginMove(source);
 		canvas.target(panel).inX(20).bottomSide().inY(-40).drag();
 		canvas.endDrag();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    SpringLayout layout = new SpringLayout();",
-				"    setLayout(layout);",
-				"    {",
-				"      Box box = new Box();",
-				"      layout.putConstraint(SpringLayout.WEST, box, 20, SpringLayout.WEST, this);",
-				"      layout.putConstraint(SpringLayout.SOUTH, box, -40, SpringLayout.SOUTH, this);",
-				"      add(box);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						SpringLayout layout = new SpringLayout();
+						setLayout(layout);
+						{
+							Box box = new Box();
+							layout.putConstraint(SpringLayout.WEST, box, 20, SpringLayout.WEST, this);
+							layout.putConstraint(SpringLayout.SOUTH, box, -40, SpringLayout.SOUTH, this);
+							add(box);
+						}
+					}
+				}""");
 	}
 
-	private void prepare_MOVE(String... lines) throws Exception {
+	private void prepare_MOVE(String lines) throws Exception {
 		prepareBox();
 		panel = openContainer(lines);
 		canvas.sideMode();
@@ -639,26 +638,26 @@ public class SpringLayoutGefTest extends SwingGefTest {
 		canvas.target(boxC).outX(30).inY(30).drag();
 		canvas.target(boxC).outX(3).inY(3).drag();
 		canvas.endDrag();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    SpringLayout layout = new SpringLayout();",
-				"    setLayout(layout);",
-				"    ",
-				"    Box boxA = new Box();",
-				"    add(boxA);",
-				"    ",
-				"    Box boxB = new Box();",
-				"    layout.putConstraint(SpringLayout.WEST, boxB, 75, SpringLayout.WEST, this);",
-				"    layout.putConstraint(SpringLayout.NORTH, boxA, 0, SpringLayout.NORTH, boxB);",
-				"    add(boxB);",
-				"    ",
-				"    Box boxC = new Box();",
-				"    layout.putConstraint(SpringLayout.WEST, boxA, 5, SpringLayout.EAST, boxC);",
-				"    layout.putConstraint(SpringLayout.WEST, boxC, 5, SpringLayout.EAST, boxB);",
-				"    add(boxC);",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						SpringLayout layout = new SpringLayout();
+						setLayout(layout);
+
+						Box boxA = new Box();
+						add(boxA);
+
+						Box boxB = new Box();
+						layout.putConstraint(SpringLayout.WEST, boxB, 75, SpringLayout.WEST, this);
+						layout.putConstraint(SpringLayout.NORTH, boxA, 0, SpringLayout.NORTH, boxB);
+						add(boxB);
+
+						Box boxC = new Box();
+						layout.putConstraint(SpringLayout.WEST, boxA, 5, SpringLayout.EAST, boxC);
+						layout.putConstraint(SpringLayout.WEST, boxC, 5, SpringLayout.EAST, boxB);
+						add(boxC);
+					}
+				}""");
 	}
 
 	@Test
@@ -667,50 +666,49 @@ public class SpringLayoutGefTest extends SwingGefTest {
 		canvas.beginMove(boxB);
 		canvas.rightSide().bottomSide().target(panel).inX(-5).inY(-5).drag();
 		canvas.endDrag();
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    SpringLayout layout = new SpringLayout();",
-				"    setLayout(layout);",
-				"    ",
-				"    Box boxA = new Box();",
-				"    layout.putConstraint(SpringLayout.WEST, boxA, 20, SpringLayout.WEST, this);",
-				"    add(boxA);",
-				"    ",
-				"    Box boxB = new Box();",
-				"    layout.putConstraint(SpringLayout.SOUTH, boxB, -10, SpringLayout.SOUTH, this);",
-				"    layout.putConstraint(SpringLayout.EAST, boxB, -10, SpringLayout.EAST, this);",
-				"    add(boxB);",
-				"    ",
-				"    Box boxC = new Box();",
-				"    layout.putConstraint(SpringLayout.WEST, boxC, 60, SpringLayout.EAST, boxA);",
-				"    add(boxC);",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						SpringLayout layout = new SpringLayout();
+						setLayout(layout);
+
+						Box boxA = new Box();
+						layout.putConstraint(SpringLayout.WEST, boxA, 20, SpringLayout.WEST, this);
+						add(boxA);
+
+						Box boxB = new Box();
+						layout.putConstraint(SpringLayout.SOUTH, boxB, -10, SpringLayout.SOUTH, this);
+						layout.putConstraint(SpringLayout.EAST, boxB, -10, SpringLayout.EAST, this);
+						add(boxB);
+
+						Box boxC = new Box();
+						layout.putConstraint(SpringLayout.WEST, boxC, 60, SpringLayout.EAST, boxA);
+						add(boxC);
+					}
+				}""");
 	}
 
 	private void prepare_MOVE_andCycles() throws Exception {
 		prepareBox(50, 20);
-		panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    SpringLayout layout = new SpringLayout();",
-						"    setLayout(layout);",
-						"    ",
-						"    Box boxA = new Box();",
-						"    layout.putConstraint(SpringLayout.WEST, boxA, 20, SpringLayout.WEST, this);",
-						"    add(boxA);",
-						"    ",
-						"    Box boxB = new Box();",
-						"    layout.putConstraint(SpringLayout.WEST, boxB, 5, SpringLayout.EAST, boxA);",
-						"    add(boxB);",
-						"    ",
-						"    Box boxC = new Box();",
-						"    layout.putConstraint(SpringLayout.WEST, boxC, 5, SpringLayout.EAST, boxB);",
-						"    add(boxC);",
-						"  }",
-						"}");
+		panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						SpringLayout layout = new SpringLayout();
+						setLayout(layout);
+
+						Box boxA = new Box();
+						layout.putConstraint(SpringLayout.WEST, boxA, 20, SpringLayout.WEST, this);
+						add(boxA);
+
+						Box boxB = new Box();
+						layout.putConstraint(SpringLayout.WEST, boxB, 5, SpringLayout.EAST, boxA);
+						add(boxB);
+
+						Box boxC = new Box();
+						layout.putConstraint(SpringLayout.WEST, boxC, 5, SpringLayout.EAST, boxB);
+						add(boxC);
+					}
+				}""");
 		{
 			List<ComponentInfo> components = panel.getChildrenComponents();
 			boxA = components.get(0);
@@ -730,9 +728,9 @@ public class SpringLayoutGefTest extends SwingGefTest {
 		prepare_RESIZE_singleTL();
 		canvas.beginResize(box, PositionConstants.WEST).dragOn(-50, 0).endDrag();
 		assert_RESIZE_singleTL(
-				"      layout.putConstraint(SpringLayout.NORTH, box, 100, SpringLayout.NORTH, this);",
-				"      layout.putConstraint(SpringLayout.WEST, box, 50, SpringLayout.WEST, this);",
-				"      layout.putConstraint(SpringLayout.EAST, box, 200, SpringLayout.WEST, this);");
+				"			layout.putConstraint(SpringLayout.NORTH, box, 100, SpringLayout.NORTH, this);",
+				"			layout.putConstraint(SpringLayout.WEST, box, 50, SpringLayout.WEST, this);",
+				"			layout.putConstraint(SpringLayout.EAST, box, 200, SpringLayout.WEST, this);");
 	}
 
 	@Test
@@ -741,9 +739,9 @@ public class SpringLayoutGefTest extends SwingGefTest {
 		canvas.beginResize(box, PositionConstants.WEST);
 		canvas.target(panel).inX(12).drag().endDrag();
 		assert_RESIZE_singleTL(
-				"      layout.putConstraint(SpringLayout.NORTH, box, 100, SpringLayout.NORTH, this);",
-				"      layout.putConstraint(SpringLayout.WEST, box, 10, SpringLayout.WEST, this);",
-				"      layout.putConstraint(SpringLayout.EAST, box, 200, SpringLayout.WEST, this);");
+				"			layout.putConstraint(SpringLayout.NORTH, box, 100, SpringLayout.NORTH, this);",
+				"			layout.putConstraint(SpringLayout.WEST, box, 10, SpringLayout.WEST, this);",
+				"			layout.putConstraint(SpringLayout.EAST, box, 200, SpringLayout.WEST, this);");
 	}
 
 	@Test
@@ -751,9 +749,9 @@ public class SpringLayoutGefTest extends SwingGefTest {
 		prepare_RESIZE_singleTL();
 		canvas.beginResize(box, PositionConstants.EAST).dragOn(50, 0).endDrag();
 		assert_RESIZE_singleTL(
-				"      layout.putConstraint(SpringLayout.NORTH, box, 100, SpringLayout.NORTH, this);",
-				"      layout.putConstraint(SpringLayout.WEST, box, 100, SpringLayout.WEST, this);",
-				"      layout.putConstraint(SpringLayout.EAST, box, 250, SpringLayout.WEST, this);");
+				"			layout.putConstraint(SpringLayout.NORTH, box, 100, SpringLayout.NORTH, this);",
+				"			layout.putConstraint(SpringLayout.WEST, box, 100, SpringLayout.WEST, this);",
+				"			layout.putConstraint(SpringLayout.EAST, box, 250, SpringLayout.WEST, this);");
 	}
 
 	@Test
@@ -762,9 +760,9 @@ public class SpringLayoutGefTest extends SwingGefTest {
 		canvas.beginResize(box, PositionConstants.EAST);
 		canvas.target(panel).rightSide().inX(-12).drag().endDrag();
 		assert_RESIZE_singleTL(
-				"      layout.putConstraint(SpringLayout.NORTH, box, 100, SpringLayout.NORTH, this);",
-				"      layout.putConstraint(SpringLayout.WEST, box, 100, SpringLayout.WEST, this);",
-				"      layout.putConstraint(SpringLayout.EAST, box, -10, SpringLayout.EAST, this);");
+				"			layout.putConstraint(SpringLayout.NORTH, box, 100, SpringLayout.NORTH, this);",
+				"			layout.putConstraint(SpringLayout.WEST, box, 100, SpringLayout.WEST, this);",
+				"			layout.putConstraint(SpringLayout.EAST, box, -10, SpringLayout.EAST, this);");
 	}
 
 	@Test
@@ -772,9 +770,9 @@ public class SpringLayoutGefTest extends SwingGefTest {
 		prepare_RESIZE_singleTL();
 		canvas.beginResize(box, PositionConstants.NORTH).dragOn(0, -50).endDrag();
 		assert_RESIZE_singleTL(
-				"      layout.putConstraint(SpringLayout.NORTH, box, 50, SpringLayout.NORTH, this);",
-				"      layout.putConstraint(SpringLayout.WEST, box, 100, SpringLayout.WEST, this);",
-				"      layout.putConstraint(SpringLayout.SOUTH, box, 150, SpringLayout.NORTH, this);");
+				"			layout.putConstraint(SpringLayout.NORTH, box, 50, SpringLayout.NORTH, this);",
+				"			layout.putConstraint(SpringLayout.WEST, box, 100, SpringLayout.WEST, this);",
+				"			layout.putConstraint(SpringLayout.SOUTH, box, 150, SpringLayout.NORTH, this);");
 	}
 
 	@Test
@@ -783,9 +781,9 @@ public class SpringLayoutGefTest extends SwingGefTest {
 		canvas.beginResize(box, PositionConstants.NORTH);
 		canvas.target(panel).inY(12).drag().endDrag();
 		assert_RESIZE_singleTL(
-				"      layout.putConstraint(SpringLayout.NORTH, box, 10, SpringLayout.NORTH, this);",
-				"      layout.putConstraint(SpringLayout.WEST, box, 100, SpringLayout.WEST, this);",
-				"      layout.putConstraint(SpringLayout.SOUTH, box, 150, SpringLayout.NORTH, this);");
+				"			layout.putConstraint(SpringLayout.NORTH, box, 10, SpringLayout.NORTH, this);",
+				"			layout.putConstraint(SpringLayout.WEST, box, 100, SpringLayout.WEST, this);",
+				"			layout.putConstraint(SpringLayout.SOUTH, box, 150, SpringLayout.NORTH, this);");
 	}
 
 	@Test
@@ -793,9 +791,9 @@ public class SpringLayoutGefTest extends SwingGefTest {
 		prepare_RESIZE_singleTL();
 		canvas.beginResize(box, PositionConstants.SOUTH).dragOn(0, 50).endDrag();
 		assert_RESIZE_singleTL(
-				"      layout.putConstraint(SpringLayout.NORTH, box, 100, SpringLayout.NORTH, this);",
-				"      layout.putConstraint(SpringLayout.WEST, box, 100, SpringLayout.WEST, this);",
-				"      layout.putConstraint(SpringLayout.SOUTH, box, 200, SpringLayout.NORTH, this);");
+				"			layout.putConstraint(SpringLayout.NORTH, box, 100, SpringLayout.NORTH, this);",
+				"			layout.putConstraint(SpringLayout.WEST, box, 100, SpringLayout.WEST, this);",
+				"			layout.putConstraint(SpringLayout.SOUTH, box, 200, SpringLayout.NORTH, this);");
 	}
 
 	@Test
@@ -804,40 +802,42 @@ public class SpringLayoutGefTest extends SwingGefTest {
 		canvas.beginResize(box, PositionConstants.SOUTH);
 		canvas.target(panel).bottomSide().inY(-12).drag().endDrag();
 		assert_RESIZE_singleTL(
-				"      layout.putConstraint(SpringLayout.NORTH, box, 100, SpringLayout.NORTH, this);",
-				"      layout.putConstraint(SpringLayout.WEST, box, 100, SpringLayout.WEST, this);",
-				"      layout.putConstraint(SpringLayout.SOUTH, box, -10, SpringLayout.SOUTH, this);");
+				"			layout.putConstraint(SpringLayout.NORTH, box, 100, SpringLayout.NORTH, this);",
+				"			layout.putConstraint(SpringLayout.WEST, box, 100, SpringLayout.WEST, this);",
+				"			layout.putConstraint(SpringLayout.SOUTH, box, -10, SpringLayout.SOUTH, this);");
 	}
 
 	private void prepare_RESIZE_singleTL() throws Exception {
 		prepareBox();
-		panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    SpringLayout layout = new SpringLayout();",
-						"    setLayout(layout);",
-						"    {",
-						"      Box box = new Box();",
-						"      layout.putConstraint(SpringLayout.NORTH, box, 100, SpringLayout.NORTH, this);",
-						"      layout.putConstraint(SpringLayout.WEST, box, 100, SpringLayout.WEST, this);",
-						"      add(box);",
-						"    }",
-						"  }",
-						"}");
+		panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						SpringLayout layout = new SpringLayout();
+						setLayout(layout);
+						{
+							Box box = new Box();
+							layout.putConstraint(SpringLayout.NORTH, box, 100, SpringLayout.NORTH, this);
+							layout.putConstraint(SpringLayout.WEST, box, 100, SpringLayout.WEST, this);
+							add(box);
+						}
+					}
+				}""");
 		box = panel.getChildrenComponents().get(0);
 	}
 
 	private void assert_RESIZE_singleTL(String... constraints) throws Exception {
-		String[] lines =
-				CodeUtils.join(new String[]{
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    SpringLayout layout = new SpringLayout();",
-						"    setLayout(layout);",
-						"    {",
-				"      Box box = new Box();"}, constraints);
-		lines = CodeUtils.join(lines, new String[]{"      add(box);", "    }", "  }", "}"});
+		String lines = """
+				public class Test extends JPanel {
+					public Test() {
+						SpringLayout layout = new SpringLayout();
+						setLayout(layout);
+						{
+							Box box = new Box();
+				%s
+							add(box);
+						}
+					}
+				}""".formatted(StringUtils.join(constraints, '\n'));
 		assertEditor(lines);
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/top/JFrameTopBoundsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/top/JFrameTopBoundsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -69,12 +69,12 @@ public class JFrameTopBoundsTest extends SwingGefTest {
 	public void test_JFrame_bigSize_setInSuperclass() throws Exception {
 		setFileContentSrc(
 				"test/MyBigFrame.java",
-				getTestSource(
-						"public class MyBigFrame extends JFrame {",
-						"  public MyBigFrame() {",
-						"    setSize(500, 400);",
-						"  }",
-						"}"));
+				getTestSource("""
+						public class MyBigFrame extends JFrame {
+							public MyBigFrame() {
+								setSize(500, 400);
+							}
+						}"""));
 		waitForAutoBuild();
 		//
 		Dimension oldSize = new Dimension(500, 400);
@@ -97,11 +97,12 @@ public class JFrameTopBoundsTest extends SwingGefTest {
 	@Test
 	public void test_JFrame_veryBig() throws Exception {
 		setFileContentSrc("test/MyVeryBigFrame.java",
-				getTestSource("public class MyVeryBigFrame extends JFrame {",
-				"  public MyVeryBigFrame() {",
-				"    setSize(500, 400);",
-				"  }",
-				"}"));
+				getTestSource("""
+						public class MyVeryBigFrame extends JFrame {
+							public MyVeryBigFrame() {
+									setSize(500, 400);
+							}
+						}"""));
 		waitForAutoBuild();
 		// Expand horizontally
 		Dimension oldSize = new Dimension(500, 400);
@@ -134,12 +135,12 @@ public class JFrameTopBoundsTest extends SwingGefTest {
 	public void test_JInternalFrame_bigSize_setInSuperclass() throws Exception {
 		setFileContentSrc(
 				"test/MyBigFrame.java",
-				getTestSource(
-						"public class MyBigFrame extends JInternalFrame {",
-						"  public MyBigFrame() {",
-						"    setSize(500, 400);",
-						"  }",
-						"}"));
+				getTestSource("""
+						public class MyBigFrame extends JInternalFrame {
+							public MyBigFrame() {
+								setSize(500, 400);
+							}
+						}"""));
 		waitForAutoBuild();
 		//
 		Dimension oldSize = new Dimension(500, 400);
@@ -180,12 +181,12 @@ public class JFrameTopBoundsTest extends SwingGefTest {
 	public void test_packAlways() throws Exception {
 		setFileContentSrc(
 				"test/MyFrame.java",
-				getTestSource(
-						"public class MyFrame extends JFrame {",
-						"  protected void finishInit() {",
-						"    pack();",
-						"  }",
-						"}"));
+				getTestSource("""
+						public class MyFrame extends JFrame {
+							protected void finishInit() {
+								pack();
+							}
+						}"""));
 		setFileContentSrc(
 				"test/MyFrame.wbp-component.xml",
 				getSourceDQ(
@@ -200,14 +201,13 @@ public class JFrameTopBoundsTest extends SwingGefTest {
 						"</component>"));
 		waitForAutoBuild();
 		// open
-		ContainerInfo frame =
-				openContainer(
-						"// filler filler filler filler filler",
-						"public class Test extends MyFrame {",
-						"  public Test() {",
-						"    finishInit();",
-						"  }",
-						"}");
+		ContainerInfo frame = openContainer("""
+				// filler filler filler filler filler
+				public class Test extends MyFrame {
+					public Test() {
+						finishInit();
+					}
+				}""");
 		// assert that pack() was invoked and not overridden
 		Dimension size = frame.getBounds().getSize();
 		assertNotEquals(size.width, 450);
@@ -274,16 +274,15 @@ public class JFrameTopBoundsTest extends SwingGefTest {
 			Dimension resizeSize,
 			Dimension newSize,
 			String newSizeLine) throws Exception {
-		ContainerInfo frame =
-				openContainer(
-						"public class Test extends " + superClassName + " {",
-						"  public Test() {",
-						"    " + oldSizeLine,
-						"    getContentPane().add(new JButton('Swing JButton'), BorderLayout.NORTH);",
-						"    getContentPane().add(new Button('AWT Button'), BorderLayout.WEST);",
-						"    " + addSizeString,
-						"  }",
-						"}");
+		ContainerInfo frame = openContainer("""
+				public class Test extends %s {
+					public Test() {
+						%s
+						getContentPane().add(new JButton("Swing JButton"), BorderLayout.NORTH);
+						getContentPane().add(new Button("AWT Button"), BorderLayout.WEST);
+						%s
+					}
+				}""".formatted(superClassName, oldSizeLine, addSizeString));
 		// check size
 		assertEquals(oldSize, canvas.getSize(frame));
 		waitEventLoop(50);
@@ -294,15 +293,15 @@ public class JFrameTopBoundsTest extends SwingGefTest {
 		canvas.dragTo(frame, 0, resizeSize.height).endDrag();
 		// check new size
 		assertEquals(newSize, canvas.getSize(frame));
-		assertEditor(
-				"public class Test extends " + superClassName + " {",
-				"  public Test() {",
-				"    " + newSizeLine,
-				"    getContentPane().add(new JButton('Swing JButton'), BorderLayout.NORTH);",
-				"    getContentPane().add(new Button('AWT Button'), BorderLayout.WEST);",
-				"    " + addSizeString,
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends %s {
+					public Test() {
+						%s
+						getContentPane().add(new JButton("Swing JButton"), BorderLayout.NORTH);
+						getContentPane().add(new Button("AWT Button"), BorderLayout.WEST);
+						%s
+					}
+				}""".formatted(superClassName, newSizeLine, addSizeString));
 		//
 		return m_lastEditor.getModelUnit();
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/top/JPanelTopBoundsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/top/JPanelTopBoundsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -119,15 +119,14 @@ public class JPanelTopBoundsTest extends SwingGefTest {
 			Dimension oldSize,
 			Dimension newSize,
 			String newSizeLine) throws Exception {
-		ContainerInfo panel =
-				openContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    " + oldSizeLine,
-						"    add(new JButton('Swing JButton'));",
-						"    add(new Button('AWT Button'));",
-						"  }",
-						"}");
+		ContainerInfo panel = openContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						%s
+						add(new JButton("Swing JButton"));
+						add(new Button("AWT Button"));
+					}
+				}""".formatted(oldSizeLine));
 		// check size
 		assertEquals(oldSize, canvas.getSize(panel));
 		waitEventLoop(50);
@@ -138,14 +137,14 @@ public class JPanelTopBoundsTest extends SwingGefTest {
 		canvas.dragTo(panel, 0, newSize.height).endDrag();
 		// check new size
 		assertEquals(newSize, canvas.getSize(panel));
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    " + newSizeLine,
-				"    add(new JButton('Swing JButton'));",
-				"    add(new Button('AWT Button'));",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						%s
+						add(new JButton("Swing JButton"));
+						add(new Button("AWT Button"));
+					}
+				}""".formatted(newSizeLine));
 		//
 		return m_lastEditor.getModelUnit();
 	}


### PR DESCRIPTION
This adapts the following methods of the SwingGefTest class to use accept single strings, rather than an array of string lines, which is then written using text blocks:

- openContainer
- openEditor
- assertEditor
- getTestSource