### PR TITLE
Put call to exportAllModulesToAllModules() in try-catch block

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/DesignerPlugin.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/DesignerPlugin.java
@@ -63,7 +63,12 @@ public class DesignerPlugin extends AbstractUIPlugin {
 		if (EnvironmentUtils.IS_LINUX) {
 			installPreferenceForwarder();
 		}
-		exportAllModulesToAllModules();
+		try {
+			// https://github.com/eclipse-windowbuilder/windowbuilder/issues/1027
+			exportAllModulesToAllModules();
+		} catch (Throwable e) {
+			log(e);
+		}
 	}
 
 	private void exportAllModulesToAllModules() {


### PR DESCRIPTION
The current version of BurningWave is incompatible with Java 24 and causes a crash whenever the editor is opened.

Until this issue is resolved, the following modules need to be opened manually in the eclipse.ini:

--add-opens java.base/java.lang=ALL-UNNAMED
--add-opens java.desktop/javax.swing=ALL-UNNAMED
--add-opens java.desktop/java.awt=ALL-UNNAMED

See https://github.com/eclipse-windowbuilder/windowbuilder/issues/1027