### PR TITLE
Adapt tests to updated "New Wizard" title

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/swtbot/designer/bot/WindowBuilderProjectExplorerBot.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/swtbot/designer/bot/WindowBuilderProjectExplorerBot.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Patrick Ziegler and others.
+ * Copyright (c) 2024, 2025 Patrick Ziegler and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -34,6 +34,6 @@ public class WindowBuilderProjectExplorerBot extends SWTBotView {
 		LOGGER.fine("Open New wizard");
 		bot().tree().getTreeItem("TestProject").contextMenu().menu("New", "Other...").click();
 		LOGGER.fine("Opened New wizard");
-		return bot.shell("Select a wizard");
+		return bot.shell("New");
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/swtbot/designer/bot/WindowBuilderWorkbenchBot.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/swtbot/designer/bot/WindowBuilderWorkbenchBot.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Patrick Ziegler and others.
+ * Copyright (c) 2024, 2025 Patrick Ziegler and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -119,7 +119,7 @@ public class WindowBuilderWorkbenchBot extends SWTWorkbenchBot {
 		LOGGER.fine("Open New wizard");
 		shell().menu().menu("File").menu("New", "Other...").click();
 		LOGGER.fine("Opened New wizard");
-		return shell("Select a wizard");
+		return shell("New");
 	}
 
 	// I/O


### PR DESCRIPTION
The title was changed from "Select a wizard" back to "New" via https://github.com/eclipse-platform/eclipse.platform.ui/pull/2827