### PR TITLE
Realize SwingPaletteEntryInfo as a PaletteDrawer

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPalette.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPalette.java
@@ -54,9 +54,7 @@ import org.eclipse.wb.internal.core.editor.palette.model.entry.StaticFactoryEntr
 import org.eclipse.wb.internal.core.model.description.helpers.ComponentPresentationHelper;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 import org.eclipse.wb.internal.gef.core.EditDomain;
-import org.eclipse.wb.internal.gef.core.IDefaultToolProvider;
 
 import org.eclipse.core.runtime.jobs.IJobManager;
 import org.eclipse.core.runtime.jobs.Job;
@@ -350,12 +348,7 @@ public class DesignerPalette {
 				public List<DesignerEntry> getChildren() {
 					final List<EntryInfo> entryInfoList = new ArrayList<>(categoryInfo.getEntries());
 					// add new EntryInfo's using broadcast
-					ExecutionUtils.runIgnore(new RunnableEx() {
-						@Override
-						public void run() throws Exception {
-							getBroadcastPalette().entries(categoryInfo, entryInfoList);
-						}
-					});
+					ExecutionUtils.runIgnore(() -> getBroadcastPalette().entries(categoryInfo, entryInfoList));
 					// convert EntryInfo's into IEntry's
 					List<DesignerEntry> entries = new ArrayList<>();
 					for (EntryInfo entryInfo : entryInfoList) {
@@ -489,18 +482,15 @@ public class DesignerPalette {
 	private void configure_EditDomain_DefaultTool() {
 		if (m_isMainPalette) {
 			final EditDomain editDomain = m_editPartViewer.getEditDomain();
-			editDomain.setDefaultToolProvider(new IDefaultToolProvider() {
-				@Override
-				public void loadDefaultTool() {
-					if (m_defaultEntry != null) {
-						if (m_legacyPaletteComposite != null) {
-							m_legacyPaletteComposite.selectEntry(m_defaultEntry, false);
-						} else {
-							m_paletteViewer.setActiveTool(m_defaultEntry);
-						}
+			editDomain.setDefaultToolProvider(() -> {
+				if (m_defaultEntry != null) {
+					if (m_legacyPaletteComposite != null) {
+						m_legacyPaletteComposite.selectEntry(m_defaultEntry, false);
 					} else {
-						editDomain.setActiveTool(new SelectionTool());
+						m_paletteViewer.setActiveTool(m_defaultEntry);
 					}
+				} else {
+					editDomain.setActiveTool(new SelectionTool());
 				}
 			});
 			editDomain.loadDefaultTool();

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPaletteEditPartFactory.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPaletteEditPartFactory.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.editor.palette;
 
+import org.eclipse.wb.core.controls.palette.DesignerSubPalette;
+
 import org.eclipse.draw2d.AbstractBackground;
 import org.eclipse.draw2d.Border;
 import org.eclipse.draw2d.ButtonModel;
@@ -40,7 +42,10 @@ public class DesignerPaletteEditPartFactory extends PaletteEditPartFactory {
 		editPart.addEditPartListener(new EditPartListener.Stub() {
 			@Override
 			public void childAdded(EditPart child, int index) {
-				if (child.getModel() instanceof PaletteDrawer) {
+				// Should look different from a plain PaletteDrawer
+				if (child.getModel() instanceof DesignerSubPalette) {
+					updateFigure(child, ToolEntryBackground::new);
+				} else if (child.getModel() instanceof PaletteDrawer) {
 					updateFigure(child, DrawerBackground::new);
 				} else if (child.getModel() instanceof ToolEntry) {
 					updateFigure(child, ToolEntryBackground::new);

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/ISubPaletteInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/ISubPaletteInfo.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Patrick Ziegler and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.internal.core.editor.palette;
+
+import org.eclipse.wb.core.editor.palette.model.CategoryInfo;
+import org.eclipse.wb.core.editor.palette.model.EntryInfo;
+
+import org.eclipse.gef.palette.PaletteDrawer;
+import org.eclipse.gef.palette.ToolEntry;
+
+import java.util.List;
+
+/**
+ * Interface that may be implemented by {@link EntryInfo}'s when they shouldn't
+ * be realized by a {@link ToolEntry}, but rather a {@link PaletteDrawer}.
+ */
+public interface ISubPaletteInfo {
+
+	/**
+	 * Returns the list of elements contained by this entry info.
+	 *
+	 * @return the stack elements contained by this entry.
+	 */
+	public List<CategoryInfo> getSubCategories();
+}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/DesignerSubPalette.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/DesignerSubPalette.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Patrick Ziegler and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.core.controls.palette;
+
+import org.eclipse.gef.palette.PaletteDrawer;
+import org.eclipse.gef.palette.ToolEntry;
+import org.eclipse.jface.resource.ImageDescriptor;
+
+/**
+ * Subclass of the {@link PaletteDrawer} that only supports
+ * {@link PaletteDrawer}'s, as opposed to {@link ToolEntry}'s.
+ */
+public class DesignerSubPalette extends PaletteDrawer {
+	public DesignerSubPalette(String name, String desc, ImageDescriptor icon) {
+		super(name, icon);
+		setDescription(desc);
+	}
+
+	@Override
+	public boolean acceptsType(Object type) {
+		return PaletteDrawer.PALETTE_TYPE_DRAWER.equals(type);
+	}
+}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/palette/SwingPaletteEntryInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/palette/SwingPaletteEntryInfo.java
@@ -10,10 +10,13 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.palette;
 
+import org.eclipse.wb.core.editor.palette.model.CategoryInfo;
 import org.eclipse.wb.core.editor.palette.model.EntryInfo;
 import org.eclipse.wb.gef.core.tools.Tool;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.editor.palette.DesignerPalette;
+import org.eclipse.wb.internal.core.editor.palette.ISubPaletteInfo;
+import org.eclipse.wb.internal.core.editor.palette.PaletteManager;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.core.utils.ui.UiUtils;
@@ -33,6 +36,10 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Shell;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * {@link EntryInfo} that shows popup/cascading Swing palette (this entry should be placed into RCP
  * palette).
@@ -40,7 +47,7 @@ import org.eclipse.swt.widgets.Shell;
  * @author scheglov_ke
  * @coverage swing.editor.palette
  */
-public final class SwingPaletteEntryInfo extends EntryInfo {
+public final class SwingPaletteEntryInfo extends EntryInfo implements ISubPaletteInfo {
 	private static final ImageDescriptor ICON = Activator.getImageDescriptor("popup_palette.png");
 
 	////////////////////////////////////////////////////////////////////////////
@@ -62,6 +69,17 @@ public final class SwingPaletteEntryInfo extends EntryInfo {
 	@Override
 	public ImageDescriptor getIcon() {
 		return ICON;
+	}
+
+	@Override
+	public List<CategoryInfo> getSubCategories() {
+		PaletteManager swingManager = new PaletteManager(m_rootJavaInfo, IPreferenceConstants.TOOLKIT_ID);
+		swingManager.reloadPalette();
+
+		List<CategoryInfo> elements = new ArrayList<>(swingManager.getPalette().getCategories());
+
+		elements.removeIf(category -> "org.eclipse.wb.swing.system".equals(category.getId()));
+		return Collections.unmodifiableList(elements);
 	}
 
 	////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Previously, clicking on the "Choose Swing Component" entry would spawn a
separate palette in a new shell. This approach doesn't really work when
using a GEF viewer.

Instead, this entry is converted to a drawer. The Swing component can be
revealed and/or concealed by clicking on it.