### PR TITLE
Repair and restore NLS JUnit tests

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/EditableSupportTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/EditableSupportTest.java
@@ -934,12 +934,12 @@ public class EditableSupportTest extends AbstractNlsTest {
 					new JavaInfo[][]{new JavaInfo[]{frame}, new JavaInfo[]{frame}});
 		}
 		// dispose shell, so cancel dialog
-		new UiContext().executeAndCheck(new FailableRunnable<Exception>() {
+		new UiContext().executeAndCheck(new FailableRunnable<>() {
 			@Override
 			public void run() throws Exception {
 				editableSource.renameKey("frame.name", "frame.title");
 			}
-		}, new FailableConsumer<SWTBot, Exception>() {
+		}, new FailableConsumer<>() {
 			@Override
 			public void accept(SWTBot bot) throws Exception {
 				bot.shell("Confirm").close();
@@ -977,12 +977,12 @@ public class EditableSupportTest extends AbstractNlsTest {
 		IEditableSupport editableSupport = support.getEditable();
 		final IEditableSource editableSource = editableSupport.getEditableSources().get(0);
 		// yes, keep existing value
-		new UiContext().executeAndCheck(new FailableRunnable<Exception>() {
+		new UiContext().executeAndCheck(new FailableRunnable<>() {
 			@Override
 			public void run() throws Exception {
 				editableSource.renameKey("frame.name", "frame.title");
 			}
-		}, new FailableConsumer<SWTBot, Exception>() {
+		}, new FailableConsumer<>() {
 			@Override
 			public void accept(SWTBot bot) throws Exception {
 				bot.shell("Confirm").bot().button("Yes, keep existing value").click();
@@ -1018,12 +1018,12 @@ public class EditableSupportTest extends AbstractNlsTest {
 		IEditableSupport editableSupport = support.getEditable();
 		final IEditableSource editableSource = editableSupport.getEditableSources().get(0);
 		// no, use value of renaming key
-		new UiContext().executeAndCheck(new FailableRunnable<Exception>() {
+		new UiContext().executeAndCheck(new FailableRunnable<>() {
 			@Override
 			public void run() throws Exception {
 				editableSource.renameKey("frame.name", "frame.title");
 			}
-		}, new FailableConsumer<SWTBot, Exception>() {
+		}, new FailableConsumer<>() {
 			@Override
 			public void accept(SWTBot bot) throws Exception {
 				bot.shell("Confirm").bot().button("No, use value of renaming key").click();

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/AbstractDialogTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/AbstractDialogTest.java
@@ -147,7 +147,7 @@ public abstract class AbstractDialogTest extends AbstractNlsUiTest {
 	/**
 	 * Asserts that {@link List} has items's with given titles.
 	 */
-	protected static void assertItems(List list, String[] expectedTitles) {
+	protected static void assertItems(List list, String... expectedTitles) {
 		String[] items = list.getItems();
 		assertEquals(expectedTitles.length, items.length);
 		for (int i = 0; i < items.length; i++) {

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/AbstractDialogTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/AbstractDialogTest.java
@@ -13,24 +13,11 @@
 package org.eclipse.wb.tests.designer.core.nls.ui;
 
 import org.eclipse.wb.internal.core.nls.ui.NlsDialog;
-import org.eclipse.wb.internal.core.nls.ui.SourceComposite;
-import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
-import org.eclipse.wb.internal.core.utils.ui.dialogs.ResizableDialog;
-import org.eclipse.wb.tests.gef.EventSender;
-import org.eclipse.wb.tests.gef.UIRunnable;
-import org.eclipse.wb.tests.gef.UiContext;
 
 import static org.eclipse.swtbot.swt.finder.matchers.WidgetOfType.widgetOfType;
 
-import org.eclipse.swt.graphics.Point;
-import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.List;
-import org.eclipse.swt.widgets.Shell;
-import org.eclipse.swt.widgets.TabFolder;
 import org.eclipse.swt.widgets.TabItem;
-import org.eclipse.swt.widgets.Table;
-import org.eclipse.swt.widgets.TableColumn;
-import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.swtbot.swt.finder.SWTBot;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotList;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTabItem;
@@ -92,145 +79,5 @@ public abstract class AbstractDialogTest extends AbstractNlsUiTest {
 	 */
 	protected static void assertColumns(SWTBotTable table, String... expectedTitles) {
 		assertEquals(table.columns(), Arrays.asList(expectedTitles));
-	}
-
-	/**
-	 * @return the {@link Table} relative location of given item.
-	 */
-	protected static Point getItemLocation(Table table, int column, int row) {
-		// prepare 'x'
-		int x;
-		{
-			x = 0;
-			TableColumn[] columns = table.getColumns();
-			for (int i = 0; i < column; i++) {
-				TableColumn tableColumn = columns[i];
-				x += tableColumn.getWidth();
-			}
-			//
-			x += columns[column].getWidth() / 2;
-		}
-		// prepare 'y'
-		int y = table.getHeaderHeight() + table.getItemHeight() * row + table.getItemHeight() / 2;
-		// return as point
-		return new Point(x, y);
-	}
-
-	/**
-	 * Click on {@link TableItem} with given column/row.
-	 */
-	protected static void clickItem(Table table, int column, int row, int button) throws Exception {
-		Point p = getItemLocation(table, column, row);
-		// do click
-		EventSender eventSender = new EventSender(table);
-		eventSender.postMouseMove(p);
-		EventSender.postMouseDown(1);
-		EventSender.postMouseUp(1);
-		waitEventLoop(10);
-	}
-
-	/**
-	 * Asserts that {@link TabFolder} has {@link TabItem}'s with given titles.
-	 *
-	 * @return the array of {@link TabItem}'s.
-	 */
-	protected static TabItem[] assertItems(TabFolder tabFolder, String... expectedTitles) {
-		TabItem[] items = tabFolder.getItems();
-		assertEquals(expectedTitles.length, items.length);
-		for (int i = 0; i < items.length; i++) {
-			TabItem item = items[i];
-			assertEquals(expectedTitles[i], item.getText());
-		}
-		return items;
-	}
-
-	/**
-	 * Asserts that {@link List} has items's with given titles.
-	 */
-	protected static void assertItems(List list, String... expectedTitles) {
-		String[] items = list.getItems();
-		assertEquals(expectedTitles.length, items.length);
-		for (int i = 0; i < items.length; i++) {
-			String item = items[i];
-			assertEquals(expectedTitles[i], item);
-		}
-	}
-
-	/**
-	 * Asserts that {@link Table} has {@link TableColumn}'s with given titles.
-	 */
-	protected static void assertColumns(Table table, String... expectedTitles) {
-		TableColumn[] columns = table.getColumns();
-		assertEquals(expectedTitles.length, columns.length);
-		for (int i = 0; i < columns.length; i++) {
-			TableColumn column = columns[i];
-			assertEquals(expectedTitles[i], column.getText());
-		}
-	}
-
-	/**
-	 * Asserts that {@link Table} has {@link TableItems}'s with given titles.
-	 */
-	protected static void assertItems(Table table, String[]... expectedTitles2) {
-		TableItem[] items = table.getItems();
-		assertEquals(expectedTitles2.length, items.length);
-		for (int i = 0; i < items.length; i++) {
-			TableItem item = items[i];
-			String[] expectedTitles = expectedTitles2[i];
-			for (int j = 0; j < table.getColumnCount(); j++) {
-				assertEquals(expectedTitles[j], item.getText(j));
-			}
-		}
-	}
-
-	/**
-	 * @return the {@link SourceComposite} corresponding to given {@link TabItem}.
-	 */
-	protected static SourceComposite getSourceComposite(UiContext context, TabItem tabItem) {
-		return UiContext.findFirstWidget(tabItem, SourceComposite.class);
-	}
-
-	/**
-	 * @return the {@link Table} from {@link SourceComposite} corresponding to given {@link TabItem}.
-	 */
-	protected static Table getSourceTable(UiContext context, TabItem tabItem) {
-		SourceComposite sourceComposite = getSourceComposite(context, tabItem);
-		return UiContext.findFirstWidget(sourceComposite, Table.class);
-	}
-
-	////////////////////////////////////////////////////////////////////////////
-	//
-	// "Open" support
-	//
-	////////////////////////////////////////////////////////////////////////////
-	/**
-	 * Runnable for executing operations on {@link NlsDialog}.
-	 */
-	protected static interface NLSDialogRunnable {
-		void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception;
-	}
-
-	/**
-	 * Creates compilation unit, opens Design page, opens NLS dialog and then run given
-	 * {@link NLSDialogRunnable}.
-	 */
-	protected final void openDialogNLS(String initialSource, final NLSDialogRunnable runnable)
-			throws Exception {
-		openDialogNLS("test", initialSource, new UIRunnable() {
-			@Override
-			public void run(UiContext context) throws Exception {
-				Shell activeShell = context.useShell("Externalize strings");
-				NlsDialog dialog = (NlsDialog) activeShell.getData(ResizableDialog.KEY_DIALOG);
-				//
-				try {
-					TabFolder tabFolder = (TabFolder) ReflectionUtils.getFieldObject(dialog, "m_tabFolder");
-					runnable.run(context, dialog, tabFolder);
-				} finally {
-					// click "OK"
-					Button okButton = context.getButtonByText("OK");
-					context.click(okButton);
-				}
-			}
-		});
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/AbstractNlsUiTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/AbstractNlsUiTest.java
@@ -13,15 +13,14 @@
 package org.eclipse.wb.tests.designer.core.nls.ui;
 
 import org.eclipse.wb.tests.designer.swing.SwingGefTest;
-import org.eclipse.wb.tests.gef.UIRunnable;
 import org.eclipse.wb.tests.gef.UiContext;
+import org.eclipse.wb.tests.utils.SWTBotExternalizeDropDownButton;
 
 import static org.eclipse.swtbot.swt.finder.matchers.WithTooltip.withTooltip;
 
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.swt.widgets.ToolItem;
 import org.eclipse.swtbot.swt.finder.SWTBot;
-import org.eclipse.swtbot.swt.finder.widgets.SWTBotToolbarDropDownButton;
 
 import org.apache.commons.lang3.function.FailableBiConsumer;
 import org.apache.commons.lang3.function.FailableConsumer;
@@ -36,7 +35,7 @@ import org.junit.BeforeClass;
  * @author scheglov_ke
  */
 public abstract class AbstractNlsUiTest extends SwingGefTest {
-	protected SWTBotToolbarDropDownButton m_dialogItem;
+	protected SWTBotExternalizeDropDownButton m_dialogItem;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -50,7 +49,7 @@ public abstract class AbstractNlsUiTest extends SwingGefTest {
 			// NLS dialog item
 			SWTBot bot = new SWTBot(m_designerEditor.getRootControl());
 			ToolItem widget = (ToolItem) bot.getFinder().findControls(withTooltip("Externalize strings")).getFirst();
-			m_dialogItem = new SWTBotToolbarDropDownButton(widget);
+			m_dialogItem = new SWTBotExternalizeDropDownButton(widget);
 		}
 	}
 
@@ -59,31 +58,7 @@ public abstract class AbstractNlsUiTest extends SwingGefTest {
 	// Utils
 	//
 	////////////////////////////////////////////////////////////////////////////
-	/**
-	 * Creates compilation unit, opens Design page, opens NLS dialog and then run given
-	 * {@link UIRunnable}.
-	 */
-	protected final void openDialogNLS(String initialSource, UIRunnable runnable) throws Exception {
-		openDialogNLS("test", initialSource, runnable);
-	}
 
-	/**
-	 * Creates compilation unit, opens Design page, opens NLS dialog and then run given
-	 * {@link UIRunnable}.
-	 */
-	protected final void openDialogNLS(String packageName, String initialSource, UIRunnable runnable)
-			throws Exception {
-		ICompilationUnit unit = createModelCompilationUnit(packageName, "Test.java", initialSource);
-		openDesign(unit);
-		// click on "Externalize strings" item
-		new UiContext().executeAndCheck(new UIRunnable() {
-			@Override
-			public void run(UiContext context) throws Exception {
-				context.click(m_dialogItem.widget);
-			}
-		}, runnable);
-	}
-	
 	/**
 	 * Creates compilation unit, opens Design page, opens NLS dialog and then run
 	 * given {@link FailableBiConsumer}.
@@ -104,7 +79,7 @@ public abstract class AbstractNlsUiTest extends SwingGefTest {
 		openDesign(unit);
 		// click on "Externalize strings" item
 		UiContext context = new UiContext();
-		context.executeAndCheck(new FailableRunnable<Exception>() {
+		context.executeAndCheck(new FailableRunnable<>() {
 			@Override
 			public void run() {
 				m_dialogItem.click();

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/NlsDialogTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/NlsDialogTest.java
@@ -15,11 +15,11 @@ package org.eclipse.wb.tests.designer.core.nls.ui;
 import org.eclipse.wb.internal.core.nls.ui.NlsDialog;
 import org.eclipse.wb.tests.gef.UiContext;
 
-import org.eclipse.swt.widgets.TabFolder;
-import org.eclipse.swt.widgets.TabItem;
-import org.eclipse.swt.widgets.Table;
+import org.eclipse.swtbot.swt.finder.SWTBot;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotTabItem;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotTable;
 
-import org.junit.Ignore;
+import org.apache.commons.lang3.function.FailableBiConsumer;
 import org.junit.Test;
 
 /**
@@ -27,7 +27,6 @@ import org.junit.Test;
  *
  * @author scheglov_ke
  */
-@Ignore
 public class NlsDialogTest extends AbstractDialogTest {
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -42,11 +41,13 @@ public class NlsDialogTest extends AbstractDialogTest {
 					public Test() {
 					}
 				}""");
-		openDialogNLS(initialSource, new NLSDialogRunnable() {
+		openDialogNLS(initialSource, new FailableBiConsumer<UiContext, SWTBot, Exception>() {
 			@Override
-			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
-				assertEquals(0, tabFolder.getSelectionIndex());
-				assertItems(tabFolder, "Properties");
+			public void accept(UiContext context, SWTBot bot) {
+				SWTBot shell = bot.shell("Externalize strings").bot();
+				SWTBotTabItem properties = shell.tabItem("Properties");
+				assertTrue(properties.isActive());
+				assertItems(shell, "Properties");
 			}
 		});
 	}
@@ -68,21 +69,28 @@ public class NlsDialogTest extends AbstractDialogTest {
 					public Test() {
 					}
 				}""");
-		openDialogNLS(initialSource, new NLSDialogRunnable() {
+		openDialogNLS(initialSource, new FailableBiConsumer<UiContext, SWTBot, Exception>() {
 			@Override
-			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
-				assertEquals(2, tabFolder.getSelectionIndex());
-				TabItem[] tabItems =
-						assertItems(tabFolder, "test.messages", "test.messages2", "Properties");
+			public void accept(UiContext context, SWTBot bot) {
+				SWTBot shell = bot.shell("Externalize strings").bot();
+				assertItems(shell, "test.messages", "test.messages2", "Properties");
+				SWTBotTabItem messagesTab = shell.tabItem("test.messages");
+				assertFalse(messagesTab.isActive());
+				SWTBotTabItem messages2Tab = shell.tabItem("test.messages2");
+				assertFalse(messages2Tab.isActive());
+				SWTBotTabItem properties = shell.tabItem("Properties");
+				assertTrue(properties.isActive());
 				// check possible sources: 0
 				{
-					Table table = getSourceTable(context, tabItems[0]);
+					messagesTab.activate();
+					SWTBotTable table = shell.tableWithLabel("Strings:");
 					assertColumns(table, "Key", "(default)");
 					assertItems(table, new String[] { "frame.title", "My JFrame" });
 				}
 				// check possible sources: 1
 				{
-					Table table = getSourceTable(context, tabItems[1]);
+					messages2Tab.activate();
+					SWTBotTable table = shell.tableWithLabel("Strings:");
 					assertColumns(table, "Key", "(default)");
 					assertItems(table, new String[] { "frame.name", "My name" });
 				}
@@ -105,13 +113,15 @@ public class NlsDialogTest extends AbstractDialogTest {
 						setTitle(ResourceBundle.getBundle("test.messages").getString("frame.title")); //$NON-NLS-1$ //$NON-NLS-2$
 					}
 				}""");
-		openDialogNLS(initialSource, new NLSDialogRunnable() {
+		openDialogNLS(initialSource, new FailableBiConsumer<UiContext, SWTBot, Exception>() {
 			@Override
-			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
-				assertEquals(0, tabFolder.getSelectionIndex());
-				TabItem[] tabItems = assertItems(tabFolder, "test.messages", "Properties");
+			public void accept(UiContext context, SWTBot bot) {
+				SWTBot shell = bot.shell("Externalize strings").bot();
+				assertItems(shell, "test.messages", "Properties");
+				SWTBotTabItem messagesTab = shell.tabItem("test.messages");
+				assertTrue(messagesTab.isActive());
 				// check source
-				Table table = getSourceTable(context, tabItems[0]);
+				SWTBotTable table = shell.tableWithLabel("Strings:");
 				assertColumns(table, "Key", "(default)", "it");
 				assertItems(table,
 						new String[] { "frame.name", "My name", "" },

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/NlsDialogTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/NlsDialogTest.java
@@ -46,7 +46,7 @@ public class NlsDialogTest extends AbstractDialogTest {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
 				assertEquals(0, tabFolder.getSelectionIndex());
-				assertItems(tabFolder, new String[]{"Properties"});
+				assertItems(tabFolder, "Properties");
 			}
 		});
 	}
@@ -73,18 +73,18 @@ public class NlsDialogTest extends AbstractDialogTest {
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
 				assertEquals(2, tabFolder.getSelectionIndex());
 				TabItem[] tabItems =
-						assertItems(tabFolder, new String[]{"test.messages", "test.messages2", "Properties"});
+						assertItems(tabFolder, "test.messages", "test.messages2", "Properties");
 				// check possible sources: 0
 				{
 					Table table = getSourceTable(context, tabItems[0]);
-					assertColumns(table, new String[]{"Key", "(default)"});
-					assertItems(table, new String[][]{new String[]{"frame.title", "My JFrame"}});
+					assertColumns(table, "Key", "(default)");
+					assertItems(table, new String[] { "frame.title", "My JFrame" });
 				}
 				// check possible sources: 1
 				{
 					Table table = getSourceTable(context, tabItems[1]);
-					assertColumns(table, new String[]{"Key", "(default)"});
-					assertItems(table, new String[][]{new String[]{"frame.name", "My name"}});
+					assertColumns(table, "Key", "(default)");
+					assertItems(table, new String[] { "frame.name", "My name" });
 				}
 			}
 		});
@@ -109,13 +109,13 @@ public class NlsDialogTest extends AbstractDialogTest {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
 				assertEquals(0, tabFolder.getSelectionIndex());
-				TabItem[] tabItems = assertItems(tabFolder, new String[]{"test.messages", "Properties"});
+				TabItem[] tabItems = assertItems(tabFolder, "test.messages", "Properties");
 				// check source
 				Table table = getSourceTable(context, tabItems[0]);
-				assertColumns(table, new String[]{"Key", "(default)", "it"});
-				assertItems(table, new String[][]{
-					new String[]{"frame.name", "My name", ""},
-					new String[]{"frame.title", "My JFrame", "My JFrame IT"},});
+				assertColumns(table, "Key", "(default)", "it");
+				assertItems(table,
+						new String[] { "frame.name", "My name", "" },
+						new String[] { "frame.title", "My JFrame", "My JFrame IT" });
 			}
 		});
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/PropertiesCompositeTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/PropertiesCompositeTest.java
@@ -56,7 +56,7 @@ public class PropertiesCompositeTest extends AbstractDialogTest {
 		openDialogNLS(initialSource, new NLSDialogRunnable() {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
-				TabItem[] tabItems = assertItems(tabFolder, new String[]{"Properties"});
+				TabItem[] tabItems = assertItems(tabFolder, "Properties");
 				List sourcesList = UiContext.findFirstWidget(tabItems[0], List.class);
 				assertEquals(0, sourcesList.getItemCount());
 			}
@@ -84,14 +84,13 @@ public class PropertiesCompositeTest extends AbstractDialogTest {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
 				TabItem[] tabItems =
-						assertItems(tabFolder, new String[]{"test.messages", "test.messages2", "Properties"});
+						assertItems(tabFolder, "test.messages", "test.messages2", "Properties");
 				List sourcesList = UiContext.findFirstWidget(tabItems[2], List.class);
 				//
 				assertItems(
 						sourcesList,
-						new String[]{
-								"test.messages (Direct ResourceBundle usage)",
-						"test.messages2 (Direct ResourceBundle usage)"});
+						"test.messages (Direct ResourceBundle usage)",
+						"test.messages2 (Direct ResourceBundle usage)");
 			}
 		});
 	}
@@ -114,10 +113,10 @@ public class PropertiesCompositeTest extends AbstractDialogTest {
 		openDialogNLS(initialSource, new NLSDialogRunnable() {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
-				TabItem[] tabItems = assertItems(tabFolder, new String[]{"test.messages", "Properties"});
+				TabItem[] tabItems = assertItems(tabFolder, "test.messages", "Properties");
 				List sourcesList = UiContext.findFirstWidget(tabItems[1], List.class);
 				//
-				assertItems(sourcesList, new String[]{"test.messages (Direct ResourceBundle usage)"});
+				assertItems(sourcesList, "test.messages (Direct ResourceBundle usage)");
 			}
 		});
 	}
@@ -142,7 +141,7 @@ public class PropertiesCompositeTest extends AbstractDialogTest {
 		openDialogNLS(initialSource, new NLSDialogRunnable() {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
-				TabItem[] tabItems = assertItems(tabFolder, new String[]{"test.messages", "Properties"});
+				TabItem[] tabItems = assertItems(tabFolder, "test.messages", "Properties");
 				PropertiesComposite propertiesComposite = (PropertiesComposite) tabItems[1].getControl();
 				// sources list
 				List sourcesList = UiContext.findFirstWidget(propertiesComposite, List.class);
@@ -156,24 +155,23 @@ public class PropertiesCompositeTest extends AbstractDialogTest {
 				// check content on properties tree
 				{
 					assertNotNull(
-							getItem(propertiesTree, new String[]{"(javax.swing.JFrame)", "title: My JFrame"}));
+							getItem(propertiesTree, "(javax.swing.JFrame)", "title: My JFrame"));
 					assertNotNull(
 							getItem(
 									propertiesTree,
-									new String[]{
-											"(javax.swing.JFrame)",
-											"getContentPane()",
-											"button",
-									"text: New button"}));
+									"(javax.swing.JFrame)",
+									"getContentPane()",
+									"button",
+									"text: New button"));
 					assertNull(
 							getItem(
 									propertiesTree,
-									new String[]{"(javax.swing.JFrame)", "getContentPane()", "textField"}));
+									"(javax.swing.JFrame)", "getContentPane()", "textField"));
 				}
 				// prepare TreeItem's
 				TreeItem buttonItem = getItem(
 						propertiesTree,
-						new String[]{"(javax.swing.JFrame)", "getContentPane()", "button"});
+						"(javax.swing.JFrame)", "getContentPane()", "button");
 				TreeItem buttonTextItem = getItem(buttonItem, new String[]{"text: New button"}, 0);
 				// set checked "button" item
 				{
@@ -220,17 +218,16 @@ public class PropertiesCompositeTest extends AbstractDialogTest {
 					assertNull(
 							getItem(
 									propertiesTree,
-									new String[]{
-											"(javax.swing.JFrame)",
-											"getContentPane()",
-											"button",
-									"text: New button"}));
+									"(javax.swing.JFrame)",
+									"getContentPane()",
+									"button", 
+									"text: New button"));
 					assertNull(
 							getItem(
 									propertiesTree,
-									new String[]{"(javax.swing.JFrame)", "getContentPane()", "button"}));
+									"(javax.swing.JFrame)", "getContentPane()", "button"));
 					assertNull(
-							getItem(propertiesTree, new String[]{"(javax.swing.JFrame)", "getContentPane()"}));
+							getItem(propertiesTree, "(javax.swing.JFrame)", "getContentPane()"));
 					// check IEditableSource
 					IEditableSource editableSource = (IEditableSource) ReflectionUtils.invokeMethod(
 							propertiesComposite,
@@ -262,7 +259,7 @@ public class PropertiesCompositeTest extends AbstractDialogTest {
 		openDialogNLS(initialSource, new NLSDialogRunnable() {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
-				TabItem[] tabItems = assertItems(tabFolder, new String[]{"Properties"});
+				TabItem[] tabItems = assertItems(tabFolder, "Properties");
 				List sourcesList = UiContext.findFirstWidget(tabItems[0], List.class);
 				assertEquals(0, sourcesList.getItemCount());
 				//
@@ -290,7 +287,7 @@ public class PropertiesCompositeTest extends AbstractDialogTest {
 	/**
 	 * @return {@link TreeItem} of given {@link Tree} on given path.
 	 */
-	private static TreeItem getItem(Tree tree, String[] pathElements) {
+	private static TreeItem getItem(Tree tree, String... pathElements) {
 		TreeItem[] treeItems = tree.getItems();
 		assertTrue(treeItems.length <= 1);
 		if (treeItems.length == 1) {

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/utils/SWTBotExternalizeDropDownButton.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/utils/SWTBotExternalizeDropDownButton.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Patrick Ziegler
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.tests.utils;
+
+import org.eclipse.wb.internal.core.nls.ExternalizeStringsContributionItem;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Menu;
+import org.eclipse.swt.widgets.ToolBar;
+import org.eclipse.swt.widgets.ToolItem;
+import org.eclipse.swtbot.swt.finder.SWTBot;
+import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
+import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotRootMenu;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotToolbarDropDownButton;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Wrapped for the {@code Externalize} {@link ToolBar} button to allow access
+ * when not in the UI thread.
+ */
+public class SWTBotExternalizeDropDownButton extends SWTBotToolbarDropDownButton {
+	public SWTBotExternalizeDropDownButton(ToolItem w) {
+		super(w);
+	}
+
+	/**
+	 * Gets the "{@code Externalize} menu of this widget.
+	 */
+	public SWTBotRootMenu externalizeMenu() throws WidgetNotFoundException {
+		// Set-up
+		Menu[] menu = new Menu[1];
+
+		Listener l = new Listener() {
+			@Override
+			public void handleEvent(Event event) {
+				if (event.widget instanceof Menu m) {
+					menu[0] = m;
+				}
+			}
+		};
+		// Open menu
+		try {
+			syncExec(() -> display.addFilter(SWT.Show, l));
+
+			asyncExec(() -> widget.notifyListeners(SWT.Selection, createArrowEvent()));
+
+			new SWTBot().waitUntil(new WaitForMenu(menu));
+
+			return new SWTBotRootMenu(menu[0]);
+		} finally {
+			syncExec(() -> display.removeFilter(SWT.Show, l));
+		}
+	}
+
+	private static class WaitForMenu extends DefaultCondition {
+		private final Menu[] menu;
+
+		public WaitForMenu(Menu[] menu) {
+			assertEquals(menu.length, 1, "Menu array must be of length 1: " + menu.length);
+			this.menu = menu;
+		}
+
+		@Override
+		public boolean test() throws Exception {
+			return menu[0] != null;
+		}
+
+		@Override
+		public String getFailureMessage() {
+			return "Unable to find \"Externalize\" context menu";
+		}
+	}
+
+	/**
+	 * Used to notify
+	 * {@link ExternalizeStringsContributionItem#handleClick(ToolBar,Event)}
+	 */
+	private static Event createArrowEvent() {
+		Event event = new Event();
+		event.detail = SWT.ARROW;
+		return event;
+	}
+}
+


### PR DESCRIPTION
Those tests were previously disabled because they caused a deadlock while opening a modal dialog. By integrating SWTBot into our own UiContext class, we can avoid this problem.