### PR TITLE
Try to stabilize failing "Open Type" tests

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/tests/DesignerTestCase.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/tests/DesignerTestCase.java
@@ -506,12 +506,9 @@ public abstract class DesignerTestCase extends Assert {
 				public String getFailureMessage() {
 					return "\"Open type\" dialog took too long to find types.";
 				}
-			});
+			}, 30000);
 		}
 		shell.button(buttonName).click();
-		shell.waitUntil(shellCloses(shellBot));
-		// wait for result to be applied
-		UIThreadRunnable.syncExec(() -> waitEventLoop(10));
 	}
 
 	////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The test may throw a NullPointerException if no matching type is found or if the resolution took too long. Increase timeout from 5s to 30s to account for a slower Jenkins node.