### PR TITLE
[Draw2D] Extract custom tool-tip handling from Draw2D Figure

### DIFF
--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,7 +14,6 @@ package org.eclipse.wb.draw2d;
 
 import org.eclipse.wb.internal.draw2d.FigureCanvas;
 import org.eclipse.wb.internal.draw2d.FigureVisitor;
-import org.eclipse.wb.internal.draw2d.ICustomTooltipProvider;
 
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
@@ -33,7 +32,6 @@ import java.util.List;
  */
 public class Figure extends org.eclipse.draw2d.Figure {
 	private String m_toolTipText;
-	private ICustomTooltipProvider m_customTooltipProvider;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -193,22 +191,6 @@ public class Figure extends org.eclipse.draw2d.Figure {
 	 */
 	public void setToolTipText(String toolTipText) {
 		m_toolTipText = toolTipText;
-	}
-
-	/**
-	 * @return custom tool tip provider {@link ICustomTooltipProvider}, or <code>null</code> if it has
-	 *         not been set.
-	 */
-	public ICustomTooltipProvider getCustomTooltipProvider() {
-		return m_customTooltipProvider;
-	}
-
-	/**
-	 * Sets the custom tool tip provider {@link ICustomTooltipProvider} to the argument, which may be
-	 * <code>null</code> indicating that no tool tip text should be shown.
-	 */
-	public void setCustomTooltipProvider(ICustomTooltipProvider provider) {
-		m_customTooltipProvider = provider;
 	}
 
 	@Override

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/PaletteFigure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/PaletteFigure.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.draw2d;
+
+import org.eclipse.wb.internal.draw2d.ICustomTooltipProvider;
+
+/**
+ * Subclass of the Draw2D figure used for palette entries and categories.
+ */
+public class PaletteFigure extends Figure {
+	private ICustomTooltipProvider m_customTooltipProvider;
+
+	/**
+	 * @return custom tool tip provider {@link ICustomTooltipProvider}, or
+	 *         <code>null</code> if it has not been set.
+	 */
+	public ICustomTooltipProvider getCustomTooltipProvider() {
+		return m_customTooltipProvider;
+	}
+
+	/**
+	 * Sets the custom tool tip provider {@link ICustomTooltipProvider} to the
+	 * argument, which may be <code>null</code> indicating that no tool tip text
+	 * should be shown.
+	 */
+	public void setCustomTooltipProvider(ICustomTooltipProvider provider) {
+		m_customTooltipProvider = provider;
+	}
+}

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/CustomTooltipManager.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/CustomTooltipManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,6 +13,7 @@
 package org.eclipse.wb.internal.draw2d;
 
 import org.eclipse.wb.draw2d.Figure;
+import org.eclipse.wb.draw2d.PaletteFigure;
 import org.eclipse.wb.internal.core.EnvironmentUtils;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
 
@@ -142,8 +143,8 @@ public final class CustomTooltipManager implements ICustomTooltipSite {
 	protected final void handleShowCustomTooltip(int mouseX, int mouseY) {
 		hideTooltip();
 		Figure cursorFigure = m_eventManager.getCursorFigure();
-		if (cursorFigure != null) {
-			ICustomTooltipProvider tooltipProvider = cursorFigure.getCustomTooltipProvider();
+		if (cursorFigure instanceof PaletteFigure paletteFigure) {
+			ICustomTooltipProvider tooltipProvider = paletteFigure.getCustomTooltipProvider();
 			if (tooltipProvider != null) {
 				m_tooltipFigure = cursorFigure;
 				//

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
@@ -17,6 +17,7 @@ import org.eclipse.wb.core.editor.constants.CoreImages;
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.draw2d.Layer;
+import org.eclipse.wb.draw2d.PaletteFigure;
 import org.eclipse.wb.draw2d.border.LineBorder;
 import org.eclipse.wb.internal.core.utils.GenericsUtils;
 import org.eclipse.wb.internal.core.utils.ui.DrawUtils;
@@ -131,7 +132,7 @@ public final class PaletteComposite extends Composite {
 	private IPalettePreferences m_preferences;
 	private final FigureCanvas m_figureCanvas;
 	private final EventManager m_eventManager;
-	private final PaletteFigure m_paletteFigure;
+	private final PaletteRootFigure m_paletteFigure;
 	private final Layer m_feedbackLayer;
 	@SuppressWarnings("removal")
 	private final Map<ICategory, CategoryFigure> m_categoryFigures = new HashMap<>();
@@ -163,7 +164,7 @@ public final class PaletteComposite extends Composite {
 			m_eventManager = (EventManager) m_figureCanvas.getRootFigure().internalGetEventDispatcher();
 		}
 		// add palette figure (layer)
-		m_paletteFigure = new PaletteFigure();
+		m_paletteFigure = new PaletteRootFigure();
 		m_figureCanvas.getRootFigure().add(m_paletteFigure);
 		// set menu
 		{
@@ -367,13 +368,13 @@ public final class PaletteComposite extends Composite {
 	 * @author scheglov_ke
 	 */
 	@SuppressWarnings("removal")
-	private final class PaletteFigure extends Layer {
+	private final class PaletteRootFigure extends Layer {
 		////////////////////////////////////////////////////////////////////////////
 		//
 		// Constructor
 		//
 		////////////////////////////////////////////////////////////////////////////
-		public PaletteFigure() {
+		public PaletteRootFigure() {
 			super("palette");
 		}
 
@@ -427,6 +428,7 @@ public final class PaletteComposite extends Composite {
 			}
 		}
 	}
+
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// CategoryFigure
@@ -438,7 +440,7 @@ public final class PaletteComposite extends Composite {
 	 * @author scheglov_ke
 	 */
 	@SuppressWarnings("removal")
-	private final class CategoryFigure extends Figure {
+	private final class CategoryFigure extends PaletteFigure {
 		private static final int IMAGE_SPACE_LEFT = 4;
 		private static final int IMAGE_SPACE_RIGHT = 4;
 		private static final int MARGIN_HEIGHT = 2;
@@ -780,7 +782,7 @@ public final class PaletteComposite extends Composite {
 	 * @author scheglov_ke
 	 */
 	@SuppressWarnings("removal")
-	private final class EntryFigure extends Figure {
+	private final class EntryFigure extends PaletteFigure {
 		private static final int IMAGE_SPACE_RIGHT = 2;
 		private static final int MARGIN_WIDTH_1 = 3;
 		private static final int MARGIN_WIDTH_2 = 6;
@@ -1274,7 +1276,7 @@ public final class PaletteComposite extends Composite {
 	/**
 	 * Sets wrapped tooltip for given figure.
 	 */
-	private static void setToolTip(Figure figure, String header, String details) {
+	private static void setToolTip(PaletteFigure figure, String header, String details) {
 		if (header != null && details != null) {
 			figure.setCustomTooltipProvider(new HtmlPaletteTooltipProvider(header, details));
 		} else if (details == null) {


### PR DESCRIPTION
The CustomToolTipManager is only used in the context of palette figures and should therefore not be part of the generic Draw2D Figure.