### PR TITLE
Partially revert fix for Bug 502397

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/nls/edit/EditableSource.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/nls/edit/EditableSource.java
@@ -237,6 +237,11 @@ public final class EditableSource implements IEditableSource {
 		if (oldKey.equals(newKey)) {
 			return;
 		}
+		// check that changing key is used in current form, else
+		// we will break code, because other form will use not existing key
+		if (!m_formKeys.contains(oldKey)) {
+			return;
+		}
 		// check, may be there is already such key in some bundle
 		boolean containsNewKey = false;
 		for (EditableLocaleInfo editableLocale : m_localeToInfo.values()) {


### PR DESCRIPTION
The fix accidentally removed a check that would prevent the key to be changed to an invalid value. Even with this check added back, the user can still use the original translation as key.

See https://bugs.eclipse.org/bugs/show_bug.cgi?id=502397
> Bug 502397 - Provide alternative name generation for NLS keys