### PR TITLE
[GEF] RootEditPart should implement the LayerManager interface

### DIFF
--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/graphical/GraphicalViewer.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/graphical/GraphicalViewer.java
@@ -65,7 +65,8 @@ public class GraphicalViewer extends AbstractEditPartViewer {
 
 	protected GraphicalViewer(FigureCanvas canvas) {
 		m_canvas = canvas;
-		m_rootEditPart = new RootEditPart(this, getRootFigure());
+		m_rootEditPart = new RootEditPart(getRootFigure());
+		m_rootEditPart.setViewer(this);
 		m_rootEditPart.activate();
 		setRootEditPart(m_rootEditPart);
 	}

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/graphical/RootEditPart.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/graphical/RootEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -21,8 +21,10 @@ import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.gef.graphical.tools.MarqueeSelectionTool;
 import org.eclipse.wb.internal.draw2d.IRootFigure;
 
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.Request;
+import org.eclipse.gef.editparts.LayerManager;
 
 /**
  * A {@link RootEditPart} is the <i>root</i> of an {@link IEditPartViewer}. It bridges the gap
@@ -33,7 +35,7 @@ import org.eclipse.gef.Request;
  * @author lobas_av
  * @coverage gef.graphical
  */
-public class RootEditPart extends GraphicalEditPart implements org.eclipse.gef.RootEditPart {
+public class RootEditPart extends GraphicalEditPart implements org.eclipse.gef.RootEditPart, LayerManager {
 	private IEditPartViewer m_viewer;
 	private final IRootFigure m_rootFigure;
 	private EditPart m_contentEditPart;
@@ -43,8 +45,7 @@ public class RootEditPart extends GraphicalEditPart implements org.eclipse.gef.R
 	// Constructor
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public RootEditPart(IEditPartViewer viewer, IRootFigure rootFigure) {
-		m_viewer = viewer;
+	public RootEditPart(IRootFigure rootFigure) {
 		m_rootFigure = rootFigure;
 		createLayers();
 	}
@@ -88,7 +89,16 @@ public class RootEditPart extends GraphicalEditPart implements org.eclipse.gef.R
 
 	@Override
 	public void setViewer(EditPartViewer viewer) {
+		if (m_viewer == viewer) {
+			return;
+		}
+		if (m_viewer != null) {
+			unregister();
+		}
 		m_viewer = (IEditPartViewer) viewer;
+		if (m_viewer != null) {
+			register();
+		}
 	}
 
 	/**
@@ -105,6 +115,11 @@ public class RootEditPart extends GraphicalEditPart implements org.eclipse.gef.R
 	@Override
 	protected Figure createFigure() {
 		return null;
+	}
+
+	@Override
+	public Object getModel() {
+		return LayerManager.ID;
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -151,5 +166,13 @@ public class RootEditPart extends GraphicalEditPart implements org.eclipse.gef.R
 	@Override
 	public Tool getDragTracker(Request request) {
 		return new MarqueeSelectionTool();
+	}
+
+	@Override
+	public IFigure getLayer(Object key) {
+		if (key instanceof String name) {
+			return m_rootFigure.getLayer(name);
+		}
+		return null;
 	}
 }

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/tree/RootEditPart.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/tree/RootEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -29,15 +29,6 @@ import org.eclipse.swt.widgets.TreeItem;
 public class RootEditPart extends TreeEditPart implements org.eclipse.gef.RootEditPart {
 	private IEditPartViewer m_viewer;
 	private TreeEditPart m_contentEditPart;
-
-	////////////////////////////////////////////////////////////////////////////
-	//
-	// Constructor
-	//
-	////////////////////////////////////////////////////////////////////////////
-	public RootEditPart(IEditPartViewer viewer) {
-		m_viewer = viewer;
-	}
 
 	////////////////////////////////////////////////////////////////////////////
 	//

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/tree/TreeViewer.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/tree/TreeViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -61,7 +61,8 @@ public class TreeViewer extends AbstractEditPartViewer {
 		// handle SWT events
 		m_eventManager = new TreeEventManager(m_tree, this);
 		// create root EditPart
-		m_rootEditPart = new RootEditPart(this);
+		m_rootEditPart = new RootEditPart();
+		m_rootEditPart.setViewer(this);
 		m_rootEditPart.activate();
 		setRootEditPart(m_rootEditPart);
 		// handle selection events


### PR DESCRIPTION
The layer should be accessed from the RootEditPart, not the EditPartViewer. This requires the root edit part to implement the LayerManager interface and to use the LayerManager.ID as model, to become visible to the LayerManager.Helper class.