### PR TITLE
Finalize changes to be compatible with Java 24

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/DesignerPlugin.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/DesignerPlugin.java
@@ -67,7 +67,9 @@ public class DesignerPlugin extends AbstractUIPlugin {
 		}
 		try {
 			// https://github.com/eclipse-windowbuilder/windowbuilder/issues/1027
-			exportAllModulesToAllModules();
+			if (EnvironmentUtils.isBurningWaveEnabled()) {
+				exportAllModulesToAllModules();
+			}
 		} catch (Throwable e) {
 			log(e);
 		}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/EnvironmentUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/EnvironmentUtils.java
@@ -223,4 +223,15 @@ public final class EnvironmentUtils extends AbstractUIPlugin {
 	public static boolean isGefPalette() {
 		return Boolean.getBoolean(WBP_GEF_PALETTE);
 	}
+
+	////////////////////////////////////////////////////////////////////////////
+	//
+	// Testing
+	//
+	////////////////////////////////////////////////////////////////////////////
+	private static final String WBP_BURNINGWAVE = "wbp.burningwave.enabled";
+
+	public static boolean isBurningWaveEnabled() {
+		return Boolean.valueOf(System.getProperty(WBP_BURNINGWAVE, Boolean.TRUE.toString()));
+	}
 }

--- a/org.eclipse.wb.tests/pom.xml
+++ b/org.eclipse.wb.tests/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2021, 2024, vogella GmbH
+  Copyright (c) 2021, 2025, vogella GmbH and others.
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
@@ -21,7 +21,10 @@
   <version>1.7.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
- 
+	<properties>
+		<uitest.vmparams>-Dwbp.burningwave.enabled=false</uitest.vmparams>
+	</properties>
+
 	<profiles>
 		<profile>
 			<id>macosx</id>


### PR DESCRIPTION
This removes the changes done to the ReflectionUtils class that were made to solve the IllegalAccessException thrown when BurningWave is disabled (primarily the use of MethodHandles and the FieldUtils class) and simply tries to set the "accessible" flag via trySetAcccessible().

Furthermore, BurningWave can now be disabled at launch via a system property, which is enabled by default and explicitly disabled for the tests.

Contributes to
https://github.com/eclipse-windowbuilder/windowbuilder/issues/1027