### PR TITLE
 Remove redundant dispose listener in EmbeddedSwingComposite 

### DIFF
--- a/org.eclipse.wb.swing/src/swingintegration/example/EmbeddedSwingComposite.java
+++ b/org.eclipse.wb.swing/src/swingintegration/example/EmbeddedSwingComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2024 SAS Institute. All rights reserved.
+ * Copyright (c) 2007, 2025 SAS Institute. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -173,7 +173,6 @@ public abstract class EmbeddedSwingComposite extends Composite {
 		currentSystemFont = getFont();
 		// set listeners
 		getDisplay().addListener(SWT.Settings, settingsListener);
-		addListener(SWT.Dispose, event -> dispose_AWT());
 	}
 
 	/**

--- a/org.eclipse.wb.swing/src/swingintegration/example/EmbeddedSwingComposite2.java
+++ b/org.eclipse.wb.swing/src/swingintegration/example/EmbeddedSwingComposite2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2024 SAS Institute. All rights reserved.
+ * Copyright (c) 2007, 2025 SAS Institute. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -164,8 +164,6 @@ public abstract class EmbeddedSwingComposite2 extends Composite {
 	public EmbeddedSwingComposite2(Composite parent, int style) {
 		super(parent, style | SWT.EMBEDDED | SWT.NO_BACKGROUND);
 		setLayout(new FillLayout());
-		// set listeners
-		addListener(SWT.Dispose, event -> dispose_AWT());
 	}
 
 	/**

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/property/BorderPropertyEditorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/property/BorderPropertyEditorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -37,13 +37,12 @@ public class BorderPropertyEditorTest extends SwingModelTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_getText_defaultBorder() throws Exception {
-		ContainerInfo panel =
-				parseContainer(
-						"// filler filler filler",
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"  }",
-						"}");
+		ContainerInfo panel = parseContainer("""
+				// filler filler filler
+				public class Test extends JPanel {
+					public Test() {
+					}
+				}""");
 		panel.refresh();
 		// property
 		Property borderProperty = panel.getPropertyByTitle("border");
@@ -52,13 +51,12 @@ public class BorderPropertyEditorTest extends SwingModelTest {
 
 	@Test
 	public void test_getText_noBorder() throws Exception {
-		ContainerInfo panel =
-				parseContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setBorder(null);",
-						"  }",
-						"}");
+		ContainerInfo panel = parseContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setBorder(null);
+					}
+				}""");
 		panel.refresh();
 		// property
 		Property borderProperty = panel.getPropertyByTitle("border");
@@ -67,13 +65,12 @@ public class BorderPropertyEditorTest extends SwingModelTest {
 
 	@Test
 	public void test_getText_EmptyBorder() throws Exception {
-		ContainerInfo panel =
-				parseContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    setBorder(new EmptyBorder(0, 0, 0, 0));",
-						"  }",
-						"}");
+		ContainerInfo panel = parseContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						setBorder(new EmptyBorder(0, 0, 0, 0));
+					}
+				}""");
 		panel.refresh();
 		// property
 		Property borderProperty = panel.getPropertyByTitle("border");
@@ -82,17 +79,16 @@ public class BorderPropertyEditorTest extends SwingModelTest {
 
 	@Test
 	public void test_getClipboardSource_EmptyBorder() throws Exception {
-		final ContainerInfo panel =
-				parseContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    {",
-						"      JButton button = new JButton();",
-						"      button.setBorder(new EmptyBorder(1, 2, 3, 4));",
-						"      add(button);",
-						"    }",
-						"  }",
-						"}");
+		final ContainerInfo panel = parseContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						{
+							JButton button = new JButton();
+							button.setBorder(new EmptyBorder(1, 2, 3, 4));
+							add(button);
+						}
+					}
+				}""");
 		panel.refresh();
 		ComponentInfo button = getJavaInfoByName("button");
 		// property
@@ -110,21 +106,21 @@ public class BorderPropertyEditorTest extends SwingModelTest {
 				((FlowLayoutInfo) panel.getLayout()).add(copy, null);
 			}
 		});
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    {",
-				"      JButton button = new JButton();",
-				"      button.setBorder(new EmptyBorder(1, 2, 3, 4));",
-				"      add(button);",
-				"    }",
-				"    {",
-				"      JButton button = new JButton();",
-				"      button.setBorder(new EmptyBorder(1, 2, 3, 4));",
-				"      add(button);",
-				"    }",
-				"  }",
-				"}");
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						{
+							JButton button = new JButton();
+							button.setBorder(new EmptyBorder(1, 2, 3, 4));
+							add(button);
+						}
+						{
+							JButton button = new JButton();
+							button.setBorder(new EmptyBorder(1, 2, 3, 4));
+							add(button);
+						}
+					}
+				}""");
 	}
 
 	/**
@@ -133,18 +129,17 @@ public class BorderPropertyEditorTest extends SwingModelTest {
 	 */
 	@Test
 	public void test_getClipboardSource_hasNotConstants() throws Exception {
-		final ContainerInfo panel =
-				parseContainer(
-						"public class Test extends JPanel {",
-						"  public Test() {",
-						"    {",
-						"      JButton button = new JButton();",
-						"      int notConst = 4;",
-						"      button.setBorder(new EmptyBorder(1, 2, 3, notConst));",
-						"      add(button);",
-						"    }",
-						"  }",
-						"}");
+		final ContainerInfo panel = parseContainer("""
+				public class Test extends JPanel {
+					public Test() {
+						{
+							JButton button = new JButton();
+							int notConst = 4;
+							button.setBorder(new EmptyBorder(1, 2, 3, notConst));
+							add(button);
+						}
+					}
+				}""");
 		panel.refresh();
 		ComponentInfo button = getJavaInfoByName("button");
 		// property
@@ -156,26 +151,21 @@ public class BorderPropertyEditorTest extends SwingModelTest {
 			assertEquals(null, cs);
 		}
 		// do copy/paste
-		doCopyPaste(button, new PasteProcedure<ComponentInfo>() {
-			@Override
-			public void run(ComponentInfo copy) throws Exception {
-				((FlowLayoutInfo) panel.getLayout()).add(copy, null);
-			}
-		});
-		assertEditor(
-				"public class Test extends JPanel {",
-				"  public Test() {",
-				"    {",
-				"      JButton button = new JButton();",
-				"      int notConst = 4;",
-				"      button.setBorder(new EmptyBorder(1, 2, 3, notConst));",
-				"      add(button);",
-				"    }",
-				"    {",
-				"      JButton button = new JButton();",
-				"      add(button);",
-				"    }",
-				"  }",
-				"}");
+		doCopyPaste(button, copy -> ((FlowLayoutInfo) panel.getLayout()).add(copy, null));
+		assertEditor("""
+				public class Test extends JPanel {
+					public Test() {
+						{
+							JButton button = new JButton();
+							int notConst = 4;
+							button.setBorder(new EmptyBorder(1, 2, 3, notConst));
+							add(button);
+						}
+						{
+							JButton button = new JButton();
+							add(button);
+						}
+					}
+				}""");
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/tests/DesignerTestCase.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/tests/DesignerTestCase.java
@@ -69,6 +69,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
 
 /**
@@ -498,6 +499,33 @@ public abstract class DesignerTestCase extends Assert {
 				}
 			});
 		}
+	}
+
+	/**
+	 * Convenience method for testing modal dialogs. This method needs to be called
+	 * <b>before</b> the dialog is opened, which then schedules the runnable to be
+	 * executed while the dialog is blocking.<br>
+	 * Note: This method forcefully closes the modal dialog after the runnable has
+	 * been executed, to ensure that it doesn't interfere with the remaining tests.
+	 *
+	 * @param runnable The runnable to execute.
+	 */
+	protected void runWithModalDialog(Runnable runnable) {
+		Set<Shell> originalShells = Set.of(DesignerPlugin.getStandardDisplay().getShells());
+		DesignerPlugin.getStandardDisplay().asyncExec(() -> {
+			try {
+				runnable.run();
+			} catch (Exception e) {
+				e.printStackTrace();
+			} finally {
+				// Dispose the modal dialog
+				for (Shell shell : DesignerPlugin.getStandardDisplay().getShells()) {
+					if (!originalShells.contains(shell)) {
+						shell.dispose();
+					}
+				}
+			}
+		});
 	}
 
 	////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The SWT_AWT bridge is explicitly disposed in the dispose() method, so there is no point to also call it via a dedicated  listeners. Depending on the order in which the listeners are notified, disposing the AWT frame twice may cause an SWT exception on e.g. Windows.

Note: While this issue has always existed, it only shows up now because the order in which the frame is disposed has been changed through https://github.com/eclipse-windowbuilder/windowbuilder/commit/9dd68c7a2dc08e664421a05a4d39df5fbfaf1ad6.

Closes https://github.com/eclipse-windowbuilder/windowbuilder/issues/1049