### PR TITLE
Add accessibility check to ReflectionUtils class

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/reflect/ReflectionUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/reflect/ReflectionUtils.java
@@ -1694,6 +1694,12 @@ public class ReflectionUtils {
 	}
 
 	private static MethodHandles.Lookup getPrivateLookup(Class<?> clazz) {
+		Module callerModule = ReflectionUtils.class.getModule();
+		Module targetModule = clazz.getModule();
+		// Quick check to see if private lookup is possible
+		if (targetModule.isNamed() && !targetModule.isOpen(clazz.getPackageName(), callerModule)) {
+			return MethodHandles.lookup();
+		}
 		try {
 			return MethodHandles.privateLookupIn(clazz, MethodHandles.lookup());
 		} catch (IllegalArgumentException | IllegalAccessException e) {


### PR DESCRIPTION
This check makes sure that we only create a "private" lookup for the given class if the package has been explicitly opened for us. Otherwise an IllegalAccessException is thrown, which obscures the exceptions being thrown at other places that still access the methods directly.