### PR TITLE
Increase SWTBot timeout from 5s to 30s

### DIFF
--- a/org.eclipse.wb.tests/pom.xml
+++ b/org.eclipse.wb.tests/pom.xml
@@ -22,7 +22,7 @@
   <packaging>eclipse-test-plugin</packaging>
 
 	<properties>
-		<uitest.vmparams>-Dwbp.burningwave.enabled=false</uitest.vmparams>
+		<uitest.vmparams>-Dwbp.burningwave.enabled=false -Dorg.eclipse.swtbot.search.timeout=30000</uitest.vmparams>
 	</properties>
 
 	<profiles>

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/tests/DesignerTestCase.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/tests/DesignerTestCase.java
@@ -506,7 +506,7 @@ public abstract class DesignerTestCase extends Assert {
 				public String getFailureMessage() {
 					return "\"Open type\" dialog took too long to find types.";
 				}
-			}, 30000);
+			});
 		}
 		shell.button(buttonName).click();
 	}


### PR DESCRIPTION
On slower systems, the widgets might not show up in time, leading to sporadic test failures.