### PR TITLE
Correct initialization of default layout in advanced JFrame template

### DIFF
--- a/org.eclipse.wb.swing/templates/JFrame_advanced.jvt
+++ b/org.eclipse.wb.swing/templates/JFrame_advanced.jvt
@@ -36,7 +36,7 @@ method
 		setBounds(100, 100, %DefaultFormSize%);
 		%this%%field-prefix%contentPane = new JPanel();
 		%this%%field-prefix%contentPane.setBorder(new EmptyBorder(5, 5, 5, 5));
-		%ContentPane.SwingLayout%
 		setContentPane(%this%%field-prefix%contentPane);
+		%ContentPane.SwingLayout%
 	}
 


### PR DESCRIPTION
Due to 280f8aa3282dce10f92e7d2cbe7077071aa11836, the default layout must now be initialized AFTER the content pane has been updated.

Closes https://github.com/eclipse-windowbuilder/windowbuilder/issues/1103