### PR TITLE
Avoid usage of setAccessible() for methods

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/eval/evaluators/InvocationEvaluator.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/eval/evaluators/InvocationEvaluator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -214,7 +214,7 @@ public final class InvocationEvaluator implements IExpressionEvaluator {
 		// invoke method
 		try {
 			invocation.getRoot().setProperty(SUPER_MI_KEY, Boolean.TRUE);
-			return method.invoke(thisValue, argumentValues);
+			return ReflectionUtils.invokeMethod(method, thisValue, argumentValues);
 		} catch (Throwable e) {
 			throw new DesignerException(ICoreExceptionConstants.EVAL_SUPER_METHOD,
 					e,
@@ -474,7 +474,7 @@ public final class InvocationEvaluator implements IExpressionEvaluator {
 		}
 		// invoke method
 		try {
-			return method.invoke(targetValue, argumentValues);
+			return ReflectionUtils.invokeMethod(method, targetValue, argumentValues);
 		} catch (Throwable e) {
 			throw new DesignerException(ICoreExceptionConstants.EVAL_METHOD,
 					e,

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/JavaInfoUtils.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/JavaInfoUtils.java
@@ -468,12 +468,9 @@ public class JavaInfoUtils {
 			// check that methods returns not "null"
 			Object methodObject = null;
 			{
-				try {
-					methodObject = getMethod.invoke(hostObject);
-					if (methodObject == null) {
-						continue;
-					}
-				} catch (Exception e) {
+				methodObject = ExecutionUtils.runObjectLog(() -> ReflectionUtils.invokeMethod(getMethod, hostObject),
+						null);
+				if (methodObject == null) {
 					continue;
 				}
 			}
@@ -500,7 +497,7 @@ public class JavaInfoUtils {
 		Assert.isNotNull(hostObject);
 		// prepare "method" object
 		Method getMethod = ReflectionUtils.getMethod(hostObject.getClass(), getMethodName);
-		Object methodObject = getMethod.invoke(hostObject);
+		Object methodObject = ReflectionUtils.invokeMethod(getMethod, hostObject);
 		Assert.isNotNull(methodObject);
 		// add exposed child
 		return addChildExposedByMethod(host, getMethod, null, methodObject);

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/creation/ExposedPropertyCreationSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/creation/ExposedPropertyCreationSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -125,7 +125,7 @@ IExposedCreationSupport {
 						// get object, may fail if not right time, case 47105
 						Object object;
 						try {
-							object = m_getMethod.invoke(o);
+							object = ReflectionUtils.invokeMethod(m_getMethod, o);
 						} catch (Throwable e) {
 							object = null;
 						}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/SetterAccessor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/accessor/SetterAccessor.java
@@ -90,7 +90,8 @@ public final class SetterAccessor extends ExpressionAccessor {
 
 	private Object askDefaultValue(final JavaInfo javaInfo) throws Exception {
 		if (m_getter != null && isDefaultEnabled(javaInfo)) {
-			return ExecutionUtils.runObjectIgnore(() -> m_getter.invoke(javaInfo.getObject()), Property.UNKNOWN_VALUE);
+			return ExecutionUtils.runObjectIgnore(() -> ReflectionUtils.invokeMethod(m_getter, javaInfo.getObject()),
+					Property.UNKNOWN_VALUE);
 		} else {
 			return Property.UNKNOWN_VALUE;
 		}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/PolicyUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/PolicyUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -138,7 +138,7 @@ public abstract class PolicyUtils {
 	 */
 	private static Layer getLayer(GraphicalEditPolicy policy, String name) throws Exception {
 		Method method = findPolicyMethod(policy, "getLayer(java.lang.String)");
-		return (Layer) method.invoke(policy, new Object[]{name});
+		return (Layer) ReflectionUtils.invokeMethod(method, policy, name);
 	}
 
 	/**

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/model/broadcast/BroadcastSupport.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/model/broadcast/BroadcastSupport.java
@@ -16,6 +16,7 @@ import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.EnvironmentUtils;
 import org.eclipse.wb.internal.core.utils.check.Assert;
+import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.implementation.InvocationHandlerAdapter;
@@ -206,7 +207,11 @@ public final class BroadcastSupport {
 							// Iterate over a local copy due to a potential ConcurrentModificationException
 							for (Object listener : getClassListeners(listenerClass).toArray()) {
 								try {
-									method.invoke(listener, args);
+									if (args == null) {
+										ReflectionUtils.invokeMethod(method, listener);
+									} else {
+										ReflectionUtils.invokeMethod(method, listener, args);
+									}
 								} catch (InvocationTargetException e) {
 									throw e.getCause();
 								}


### PR DESCRIPTION
Convert the Methods to MethodHandles and then use the new reflection API. The methods are called as if within the declaring class.

Contributes to:
https://github.com/eclipse-windowbuilder/windowbuilder/issues/1027