### PR TITLE
Make "firePropertyChange()" public in CustomizeTest

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/CustomizeTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/CustomizeTest.java
@@ -600,6 +600,12 @@ public class CustomizeTest extends SwingModelTest {
 								MyButton button = (MyButton)bean;
 								button.customizer = this;
 							}
+
+							@Override
+							// Make public for reflective access
+							public void firePropertyChange(String propertyName, Object oldValue, Object newValue) {
+								super.firePropertyChange(propertyName, oldValue, newValue);
+							}
 						}"""));
 		setFileContentSrc(
 				"test/MyButtonBeanInfo.java",


### PR DESCRIPTION
The protected firePropertyChange() method in the customizer is called reflectively. Because the method is declared by java.awt.Component, this will throw an exception and thus causing the test to get stuck.

Contributes to
https://github.com/eclipse-windowbuilder/windowbuilder/issues/1027