### PR TITLE
[Draw2D] Harmonize tool-tip handling of WindowBuilder figures

### DIFF
--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
@@ -31,7 +31,6 @@ import java.util.List;
  * @coverage gef.draw2d
  */
 public class Figure extends org.eclipse.draw2d.Figure {
-	private String m_toolTipText;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -177,21 +176,6 @@ public class Figure extends org.eclipse.draw2d.Figure {
 	// Properties
 	//
 	////////////////////////////////////////////////////////////////////////////
-
-	/**
-	 * Returns the receiver's tool tip text, or <code>null</code> if it has not been set.
-	 */
-	public String getToolTipText() {
-		return m_toolTipText;
-	}
-
-	/**
-	 * Sets the receiver's tool tip text to the argument, which may be <code>null</code> indicating
-	 * that no tool tip text should be shown.
-	 */
-	public void setToolTipText(String toolTipText) {
-		m_toolTipText = toolTipText;
-	}
 
 	@Override
 	protected boolean useLocalCoordinates() {

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/EventManager.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/EventManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -107,10 +107,10 @@ public class EventManager extends EventDispatcher {
 	}
 
 	protected void updateFigureToolTipText() {
-		if (m_cursorFigure == null) {
-			m_canvas.setToolTipText(null);
+		if (m_cursorFigure != null && m_cursorFigure.getToolTip() instanceof Label label) {
+			m_canvas.setToolTipText(label.getText());
 		} else {
-			m_canvas.setToolTipText(m_cursorFigure.getToolTipText());
+			m_canvas.setToolTipText(null);
 		}
 	}
 

--- a/org.eclipse.wb.rcp/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.rcp;singleton:=true
-Bundle-Version: 1.9.1100.qualifier
+Bundle-Version: 1.9.1200.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.rcp.Activator
 Bundle-Vendor: %providerName
@@ -93,7 +93,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.31.100,4.0.0)",
  org.eclipse.ui;bundle-version="[3.206.0,4.0.0)",
  org.eclipse.ui.forms;bundle-version="[3.13.300,4.0.0)",
  org.eclipse.search;bundle-version="[3.16.200,4.0.0)",
- org.eclipse.wb.core;bundle-version="[1.20.0,2.0.0)",
+ org.eclipse.wb.core;bundle-version="[1.21.0,2.0.0)",
  org.eclipse.wb.core.ui;bundle-version="[1.10.800,2.0.0)",
  org.eclipse.wb.core.java;bundle-version="[1.13.100,2.0.0)",
  org.eclipse.wb.swt;bundle-version="[1.10.100,2.0.0)",

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/header/edit/DimensionHeaderEditPart.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/header/edit/DimensionHeaderEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -22,6 +22,7 @@ import org.eclipse.wb.gef.core.tools.Tool;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
+import org.eclipse.wb.internal.draw2d.Label;
 import org.eclipse.wb.internal.rcp.model.forms.layout.table.ITableWrapLayoutInfo;
 import org.eclipse.wb.internal.rcp.model.forms.layout.table.TableWrapDimensionInfo;
 import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
@@ -116,7 +117,10 @@ IHeaderMenuProvider {
 		ExecutionUtils.runLog(new RunnableEx() {
 			@Override
 			public void run() throws Exception {
-				getFigure().setToolTipText(m_dimension.getTitle());
+				String tooltip = m_dimension.getTitle();
+				if (tooltip != null && !tooltip.isEmpty()) {
+					getFigure().setToolTip(new Label(tooltip));
+				}
 				getFigure().setBackgroundColor(COLOR_NORMAL);
 			}
 		});

--- a/org.eclipse.wb.swing.FormLayout/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing.FormLayout/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swing.FormLayout;singleton:=true
-Bundle-Version: 1.12.100.qualifier
+Bundle-Version: 1.12.200.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.swing.FormLayout.Activator
 Bundle-Vendor: %providerName
@@ -21,7 +21,7 @@ Export-Package: org.eclipse.wb.internal.swing.FormLayout,
 Require-Bundle: org.eclipse.ui;bundle-version="[3.206.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.31.100,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.20.200,4.0.0)",
- org.eclipse.wb.core;bundle-version="[1.20.0,2.0.0)",
+ org.eclipse.wb.core;bundle-version="[1.21.0,2.0.0)",
  org.eclipse.wb.swing;bundle-version="[1.10.200,2.0.0)",
  org.eclipse.draw2d;bundle-version="[3.20.0,4.0.0)",
  org.eclipse.gef;bundle-version="[3.21.100,4.0.0)"

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/edit/DimensionHeaderEditPart.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/edit/DimensionHeaderEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -21,6 +21,7 @@ import org.eclipse.wb.gef.core.tools.ParentTargetDragEditPartTracker;
 import org.eclipse.wb.gef.core.tools.Tool;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.core.utils.ui.DrawUtils;
+import org.eclipse.wb.internal.draw2d.Label;
 import org.eclipse.wb.internal.swing.FormLayout.gef.header.actions.SetTemplateAction;
 import org.eclipse.wb.internal.swing.FormLayout.model.FormDimensionInfo;
 import org.eclipse.wb.internal.swing.FormLayout.model.FormDimensionTemplate;
@@ -124,7 +125,10 @@ GraphicalEditPart implements IHeaderMenuProvider {
 	@Override
 	protected void refreshVisuals() {
 		// update tooltip
-		getFigure().setToolTipText(m_dimension.getToolTip());
+		String tooltip = m_dimension.getToolTip();
+		if (tooltip != null && !tooltip.isEmpty()) {
+			getFigure().setToolTip(new Label(tooltip));
+		}
 		// update background
 		{
 			if (m_dimension.isGap()) {

--- a/org.eclipse.wb.swing.MigLayout/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing.MigLayout/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swing.MigLayout;singleton:=true
-Bundle-Version: 1.11.100.qualifier
+Bundle-Version: 1.11.200.qualifier
 Bundle-Activator: org.eclipse.wb.internal.swing.MigLayout.Activator
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-21
@@ -10,7 +10,7 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.ui;bundle-version="[3.206.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.31.100,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.20.200,4.0.0)",
- org.eclipse.wb.core;bundle-version="[1.20.0,2.0.0)",
+ org.eclipse.wb.core;bundle-version="[1.21.0,2.0.0)",
  org.eclipse.wb.swing;bundle-version="[1.10.200,2.0.0)",
  org.eclipse.draw2d;bundle-version="[3.20.0,4.0.0)",
  org.eclipse.gef;bundle-version="[3.21.100,4.0.0)"

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/edit/ColumnHeaderEditPart.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/edit/ColumnHeaderEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,6 +17,7 @@ import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.core.DesignerPlugin;
+import org.eclipse.wb.internal.draw2d.Label;
 import org.eclipse.wb.internal.swing.MigLayout.gef.GefMessages;
 import org.eclipse.wb.internal.swing.MigLayout.gef.header.actions.DimensionHeaderAction;
 import org.eclipse.wb.internal.swing.MigLayout.gef.header.actions.SetAlignmentColumnAction;
@@ -141,7 +142,10 @@ public class ColumnHeaderEditPart extends DimensionHeaderEditPart<MigColumnInfo>
 			figure.setBounds(bounds);
 		}
 		// tooltip
-		figure.setToolTipText(m_column.getTooltip());
+		String tooltip = m_column.getTooltip();
+		if (tooltip != null && !tooltip.isEmpty()) {
+			figure.setToolTip(new Label(tooltip));
+		}
 	}
 
 	@Override

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/edit/RowHeaderEditPart.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/edit/RowHeaderEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,6 +17,7 @@ import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.core.DesignerPlugin;
+import org.eclipse.wb.internal.draw2d.Label;
 import org.eclipse.wb.internal.swing.MigLayout.gef.GefMessages;
 import org.eclipse.wb.internal.swing.MigLayout.gef.header.actions.DimensionHeaderAction;
 import org.eclipse.wb.internal.swing.MigLayout.gef.header.actions.SetAlignmentRowAction;
@@ -141,7 +142,10 @@ public class RowHeaderEditPart extends DimensionHeaderEditPart<MigRowInfo> {
 			figure.setBounds(bounds);
 		}
 		// tooltip
-		figure.setToolTipText(m_row.getTooltip());
+		String tooltip = m_row.getTooltip();
+		if (tooltip != null && !tooltip.isEmpty()) {
+			figure.setToolTip(new Label(tooltip));
+		}
 	}
 
 	@Override

--- a/org.eclipse.wb.swt/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swt;singleton:=true
-Bundle-Version: 1.10.100.qualifier
+Bundle-Version: 1.10.200.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.swt.Activator
 Bundle-Vendor: %providerName
@@ -55,7 +55,7 @@ Export-Package: org.eclipse.wb.internal.swt,
  org.eclipse.wb.internal.swt.utils
 Require-Bundle: org.eclipse.ui;bundle-version="[3.206.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.31.100,4.0.0)",
- org.eclipse.wb.core;bundle-version="[1.20.0,2.0.0)",
+ org.eclipse.wb.core;bundle-version="[1.21.0,2.0.0)",
  org.eclipse.wb.core.java;bundle-version="[1.13.100,2.0.0)",
  org.eclipse.pde.core;bundle-version="[3.18.100,4.0.0)",
  org.eclipse.draw2d;bundle-version="[3.20.0,4.0.0)",

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormHeaderEditPart.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormHeaderEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,6 +17,7 @@ import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.tools.ParentTargetDragEditPartTracker;
 import org.eclipse.wb.gef.core.tools.Tool;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
+import org.eclipse.wb.internal.draw2d.Label;
 import org.eclipse.wb.internal.swt.model.layout.form.FormLayoutPreferences;
 import org.eclipse.wb.internal.swt.model.layout.form.IFormLayoutInfo;
 import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
@@ -76,7 +77,7 @@ public class FormHeaderEditPart<C extends IControlInfo> extends GraphicalEditPar
 				isHorizontal ? FormUtils.getLayoutMarginLeft(layout) : FormUtils.getLayoutMarginTop(layout);
 		int position = size * percent / 100 + marginOffset;
 		Figure figure = getFigure();
-		figure.setToolTipText(String.valueOf(percent) + "%");
+		figure.setToolTip(new Label(percent + "%"));
 		int figureSize = t.t(figure.getParent().getSize()).height;
 		Rectangle bounds = t.t(new Rectangle(position - figureSize / 2, 0, figureSize, figureSize));
 		figure.setBounds(translateModelToFeedback(bounds));

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/header/edit/DimensionHeaderEditPart.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/header/edit/DimensionHeaderEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -22,6 +22,7 @@ import org.eclipse.wb.gef.core.tools.Tool;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
+import org.eclipse.wb.internal.draw2d.Label;
 import org.eclipse.wb.internal.swt.model.layout.grid.GridDimensionInfo;
 import org.eclipse.wb.internal.swt.model.layout.grid.IGridLayoutInfo;
 import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
@@ -116,7 +117,10 @@ IHeaderMenuProvider {
 		ExecutionUtils.runLog(new RunnableEx() {
 			@Override
 			public void run() throws Exception {
-				getFigure().setToolTipText(m_dimension.getTitle());
+				String tooltip = m_dimension.getTitle();
+				if (tooltip != null && !tooltip.isEmpty()) {
+					getFigure().setToolTip(new Label(tooltip));
+				}
 				getFigure().setBackgroundColor(COLOR_NORMAL);
 			}
 		});

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigureTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigureTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,6 +17,7 @@ import org.eclipse.wb.draw2d.border.Border;
 import org.eclipse.wb.draw2d.border.LineBorder;
 import org.eclipse.wb.draw2d.border.MarginBorder;
 import org.eclipse.wb.internal.draw2d.FigureVisitor;
+import org.eclipse.wb.internal.draw2d.Label;
 import org.eclipse.wb.tests.gef.TestLogger;
 
 import org.eclipse.draw2d.AncestorListener;
@@ -538,7 +539,7 @@ public class FigureTest extends Draw2dFigureTestCase {
 		assertNull(testFigure.getCursor());
 		assertFalse(testFigure.isOpaque());
 		assertTrue(testFigure.isVisible());
-		assertNull(testFigure.getToolTipText());
+		assertNull(testFigure.getToolTip());
 	}
 
 	@Test
@@ -676,19 +677,19 @@ public class FigureTest extends Draw2dFigureTestCase {
 		Figure testFigure = new Figure();
 		//
 		// check tooltip for new Figure
-		assertNull(testFigure.getToolTipText());
+		assertNull(testFigure.getToolTip());
 		//
 		// check set tooltip
-		testFigure.setToolTipText("JLabel(\"123\")");
-		assertEquals("JLabel(\"123\")", testFigure.getToolTipText());
+		testFigure.setToolTip(new Label("JLabel(\"123\")"));
+		assertEquals("JLabel(\"123\")", ((Label) testFigure.getToolTip()).getText());
 		//
 		// check set other tooltip
-		testFigure.setToolTipText("new Button()");
-		assertEquals("new Button()", testFigure.getToolTipText());
+		testFigure.setToolTip(new Label("new Button()"));
+		assertEquals("new Button()", ((Label) testFigure.getToolTip()).getText());
 		//
 		// check set 'null' tooltip
-		testFigure.setToolTipText(null);
-		assertNull(testFigure.getToolTipText());
+		testFigure.setToolTip(null);
+		assertNull(testFigure.getToolTip());
 	}
 
 	////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
By wrapping the tool-tip string in a Label, it is possible to use the setToolTip() method specified by the IFigure interface, thus avoiding an additional setToolTipText() method.

This Label then needs to be unwrapped in our EventManager, as figures are not yet supported here, until the manager has been harmonized with the SWTEventDispatcher.

The tool-tip handling has also been improved so that it is only shown for non-empty strings.