### PR TITLE
Set DOUBLE_BUFFERED style for WindowBuilder FigureCanvas

### DIFF
--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/FigureCanvas.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/FigureCanvas.java
@@ -38,7 +38,7 @@ public class FigureCanvas extends org.eclipse.draw2d.FigureCanvas {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	public FigureCanvas(Composite parent, int style) {
-		super(parent, style | SWT.NO_BACKGROUND | SWT.NO_REDRAW_RESIZE, createLightweightSystem());
+		super(parent, style | SWT.DOUBLE_BUFFERED, createLightweightSystem());
 		// create root figure
 		createRootFigure();
 	}


### PR DESCRIPTION
This enforces the use of the NativeGraphicsSource and avoid the scaling issues when at > 100% zoom. Note that this also removes the NO_BACKGROUND and NO_REDRAW_RESIZE bits, as those are already enabled by default.