### PR TITLE
Repair and execute SourceCompositeTest

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/nls/ui/SourceComposite.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/nls/ui/SourceComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -47,11 +47,14 @@ import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CLabel;
+import org.eclipse.swt.events.MouseAdapter;
+import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.TraverseEvent;
 import org.eclipse.swt.events.TraverseListener;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
@@ -363,6 +366,14 @@ public final class SourceComposite extends Composite {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	private void setViewerMenu() {
+		final int[] column = new int[1];
+		m_table.addMouseListener(new MouseAdapter() {
+			@Override
+			public void mouseDown(MouseEvent e) {
+				Point pt = new Point(e.x, e.y);
+				column[0] = UiUtils.getColumnAt(m_table, pt);
+			}
+		});
 		// prepare manager
 		MenuManager menuManager = new MenuManager(null);
 		menuManager.setRemoveAllWhenShown(true);
@@ -411,12 +422,11 @@ public final class SourceComposite extends Composite {
 					}
 				});
 				// "Remove locale" action
-				final int column = UiUtils.getColumnUnderCursor(m_table);
 				{
 					Action action = new Action(Messages.SourceComposite_removeLocaleAction) {
 						@Override
 						public void run() {
-							final LocaleInfo locale = m_locales[column - 1];
+							final LocaleInfo locale = m_locales[column[0] - 1];
 							// ask confirmation
 							if (!MessageDialog.openConfirm(
 									getShell(),
@@ -437,7 +447,7 @@ public final class SourceComposite extends Composite {
 							});
 						}
 					};
-					action.setEnabled(column > 1 && column < m_table.getColumnCount());
+					action.setEnabled(column[0] > 1 && column[0] < m_table.getColumnCount());
 					manager.add(action);
 				}
 			}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/ui/UiUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/ui/UiUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -190,14 +190,6 @@ public class UiUtils {
 	// Table utils
 	//
 	////////////////////////////////////////////////////////////////////////////
-	/**
-	 * @return the index of {@link TableColumn} in given {@link Table} that is under mouse cursor.
-	 */
-	public static int getColumnUnderCursor(Table table) {
-		Point p = Display.getCurrent().getCursorLocation();
-		p = table.toControl(p);
-		return getColumnAt(table, p);
-	}
 
 	/**
 	 * @return the index of {@link TableColumn} in given {@link Table} that is under given

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/AbstractDialogTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/AbstractDialogTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -20,6 +20,8 @@ import org.eclipse.wb.tests.gef.EventSender;
 import org.eclipse.wb.tests.gef.UIRunnable;
 import org.eclipse.wb.tests.gef.UiContext;
 
+import static org.eclipse.swtbot.swt.finder.matchers.WidgetOfType.widgetOfType;
+
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.List;
@@ -29,6 +31,12 @@ import org.eclipse.swt.widgets.TabItem;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
+import org.eclipse.swtbot.swt.finder.SWTBot;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotList;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotTabItem;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotTable;
+
+import java.util.Arrays;
 
 /**
  * Abstract test for {@link NlsDialog}.
@@ -41,6 +49,51 @@ public abstract class AbstractDialogTest extends AbstractNlsUiTest {
 	// Utils
 	//
 	////////////////////////////////////////////////////////////////////////////
+	/**
+	 * Asserts that {@link SWTBot} has {@link TabItem}'s with given titles.
+	 *
+	 * @return the array of {@link TabItem}'s.
+	 */
+	protected static void assertItems(SWTBot shell, String... expectedTitles) {
+		java.util.List<TabItem> items = shell.getFinder().findControls(widgetOfType(TabItem.class));
+		assertEquals(expectedTitles.length, items.size());
+		for (int i = 0; i < items.size(); i++) {
+			SWTBotTabItem item = new SWTBotTabItem(items.get(i));
+			assertEquals(expectedTitles[i], item.getText());
+		}
+	}
+
+	/**
+	 * Asserts that {@link List} has items's with given titles.
+	 */
+	protected static void assertItems(SWTBotList list, String... expectedTitles) {
+		String[] items = list.getItems();
+		assertEquals(expectedTitles.length, items.length);
+		for (int i = 0; i < items.length; i++) {
+			String item = items[i];
+			assertEquals(expectedTitles[i], item);
+		}
+	}
+
+	/**
+	 * Asserts that {@link SWTBotTable} has {@code TableItems}'s with given items.
+	 */
+	protected static void assertItems(SWTBotTable table, String[]... expectedItems) {
+		assertEquals(expectedItems.length, table.rowCount());
+		for (int i = 0; i < table.rowCount(); i++) {
+			for (int j = 0; j < table.columnCount(); j++) {
+				assertEquals(expectedItems[i][j], table.cell(i, j));
+			}
+		}
+	}
+
+	/**
+	 * Asserts that {@link SWTBotTable} has {@code TableColumn}'s with given titles.
+	 */
+	protected static void assertColumns(SWTBotTable table, String... expectedTitles) {
+		assertEquals(table.columns(), Arrays.asList(expectedTitles));
+	}
+
 	/**
 	 * @return the {@link Table} relative location of given item.
 	 */

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/AbstractDialogTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/AbstractDialogTest.java
@@ -81,7 +81,7 @@ public abstract class AbstractDialogTest extends AbstractNlsUiTest {
 	 *
 	 * @return the array of {@link TabItem}'s.
 	 */
-	protected static TabItem[] assertItems(TabFolder tabFolder, String[] expectedTitles) {
+	protected static TabItem[] assertItems(TabFolder tabFolder, String... expectedTitles) {
 		TabItem[] items = tabFolder.getItems();
 		assertEquals(expectedTitles.length, items.length);
 		for (int i = 0; i < items.length; i++) {
@@ -106,7 +106,7 @@ public abstract class AbstractDialogTest extends AbstractNlsUiTest {
 	/**
 	 * Asserts that {@link Table} has {@link TableColumn}'s with given titles.
 	 */
-	protected static void assertColumns(Table table, String[] expectedTitles) {
+	protected static void assertColumns(Table table, String... expectedTitles) {
 		TableColumn[] columns = table.getColumns();
 		assertEquals(expectedTitles.length, columns.length);
 		for (int i = 0; i < columns.length; i++) {
@@ -118,7 +118,7 @@ public abstract class AbstractDialogTest extends AbstractNlsUiTest {
 	/**
 	 * Asserts that {@link Table} has {@link TableItems}'s with given titles.
 	 */
-	protected static void assertItems(Table table, String[][] expectedTitles2) {
+	protected static void assertItems(Table table, String[]... expectedTitles2) {
 		TableItem[] items = table.getItems();
 		assertEquals(expectedTitles2.length, items.length);
 		for (int i = 0; i < items.length; i++) {

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/ContributionItemTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/ContributionItemTest.java
@@ -63,7 +63,7 @@ public class ContributionItemTest extends AbstractNlsUiTest {
 			// check locales combo, and switch to "it" locale
 			assertNotNull("NLS dialog item not found.", m_dialogItem);
 			// initialize menu creation
-			context.click(m_dialogItem, SWT.ARROW);
+			context.click(m_dialogItem.widget, SWT.ARROW);
 			// find locales menu inside display popups
 			Menu localesMenu = context.getLastPopup();
 			assertNotNull("Can not find locales menu.", localesMenu);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/SourceCompositeTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/SourceCompositeTest.java
@@ -70,7 +70,7 @@ public class SourceCompositeTest extends AbstractDialogTest {
 		openDialogNLS(initialSource, new NLSDialogRunnable() {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
-				TabItem[] tabItems = assertItems(tabFolder, new String[]{"test.messages", "Properties"});
+				TabItem[] tabItems = assertItems(tabFolder, "test.messages", "Properties");
 				Table table = getSourceTable(context, tabItems[0]);
 				// prepare provider
 				ITableTooltipProvider provider;
@@ -83,9 +83,8 @@ public class SourceCompositeTest extends AbstractDialogTest {
 				// check items
 				assertItems(
 						table,
-						new String[][]{
-							new String[]{"frame.name", "My name"},
-							new String[]{"frame.title", "My JFrame"},});
+						new String[] { "frame.name", "My name" },
+						new String[] { "frame.title", "My JFrame" });
 				//
 				Shell newShell = new Shell();
 				try {
@@ -137,7 +136,7 @@ public class SourceCompositeTest extends AbstractDialogTest {
 		openDialogNLS(initialSource, new NLSDialogRunnable() {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
-				TabItem[] tabItems = assertItems(tabFolder, new String[]{"test.messages", "Properties"});
+				TabItem[] tabItems = assertItems(tabFolder, "test.messages", "Properties");
 				Table table = getSourceTable(context, tabItems[0]);
 				Menu tableMenu = table.getMenu();
 				EventSender eventSender = new EventSender(table);
@@ -164,9 +163,8 @@ public class SourceCompositeTest extends AbstractDialogTest {
 					// check items
 					assertItems(
 							table,
-							new String[][]{
-								new String[]{"frame.name", "My name", "My name IT"},
-								new String[]{"frame.title", "My JFrame", "My JFrame IT"},});
+							new String[] { "frame.name", "My name", "My name IT" },
+							new String[] { "frame.title", "My JFrame", "My JFrame IT" });
 				}
 				// confirm
 				{
@@ -186,9 +184,8 @@ public class SourceCompositeTest extends AbstractDialogTest {
 					// check items
 					assertItems(
 							table,
-							new String[][]{
-								new String[]{"frame.name", "My name"},
-								new String[]{"frame.title", "My JFrame"},});
+							new String[] { "frame.name", "My name" },
+							new String[] { "frame.title", "My JFrame" });
 				}
 			}
 		});
@@ -211,7 +208,7 @@ public class SourceCompositeTest extends AbstractDialogTest {
 		openDialogNLS(initialSource, new NLSDialogRunnable() {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
-				TabItem[] tabItems = assertItems(tabFolder, new String[]{"test.messages", "Properties"});
+				TabItem[] tabItems = assertItems(tabFolder, "test.messages", "Properties");
 				Table table = getSourceTable(context, tabItems[0]);
 				Menu tableMenu = table.getMenu();
 				EventSender eventSender = new EventSender(table);
@@ -237,7 +234,7 @@ public class SourceCompositeTest extends AbstractDialogTest {
 						}
 					});
 					// check items
-					assertItems(table, new String[][]{new String[]{"frame.title", "My JFrame"}});
+					assertItems(table, new String[] { "frame.title", "My JFrame" });
 				}
 				// confirm
 				{
@@ -255,7 +252,7 @@ public class SourceCompositeTest extends AbstractDialogTest {
 						}
 					});
 					// check items
-					assertItems(table, new String[][]{});
+					assertItems(table /* , <no elements> */);
 				}
 			}
 		});
@@ -285,7 +282,7 @@ public class SourceCompositeTest extends AbstractDialogTest {
 		openDialogNLS(initialSource, new NLSDialogRunnable() {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
-				TabItem[] tabItems = assertItems(tabFolder, new String[]{"test.messages", "Properties"});
+				TabItem[] tabItems = assertItems(tabFolder, "test.messages", "Properties");
 				Table table = getSourceTable(context, tabItems[0]);
 				Menu tableMenu = table.getMenu();
 				EventSender eventSender = new EventSender(table);
@@ -321,8 +318,8 @@ public class SourceCompositeTest extends AbstractDialogTest {
 					}
 				});
 				// check items
-				assertColumns(table, new String[]{"Key", "(default)", "it"});
-				assertItems(table, new String[][]{new String[]{"frame.title", "My JFrame", "My JFrame"},});
+				assertColumns(table, "Key", "(default)", "it");
+				assertItems(table, new String[] { "frame.title", "My JFrame", "My JFrame" });
 			}
 		});
 		// we should have new locale - 'it'
@@ -398,7 +395,7 @@ public class SourceCompositeTest extends AbstractDialogTest {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
 				assertEquals(0, tabFolder.getSelectionIndex());
-				TabItem[] tabItems = assertItems(tabFolder, new String[]{"test.messages", "Properties"});
+				TabItem[] tabItems = assertItems(tabFolder, "test.messages", "Properties");
 				//
 				SourceComposite sourceComposite = getSourceComposite(context, tabItems[0]);
 				IEditableSource editableSource =
@@ -406,8 +403,8 @@ public class SourceCompositeTest extends AbstractDialogTest {
 				Table table = getSourceTable(context, tabItems[0]);
 				// check initial items
 				{
-					assertColumns(table, new String[]{"Key", "(default)", "it"});
-					assertItems(table, new String[][]{new String[]{"frame.title", "My JFrame", ""},});
+					assertColumns(table, "Key", "(default)", "it");
+					assertItems(table, new String[] { "frame.title", "My JFrame", "" });
 				}
 				// click to activate cell editor
 				{
@@ -426,7 +423,7 @@ public class SourceCompositeTest extends AbstractDialogTest {
 					assertTrue(editableSource.getKeys().contains("frame.title"));
 					assertEquals("New title", editableSource.getValue(LocaleInfo.DEFAULT, "frame.title"));
 					//
-					assertItems(table, new String[][]{new String[]{"frame.title", "New title", ""},});
+					assertItems(table, new String[] { "frame.title", "New title", "" });
 				}
 				// rename key
 				{
@@ -442,7 +439,7 @@ public class SourceCompositeTest extends AbstractDialogTest {
 						assertTrue(editableSource.getKeys().contains("frame.title2"));
 						assertEquals("New title", editableSource.getValue(LocaleInfo.DEFAULT, "frame.title2"));
 						//
-						assertItems(table, new String[][]{new String[]{"frame.title2", "New title", ""},});
+						assertItems(table, new String[] { "frame.title2", "New title", "" });
 					}
 				}
 				// update 'it'
@@ -461,7 +458,7 @@ public class SourceCompositeTest extends AbstractDialogTest {
 						assertEquals("title IT", editableSource.getValue(localeInfo, "frame.title2"));
 						assertItems(
 								table,
-								new String[][]{new String[]{"frame.title2", "New title", "title IT"},});
+								new String[] { "frame.title2", "New title", "title IT" });
 					}
 				}
 				// wait UI
@@ -487,7 +484,7 @@ public class SourceCompositeTest extends AbstractDialogTest {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
 				assertEquals(0, tabFolder.getSelectionIndex());
-				TabItem[] tabItems = assertItems(tabFolder, new String[]{"test.messages", "Properties"});
+				TabItem[] tabItems = assertItems(tabFolder, "test.messages", "Properties");
 				//
 				SourceComposite sourceComposite = getSourceComposite(context, tabItems[0]);
 				IEditableSource editableSource =
@@ -495,8 +492,8 @@ public class SourceCompositeTest extends AbstractDialogTest {
 				Table table = getSourceTable(context, tabItems[0]);
 				// check initial items
 				{
-					assertColumns(table, new String[]{"Key", "(default)"});
-					assertItems(table, new String[][]{new String[]{"frame.title", "My JFrame"},});
+					assertColumns(table, "Key", "(default)");
+					assertItems(table, new String[] { "frame.title", "My JFrame" });
 				}
 				// externalize "name"
 				{
@@ -506,12 +503,11 @@ public class SourceCompositeTest extends AbstractDialogTest {
 				}
 				// check items
 				{
-					assertColumns(table, new String[]{"Key", "(default)"});
+					assertColumns(table, "Key", "(default)");
 					assertItems(
 							table,
-							new String[][]{
-								new String[]{"frame.title", "My JFrame"},
-								new String[]{"Test.this.name", "My name"}});
+							new String[] { "frame.title", "My JFrame" },
+							new String[] { "Test.this.name", "My name" });
 				}
 			}
 		});
@@ -536,7 +532,7 @@ public class SourceCompositeTest extends AbstractDialogTest {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
 				assertEquals(0, tabFolder.getSelectionIndex());
-				TabItem[] tabItems = assertItems(tabFolder, new String[]{"test.messages", "Properties"});
+				TabItem[] tabItems = assertItems(tabFolder, "test.messages", "Properties");
 				//
 				SourceComposite sourceComposite = getSourceComposite(context, tabItems[0]);
 				final IEditableSource editableSource =
@@ -544,12 +540,11 @@ public class SourceCompositeTest extends AbstractDialogTest {
 				Table table = getSourceTable(context, tabItems[0]);
 				// check initial items
 				{
-					assertColumns(table, new String[]{"Key", "(default)"});
+					assertColumns(table, "Key", "(default)");
 					assertItems(
 							table,
-							new String[][]{
-								new String[]{"frame.name", "My name"},
-								new String[]{"frame.title", "My JFrame"},});
+							new String[] { "frame.name", "My name" },
+							new String[] { "frame.title", "My JFrame" });
 				}
 				// rename "frame.name" -> "frame.title"
 				context.executeAndCheck(new UIRunnable() {
@@ -567,8 +562,8 @@ public class SourceCompositeTest extends AbstractDialogTest {
 				});
 				// check items
 				{
-					assertColumns(table, new String[]{"Key", "(default)"});
-					assertItems(table, new String[][]{new String[]{"frame.title", "My JFrame"}});
+					assertColumns(table, "Key", "(default)");
+					assertItems(table, new String[] { "frame.title", "My JFrame" });
 				}
 			}
 		});
@@ -592,7 +587,7 @@ public class SourceCompositeTest extends AbstractDialogTest {
 			@Override
 			public void run(UiContext context, NlsDialog dialog, TabFolder tabFolder) throws Exception {
 				assertEquals(0, tabFolder.getSelectionIndex());
-				TabItem[] tabItems = assertItems(tabFolder, new String[]{"test.messages", "Properties"});
+				TabItem[] tabItems = assertItems(tabFolder, "test.messages", "Properties");
 				//
 				//waitEventLoop(5000);
 				SourceComposite sourceComposite = getSourceComposite(context, tabItems[0]);
@@ -600,9 +595,8 @@ public class SourceCompositeTest extends AbstractDialogTest {
 				// check initial items
 				assertItems(
 						table,
-						new String[][]{
-							new String[]{"frame.name", "My name"},
-							new String[]{"frame.title", "My JFrame"},});
+						new String[] { "frame.name", "My name" },
+						new String[] { "frame.title", "My JFrame" });
 				// check "Show strings only for current form"
 				{
 					Button onlyFormButton =
@@ -611,7 +605,7 @@ public class SourceCompositeTest extends AbstractDialogTest {
 					context.click(onlyFormButton);
 				}
 				// only 'frame.title' expected
-				assertItems(table, new String[][]{new String[]{"frame.title", "My JFrame"}});
+				assertItems(table, new String[] { "frame.title", "My JFrame" });
 			}
 		});
 	}
@@ -640,9 +634,8 @@ public class SourceCompositeTest extends AbstractDialogTest {
 				// check initial items
 				assertItems(
 						table,
-						new String[][]{
-							new String[]{"key.1", "1 1", "1 2"},
-							new String[]{"key.2", "2 1", "2 2"},});
+						new String[] { "key.1", "1 1", "1 2" },
+						new String[] { "key.2", "2 1", "2 2" });
 				// check next column
 				{
 					// activate editor at (1, 0)
@@ -656,9 +649,8 @@ public class SourceCompositeTest extends AbstractDialogTest {
 					// check
 					assertItems(
 							table,
-							new String[][]{
-								new String[]{"key.1", "1 1", "a b"},
-								new String[]{"key.2", "2 1", "2 2"},});
+							new String[] { "key.1", "1 1", "a b" },
+							new String[] { "key.2", "2 1", "2 2" });
 				}
 				// check next row
 				{
@@ -673,9 +665,8 @@ public class SourceCompositeTest extends AbstractDialogTest {
 					// check
 					assertItems(
 							table,
-							new String[][]{
-								new String[]{"key.1", "1 1", "a b"},
-								new String[]{"key.2", "2 1", "b b"},});
+							new String[] { "key.1", "1 1", "a b" },
+							new String[] { "key.2", "2 1", "b b" });
 				}
 				// prev column/row
 				{
@@ -692,9 +683,8 @@ public class SourceCompositeTest extends AbstractDialogTest {
 					waitEventLoop(10);
 					assertItems(
 							table,
-							new String[][]{
-								new String[]{"key.1", "a a", "a b"},
-								new String[]{"key.2", "b a", "b b"},});
+							new String[] { "key.1", "a a", "a b" },
+							new String[] { "key.2", "b a", "b b" });
 				}
 			}
 		});

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/utils/SWTBotCTableCombo.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/utils/SWTBotCTableCombo.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Patrick Ziegler
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.tests.utils;
+
+import org.eclipse.wb.core.controls.CTableCombo;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBot;
+
+/**
+ * Wrapped for the {@link CTableCombo} to allow access when not in the UI
+ * thread.
+ */
+public class SWTBotCTableCombo extends AbstractSWTBot<CTableCombo> {
+	public SWTBotCTableCombo(CTableCombo w) {
+		super(w);
+	}
+
+	public int getItemCount() {
+		return syncExec(widget::getItemCount);
+	}
+
+	public String getItem(int i) {
+		return syncExec(() -> widget.getItem(i));
+	}
+
+	public void select(int i) {
+		syncExec(() -> {
+			widget.select(i);
+			widget.notifyListeners(SWT.Selection, null);
+		});
+	}
+}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/utils/SWTBotEditableSource.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/utils/SWTBotEditableSource.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Patrick Ziegler
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.tests.utils;
+
+import org.eclipse.wb.internal.core.nls.edit.IEditableSource;
+import org.eclipse.wb.internal.core.nls.edit.StringPropertyInfo;
+import org.eclipse.wb.internal.core.nls.model.LocaleInfo;
+
+import org.eclipse.swtbot.swt.finder.SWTBot;
+import org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable;
+
+import java.util.Set;
+
+/**
+ * Wrapped for the {@link IEditableSource} to allow access when not in the UI
+ * thread.
+ */
+public class SWTBotEditableSource extends SWTBot {
+	private final IEditableSource editableSource;
+
+	public SWTBotEditableSource(IEditableSource editableSource) {
+		this.editableSource = editableSource;
+	}
+
+	/**
+	 * Return all key's of this source.
+	 */
+	public Set<String> getKeys() {
+		return UIThreadRunnable.syncExec(editableSource::getKeys);
+	}
+
+	/**
+	 * Get value for given key and locale.
+	 */
+	public String getValue(LocaleInfo locale, String key) {
+		return UIThreadRunnable.syncExec(() -> editableSource.getValue(locale, key));
+	}
+
+	/**
+	 * Replace key in all locales.
+	 */
+	public void renameKey(String oldKey, String newKey) {
+		UIThreadRunnable.asyncExec(() -> editableSource.renameKey(oldKey, newKey));
+	}
+
+	/**
+	 * Mark passed property as externalized.
+	 */
+	public void externalize(StringPropertyInfo propertyInfo, boolean copyToAllLocales) {
+		UIThreadRunnable.asyncExec(() -> editableSource.externalize(propertyInfo, copyToAllLocales));
+	}
+}


### PR DESCRIPTION
This adapts the SourceCompositeTest to be executed via SWTBot. Note that for the "test_contextMenu_removeLocale" test, the SourceComposite class also needs to be adapted.

The current implementation opens a context menu based on the cell on which the user is clicked. To determine the cell, the current location of the mouse cursor is used. Because this isn't something that can be simulated, the location is now stored via the MouseDown event.