### PR TITLE
Add Java 24 to GitHub workflow

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: [ 21 ]
+        java: [ 21, 24 ]
         include:
           - target: master
           - target: 2024-06

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,3 @@
 -Dtycho.version=4.0.12
+-Djdk.xml.totalEntitySizeLimit=1000000
+-Djdk.xml.maxGeneralEntitySizeLimit=1000000


### PR DESCRIPTION
The changes to the maven.yaml file are due to
https://github.com/eclipse-tycho/tycho/issues/4526