### PR TITLE
Refactor class-loader hack for property cache

### DIFF
--- a/org.eclipse.wb.rcp/plugin.xml
+++ b/org.eclipse.wb.rcp/plugin.xml
@@ -29,6 +29,10 @@
     <extension point="org.eclipse.wb.core.java.classLoaderInitializers">
 		<initializer class="org.eclipse.wb.internal.swt.utils.ResourceManagerClassLoaderInitializer"
 			toolkit="org.eclipse.wb.rcp"/>
+  <initializer
+        class="org.eclipse.wb.internal.core.utils.reflect.ClassLoaderLocalMap$ClassLoaderLocalMapManager"
+        toolkit="org.eclipse.wb.rcp">
+  </initializer>
 	</extension>
 
 

--- a/org.eclipse.wb.swing/plugin.xml
+++ b/org.eclipse.wb.swing/plugin.xml
@@ -568,4 +568,14 @@
           type="java.awt.Image">
     </processor>
  </extension>
+ <extension
+       point="org.eclipse.jdt.core.classpathContainerInitializer">
+ </extension>
+ <extension
+       point="org.eclipse.wb.core.java.classLoaderInitializers">
+    <initializer
+          class="org.eclipse.wb.internal.core.utils.reflect.ClassLoaderLocalMap$ClassLoaderLocalMapManager"
+          toolkit="org.eclipse.wb.swing">
+    </initializer>
+ </extension>
 </plugin>


### PR DESCRIPTION
The methods used to hack a custom map into the class-loader won't work anymore, unless the java.base/java.lang module is explicitly opened. The ClassLoaderLocalMap has instead been refactored into a normal map, which is bound to the lifecycle of the project class-loader.

Contributes to:
https://github.com/eclipse-windowbuilder/windowbuilder/issues/764