### PR TITLE
Remove usage of deprecated ObjectUtils method

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/eval/evaluators/BooleanEvaluator.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/eval/evaluators/BooleanEvaluator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -25,9 +25,8 @@ import org.eclipse.jdt.core.dom.InfixExpression;
 import org.eclipse.jdt.core.dom.InfixExpression.Operator;
 import org.eclipse.jdt.core.dom.PrefixExpression;
 
-import org.apache.commons.lang3.ObjectUtils;
-
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Implementation of {@link IExpressionEvaluator} for "boolean" type.
@@ -74,11 +73,11 @@ public final class BooleanEvaluator implements IExpressionEvaluator {
 					Object rightObject = AstEvaluationEngine.evaluate(context, rightOperand);
 					// ==
 					if (operator == InfixExpression.Operator.EQUALS) {
-						return ObjectUtils.equals(leftObject, rightObject);
+						return Objects.equals(leftObject, rightObject);
 					}
 					// !=
 					if (operator == InfixExpression.Operator.NOT_EQUALS) {
-						return !ObjectUtils.equals(leftObject, rightObject);
+						return !Objects.equals(leftObject, rightObject);
 					}
 				}
 				// prepare operands

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/ComponentDescriptionKey.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/ComponentDescriptionKey.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,7 +15,7 @@ package org.eclipse.wb.internal.core.model.description;
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 
 /**
  * The key for caching {@link ComponentDescription}.
@@ -71,8 +71,8 @@ public final class ComponentDescriptionKey {
 	public boolean equals(Object obj) {
 		if (obj instanceof ComponentDescriptionKey key) {
 			return m_componentClass == key.m_componentClass
-					&& ObjectUtils.equals(m_host, key.m_host)
-					&& ObjectUtils.equals(m_suffix, key.m_suffix);
+					&& Objects.equals(m_host, key.m_host)
+					&& Objects.equals(m_suffix, key.m_suffix);
 		}
 		return false;
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/GenericPropertyComposite.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/GenericPropertyComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -18,7 +18,8 @@ import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 import org.eclipse.jdt.core.dom.Expression;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.lang3.ObjectUtils;
+
+import java.util.Objects;
 
 /**
  * Implementation of {@link GenericProperty} for composite property.
@@ -110,7 +111,7 @@ public final class GenericPropertyComposite extends GenericProperty {
 			Object propertyValue = property.getValue();
 			if (value == NO_VALUE) {
 				value = propertyValue;
-			} else if (!ObjectUtils.equals(value, propertyValue)) {
+			} else if (!Objects.equals(value, propertyValue)) {
 				return UNKNOWN_VALUE;
 			}
 		}
@@ -125,7 +126,7 @@ public final class GenericPropertyComposite extends GenericProperty {
 			Object propertyValue = property.getDefaultValue();
 			if (value == NO_VALUE) {
 				value = propertyValue;
-			} else if (!ObjectUtils.equals(value, propertyValue)) {
+			} else if (!Objects.equals(value, propertyValue)) {
 				return UNKNOWN_VALUE;
 			}
 		}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/GenericPropertyImpl.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/GenericPropertyImpl.java
@@ -38,13 +38,13 @@ import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 
 import org.eclipse.jdt.core.dom.Expression;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Concrete implementation of {@link GenericProperty}.
@@ -338,7 +338,7 @@ public final class GenericPropertyImpl extends GenericProperty {
 			Object value) throws Exception {
 		// check for default value
 		if (value != UNKNOWN_VALUE) {
-			if (ObjectUtils.equals(getDefaultValue(accessor), value)) {
+			if (Objects.equals(getDefaultValue(accessor), value)) {
 				source = null;
 			}
 		}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/EnumerationValuesPropertyEditor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/EnumerationValuesPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,9 +17,8 @@ import org.eclipse.wb.internal.core.model.clipboard.IClipboardSourceProvider;
 import org.eclipse.wb.internal.core.model.property.GenericProperty;
 import org.eclipse.wb.internal.core.model.property.Property;
 
-import org.apache.commons.lang3.ObjectUtils;
-
 import java.beans.PropertyDescriptor;
+import java.util.Objects;
 
 /**
  * {@link PropertyEditor} for "enumerationValues" attribute of {@link PropertyDescriptor}.
@@ -66,7 +65,7 @@ IClipboardSourceProvider {
 		// return name for value
 		if (value != Property.UNKNOWN_VALUE) {
 			for (int i = 0; i < m_values.length; i++) {
-				if (ObjectUtils.equals(m_values[i], value)) {
+				if (Objects.equals(m_values[i], value)) {
 					return m_names[i];
 				}
 			}
@@ -84,7 +83,7 @@ IClipboardSourceProvider {
 	public String getValueSource(Object value) throws Exception {
 		if (value != Property.UNKNOWN_VALUE) {
 			for (int i = 0; i < m_values.length; i++) {
-				if (ObjectUtils.equals(m_values[i], value)) {
+				if (Objects.equals(m_values[i], value)) {
 					return m_sources[i];
 				}
 			}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/StaticFieldPropertyEditor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/StaticFieldPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -23,7 +23,6 @@ import org.eclipse.wb.internal.core.utils.exception.ICoreExceptionConstants;
 import org.eclipse.wb.internal.core.utils.state.EditorState;
 import org.eclipse.wb.internal.core.utils.state.EditorWarning;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.lang.reflect.Field;
@@ -32,6 +31,7 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * The {@link PropertyEditor} for selecting single field of class from given set.
@@ -79,7 +79,7 @@ IClipboardSourceProvider {
 		if (value != Property.UNKNOWN_VALUE) {
 			for (int i = 0; i < m_values.length; i++) {
 				Object fieldValue = m_values[i];
-				if (ObjectUtils.equals(fieldValue, value)) {
+				if (Objects.equals(fieldValue, value)) {
 					return m_titles[i];
 				}
 			}
@@ -98,7 +98,7 @@ IClipboardSourceProvider {
 		if (value != Property.UNKNOWN_VALUE) {
 			for (int i = 0; i < m_values.length; i++) {
 				Object fieldValue = m_values[i];
-				if (ObjectUtils.equals(fieldValue, value)) {
+				if (Objects.equals(fieldValue, value)) {
 					String fieldName = m_names[i];
 					if (fieldName == null) {
 						return null;

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/graphical/GraphicalViewer.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/graphical/GraphicalViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -30,9 +30,8 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.widgets.Composite;
 
-import org.apache.commons.lang3.ObjectUtils;
-
 import java.util.Collection;
+import java.util.Objects;
 
 /**
  * @author lobas_av
@@ -186,7 +185,7 @@ public class GraphicalViewer extends AbstractEditPartViewer {
 			protected boolean acceptVisit(Figure figure) {
 				for (org.eclipse.gef.EditPart editPart : exclude) {
 					GraphicalEditPart graphicalPart = (GraphicalEditPart) editPart;
-					if (ObjectUtils.equals(figure, graphicalPart.getFigure())) {
+					if (Objects.equals(figure, graphicalPart.getFigure())) {
 						return false;
 					}
 				}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/editor/actions/assistant/AbstractAssistantPage.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/editor/actions/assistant/AbstractAssistantPage.java
@@ -37,13 +37,13 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Text;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Abstract implementation of {@link ILayoutAssistantPage} with convenient function to create
@@ -186,7 +186,7 @@ public abstract class AbstractAssistantPage extends Composite implements ILayout
 					Object value = property.getValue();
 					if (commonValue == NO_VALUE) {
 						commonValue = value;
-					} else if (!ObjectUtils.equals(commonValue, value)) {
+					} else if (!Objects.equals(commonValue, value)) {
 						return Property.UNKNOWN_VALUE;
 					}
 				}
@@ -200,7 +200,7 @@ public abstract class AbstractAssistantPage extends Composite implements ILayout
 		 */
 		protected final void setValue(final Object value) {
 			prepareProperties();
-			if (m_currentValue != Property.UNKNOWN_VALUE && ObjectUtils.equals(m_currentValue, value)) {
+			if (m_currentValue != Property.UNKNOWN_VALUE && Objects.equals(m_currentValue, value)) {
 				return;
 			}
 			m_currentValue = value;
@@ -630,7 +630,7 @@ public abstract class AbstractAssistantPage extends Composite implements ILayout
 			Object value = getValue();
 			for (Button button : m_buttons) {
 				Object buttonValue = button.getData();
-				button.setSelection(ObjectUtils.equals(value, buttonValue));
+				button.setSelection(Objects.equals(value, buttonValue));
 			}
 		}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/PolicyUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/PolicyUtils.java
@@ -35,9 +35,8 @@ import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.draw2d.geometry.Translatable;
 
-import org.apache.commons.lang3.ObjectUtils;
-
 import java.lang.reflect.Method;
+import java.util.Objects;
 
 /**
  * Helper for {@link EditPolicy}'s.
@@ -223,7 +222,7 @@ public abstract class PolicyUtils {
 		} else if (policy instanceof SelectionEditPolicy) {
 			translateAbsoluteToModel((SelectionEditPolicy) policy, t);
 		} else {
-			throw new IllegalArgumentException(ObjectUtils.toString(policy));
+			throw new IllegalArgumentException(Objects.toString(policy));
 		}
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/Pair.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/Pair.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.utils;
 
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 
 /**
  * Pair of two objects.
@@ -47,8 +47,8 @@ public final class Pair<L, R> {
 		if (!(o instanceof Pair<?, ?> other)) {
 			return false;
 		}
-		return ObjectUtils.equals(getLeft(), other.getLeft())
-				&& ObjectUtils.equals(getRight(), other.getRight());
+		return Objects.equals(getLeft(), other.getLeft())
+				&& Objects.equals(getRight(), other.getRight());
 	}
 
 	@Override

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/binding/ValueUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/binding/ValueUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,9 +13,9 @@
 package org.eclipse.wb.internal.core.utils.binding;
 
 import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.ObjectUtils;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author lobas_av
@@ -43,7 +43,7 @@ public final class ValueUtils {
 			return booleanObject.booleanValue();
 		}
 		// extract from Object
-		String stringObject = ObjectUtils.toString(value);
+		String stringObject = Objects.toString(value);
 		return BooleanUtils.toBoolean(stringObject);
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/binding/editors/StringComboEditor.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/binding/editors/StringComboEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,7 +15,7 @@ package org.eclipse.wb.internal.core.utils.binding.editors;
 import org.eclipse.wb.internal.core.utils.binding.IDataEditor;
 import org.eclipse.wb.internal.core.utils.dialogfields.ComboDialogField;
 
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 
 /**
  * @author lobas_av
@@ -45,6 +45,6 @@ public class StringComboEditor implements IDataEditor {
 
 	@Override
 	public void setValue(Object value) {
-		m_field.setText(ObjectUtils.toString(value));
+		m_field.setText(Objects.toString(value));
 	}
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/binding/editors/StringEditor.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/binding/editors/StringEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,7 +15,7 @@ package org.eclipse.wb.internal.core.utils.binding.editors;
 import org.eclipse.wb.internal.core.utils.binding.IDataEditor;
 import org.eclipse.wb.internal.core.utils.dialogfields.StringDialogField;
 
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 
 /**
  * @author lobas_av
@@ -45,6 +45,6 @@ public class StringEditor implements IDataEditor {
 
 	@Override
 	public void setValue(Object value) {
-		m_field.setText(ObjectUtils.toString(value));
+		m_field.setText(Objects.toString(value));
 	}
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/binding/editors/StringListEditor.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/binding/editors/StringListEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,11 +16,11 @@ import org.eclipse.wb.internal.core.utils.binding.IDataEditor;
 import org.eclipse.wb.internal.core.utils.dialogfields.ListDialogField;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author lobas_av
@@ -61,7 +61,7 @@ public class StringListEditor implements IDataEditor {
 
 	@Override
 	public void setValue(Object value) {
-		String stringValue = ObjectUtils.toString(value);
+		String stringValue = Objects.toString(value);
 		String[] values = StringUtils.split(stringValue, m_separator);
 		List<String> elements = new ArrayList<>();
 		CollectionUtils.addAll(elements, values);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/binding/providers/StringPreferenceProvider.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/binding/providers/StringPreferenceProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,7 +14,7 @@ package org.eclipse.wb.internal.core.utils.binding.providers;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 
 /**
  * @author lobas_av
@@ -42,6 +42,6 @@ public class StringPreferenceProvider extends AbstractPreferenceProvider {
 
 	@Override
 	public void setValue(Object value) {
-		m_store.setValue(m_key, ObjectUtils.toString(value));
+		m_store.setValue(m_key, Objects.toString(value));
 	}
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/external/ExternalFactoriesHelper.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/external/ExternalFactoriesHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -25,7 +25,6 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.resource.ImageDescriptor;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.ObjectUtils;
 import org.osgi.framework.Bundle;
 
 import java.lang.reflect.Field;
@@ -36,6 +35,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Helper for accessing external factories contributed via extension points.
@@ -276,7 +276,7 @@ public class ExternalFactoriesHelper {
 	public static synchronized IExtension getExtension(String pointId, String extensionId) {
 		for (IExtension extension : getExtensions(pointId)) {
 			if (extension.isValid()) {
-				if (ObjectUtils.equals(extension.getUniqueIdentifier(), extensionId)) {
+				if (Objects.equals(extension.getUniqueIdentifier(), extensionId)) {
 					return extension;
 				}
 			} else {

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/reflect/ReflectionUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/reflect/ReflectionUtils.java
@@ -18,7 +18,6 @@ import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 
@@ -46,6 +45,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -333,7 +333,7 @@ public class ReflectionUtils {
 			Field fieldTYPE = getFieldByName(candidateClass, "TYPE");
 			if (fieldTYPE != null) {
 				Class<?> primitiveType = (Class<?>) getFieldObject(candidateClass, "TYPE");
-				if (ObjectUtils.equals(primitiveType.getName(), requiredClass)) {
+				if (Objects.equals(primitiveType.getName(), requiredClass)) {
 					return true;
 				}
 			}
@@ -1191,7 +1191,7 @@ public class ReflectionUtils {
 			return true;
 		}
 		return constructor_1.getDeclaringClass() == constructor_2.getDeclaringClass()
-				&& ObjectUtils.equals(
+				&& Objects.equals(
 						getConstructorSignature(constructor_1),
 						getConstructorSignature(constructor_2));
 	}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/ui/UiUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/ui/UiUtils.java
@@ -42,12 +42,12 @@ import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.swt.widgets.Widget;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.lang3.ObjectUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Utilities for UI.
@@ -519,7 +519,7 @@ public class UiUtils {
 	 */
 	public static boolean equals(Image image_1, Image image_2) {
 		// try to compare as plain Object's
-		if (ObjectUtils.equals(image_1, image_2)) {
+		if (Objects.equals(image_1, image_2)) {
 			return true;
 		}
 		// compare bounds
@@ -535,7 +535,7 @@ public class UiUtils {
 	 */
 	public static boolean equals(ImageDescriptor imageDesc_1, ImageDescriptor imageDesc_2) {
 		// try to compare as plain Object's
-		if (ObjectUtils.equals(imageDesc_1, imageDesc_2)) {
+		if (Objects.equals(imageDesc_1, imageDesc_2)) {
 			return true;
 		}
 		// compare bounds

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/header/actions/SetAlignmentAction.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/header/actions/SetAlignmentAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -19,7 +19,7 @@ import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.resource.ImageDescriptor;
 
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 
 /**
  * {@link Action} for modifying alignment of {@link TableWrapDimensionInfo}.
@@ -41,7 +41,7 @@ public final class SetAlignmentAction<C extends IControlInfo> extends DimensionH
 			int alignment) {
 		super(header, text, imageDescriptor, AS_RADIO_BUTTON);
 		m_alignment = alignment;
-		setChecked(ObjectUtils.equals(header.getDimension().getAlignment(), m_alignment));
+		setChecked(Objects.equals(header.getDimension().getAlignment(), m_alignment));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/CategoriesAndViewsDialog.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/CategoriesAndViewsDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -62,12 +62,12 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Tree;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * {@link Dialog} for editing categories and moving views between them.
@@ -222,7 +222,7 @@ public class CategoriesAndViewsDialog extends ResizableDialog {
 					IPluginElement elementB = (IPluginElement) b;
 					String idA = PdeUtils.getAttribute(elementA, "id");
 					String idB = PdeUtils.getAttribute(elementB, "id");
-					return ObjectUtils.equals(idA, idB);
+					return Objects.equals(idA, idB);
 				}
 				return a == null ? b == null : a.equals(b);
 			}
@@ -459,7 +459,7 @@ public class CategoriesAndViewsDialog extends ResizableDialog {
 				}
 				// find category with given id
 				for (IPluginElement category : m_categories) {
-					if (ObjectUtils.equals(PdeUtils.getAttribute(category, "id"), viewCategoryId)) {
+					if (Objects.equals(PdeUtils.getAttribute(category, "id"), viewCategoryId)) {
 						return category;
 					}
 				}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/ExtensionElementProperty.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/ExtensionElementProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -19,8 +19,7 @@ import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.pde.core.plugin.IPluginElement;
 
-import org.apache.commons.lang3.ObjectUtils;
-
+import java.util.Objects;
 import java.util.function.Function;
 
 /**
@@ -98,7 +97,7 @@ public final class ExtensionElementProperty<T> extends Property {
 	@Override
 	public boolean isModified() throws Exception {
 		Object value = getValue();
-		return value != UNKNOWN_VALUE && !ObjectUtils.equals(value, m_defaultValue);
+		return value != UNKNOWN_VALUE && !Objects.equals(value, m_defaultValue);
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -122,9 +121,9 @@ public final class ExtensionElementProperty<T> extends Property {
 	@SuppressWarnings("unchecked")
 	public void setValue(Object value) throws Exception {
 		IPluginElement element = getElement();
-		if (element != null && !ObjectUtils.equals(value, getValue())) {
+		if (element != null && !Objects.equals(value, getValue())) {
 			String attributeValue;
-			if (value == UNKNOWN_VALUE || ObjectUtils.equals(value, m_defaultValue)) {
+			if (value == UNKNOWN_VALUE || Objects.equals(value, m_defaultValue)) {
 				attributeValue = null;
 			} else {
 				attributeValue = m_fromValueConverter.apply((T) value);

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/PdeUtils.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/rcp/PdeUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -47,7 +47,6 @@ import org.eclipse.pde.internal.ui.util.PDEModelUtility;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.part.EditorPart;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.osgi.framework.Bundle;
 
@@ -58,6 +57,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -749,7 +749,7 @@ public final class PdeUtils {
 				@Override
 				public boolean visit(IPluginElement element) {
 					String categoryId = getAttribute(element, "category");
-					if (ObjectUtils.equals(m_id, categoryId)) {
+					if (Objects.equals(m_id, categoryId)) {
 						views.add(createViewInfo(element));
 					}
 					return false;

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/DialogInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/DialogInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -43,9 +43,8 @@ import org.eclipse.swt.widgets.Shell;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 
-import org.apache.commons.lang3.ObjectUtils;
-
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Model for {@link Dialog}.
@@ -105,7 +104,7 @@ IThisMethodParameterEvaluator {
 			String methodSignature,
 			SingleVariableDeclaration parameter,
 			int index) throws Exception {
-		if (ObjectUtils.equals(parameter.getName().getIdentifier(), "style")) {
+		if (Objects.equals(parameter.getName().getIdentifier(), "style")) {
 			return SWT.DIALOG_TRIM;
 		}
 		return AstEvaluationEngine.UNKNOWN;

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/customize/CustomizerAction.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/customize/CustomizerAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -23,8 +23,6 @@ import org.eclipse.wb.internal.swing.model.ModelMessages;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.window.Window;
 
-import org.apache.commons.lang3.ObjectUtils;
-
 import java.awt.Component;
 import java.beans.BeanDescriptor;
 import java.beans.BeanInfo;
@@ -32,6 +30,7 @@ import java.beans.Customizer;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.text.MessageFormat;
+import java.util.Objects;
 
 /**
  * {@link Action} for performing customization.
@@ -126,7 +125,7 @@ class CustomizerAction extends Action {
 								if (javaInfoState.changedProperties.contains(property.getTitle())) {
 									Object newValue = javaInfoState.changedPropertyValues.get(property.getTitle());
 									Object oldValue = javaInfoState.oldValues.get(i);
-									if (!ObjectUtils.equals(newValue, oldValue)) {
+									if (!Objects.equals(newValue, oldValue)) {
 										property.setValue(newValue);
 									}
 								}
@@ -142,7 +141,7 @@ class CustomizerAction extends Action {
 							for (int i = 0; i < size; i++) {
 								Object newValue = javaInfoState.getters.get(i).invoke(javaInfoState.object);
 								Object oldValue = javaInfoState.oldValues.get(i);
-								if (!ObjectUtils.equals(newValue, oldValue)) {
+								if (!Objects.equals(newValue, oldValue)) {
 									javaInfoState.properties.get(i).setValue(newValue);
 								}
 							}
@@ -161,7 +160,7 @@ class CustomizerAction extends Action {
 						for (int i = 0; i < size; i++) {
 							Object newValue = javaInfoState.getters.get(i).invoke(javaInfoState.object);
 							Object oldValue = javaInfoState.oldValues.get(i);
-							if (!ObjectUtils.equals(newValue, oldValue)) {
+							if (!Objects.equals(newValue, oldValue)) {
 								javaInfoState.setters.get(i).invoke(javaInfoState.object, oldValue);
 							}
 						}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/BooleanField.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/BooleanField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -20,7 +20,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 
 /**
  * {@link AbstractBorderField} that allows to select {@link Boolean} value.
@@ -76,7 +76,7 @@ public final class BooleanField extends AbstractBorderField {
 	 * Sets the value, that should correspond to the one of the field values.
 	 */
 	public void setValue(Object value) throws Exception {
-		if (ObjectUtils.equals(Boolean.FALSE, value)) {
+		if (Objects.equals(Boolean.FALSE, value)) {
 			m_source = "false";
 			m_buttons[0].setSelection(true);
 			m_buttons[1].setSelection(false);

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/ComboField.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/ComboField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -21,9 +21,8 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 
-import org.apache.commons.lang3.ObjectUtils;
-
 import java.lang.reflect.Field;
+import java.util.Objects;
 
 /**
  * {@link AbstractBorderField} that allows to select one field from many.
@@ -78,7 +77,7 @@ public final class ComboField extends AbstractBorderField {
 		for (int i = 0; i < m_fields.length; i++) {
 			String fieldName = m_fields[i];
 			Field field = m_clazz.getField(fieldName);
-			if (ObjectUtils.equals(field.get(null), value)) {
+			if (Objects.equals(field.get(null), value)) {
 				m_source = m_clazz.getName() + "." + m_fields[i];
 				m_combo.select(i);
 				break;

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/RadioField.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/RadioField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -20,9 +20,8 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 
-import org.apache.commons.lang3.ObjectUtils;
-
 import java.lang.reflect.Field;
+import java.util.Objects;
 
 /**
  * {@link AbstractBorderField} that allows to select one field from many.
@@ -78,7 +77,7 @@ public final class RadioField extends AbstractBorderField {
 		for (int i = 0; i < m_fields.length; i++) {
 			String fieldName = m_fields[i];
 			Field field = m_clazz.getField(fieldName);
-			if (ObjectUtils.equals(field.get(null), value)) {
+			if (Objects.equals(field.get(null), value)) {
 				m_source = m_clazz.getName() + "." + m_fields[i];
 				m_buttons[i].setSelection(true);
 			} else {

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/DescriptionProcessor.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/DescriptionProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -32,7 +32,6 @@ import org.eclipse.wb.internal.core.utils.ui.ImageUtils;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Layout;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.beans.BeanInfo;
@@ -42,6 +41,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 
 /**
@@ -280,7 +280,7 @@ public final class DescriptionProcessor implements IDescriptionProcessor {
 			if (!isComposite(componentClass)) {
 				return;
 			}
-			if (!ObjectUtils.equals(componentDescription.getParameter("layout.has"), "false")) {
+			if (!Objects.equals(componentDescription.getParameter("layout.has"), "false")) {
 				return;
 			}
 			// remove setLayout() method

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/header/actions/SetAlignmentAction.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/header/actions/SetAlignmentAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -19,7 +19,7 @@ import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.resource.ImageDescriptor;
 
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 
 /**
  * {@link Action} for modifying alignment of {@link FormDimensionInfo}.
@@ -41,7 +41,7 @@ public final class SetAlignmentAction<C extends IControlInfo> extends DimensionH
 			int alignment) {
 		super(header, text, imageDescriptor, AS_RADIO_BUTTON);
 		m_alignment = alignment;
-		setChecked(ObjectUtils.equals(header.getDimension().getAlignment(), m_alignment));
+		setChecked(Objects.equals(header.getDimension().getAlignment(), m_alignment));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/widgets/CompositeInfo.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/widgets/CompositeInfo.java
@@ -85,12 +85,12 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Layout;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.osgi.framework.Bundle;
 
 import java.lang.reflect.Constructor;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Model for any SWT {@link Composite}.
@@ -288,7 +288,7 @@ IThisMethodParameterEvaluator {
 			String methodSignature,
 			SingleVariableDeclaration parameter,
 			int index) throws Exception {
-		if (ObjectUtils.equals(parameter.getName().getIdentifier(), "style")) {
+		if (Objects.equals(parameter.getName().getIdentifier(), "style")) {
 			return SWT.NONE;
 		}
 		return AstEvaluationEngine.UNKNOWN;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/validator/LayoutRequestValidatorsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/validator/LayoutRequestValidatorsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -22,9 +22,10 @@ import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
+
+import java.util.Objects;
 
 /**
  * Tests for {@link LayoutRequestValidators}.
@@ -129,7 +130,7 @@ public class LayoutRequestValidatorsTest extends AbstractLayoutRequestValidatorT
 		ILayoutRequestValidator[] validators = getValidators(compoundValidator);
 		for (ILayoutRequestValidator validator : validators) {
 			if (validator instanceof ModelClassLayoutRequestValidator) {
-				if (ObjectUtils.equals(
+				if (Objects.equals(
 						ReflectionUtils.getFieldObject(validator, "m_requiredModelClass"),
 						requiredModelClass)) {
 					return;
@@ -144,7 +145,7 @@ public class LayoutRequestValidatorsTest extends AbstractLayoutRequestValidatorT
 		ILayoutRequestValidator[] validators = getValidators(compoundValidator);
 		for (ILayoutRequestValidator validator : validators) {
 			if (validator instanceof ComponentClassLayoutRequestValidator) {
-				if (ObjectUtils.equals(
+				if (Objects.equals(
 						ReflectionUtils.getFieldObject(validator, "m_requiredClass"),
 						requiredComponentClass)) {
 					return;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/GraphicalRobot.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/GraphicalRobot.java
@@ -46,13 +46,13 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.description.Description;
 
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Predicate;
 
 /**
@@ -224,7 +224,7 @@ public final class GraphicalRobot {
 			if (handle.getDragTrackerTool() instanceof ResizeTracker) {
 				ResizeTracker resizeTracker = (ResizeTracker) handle.getDragTrackerTool();
 				return resizeTracker.getDirection() == direction
-						&& ObjectUtils.equals(resizeTracker.getRequestType(), type);
+						&& Objects.equals(resizeTracker.getRequestType(), type);
 			}
 			return false;
 		};


### PR DESCRIPTION
Use drop-in replacement from java.util.Objects instead.