### PR TITLE
[GEF] Generalize decorateChild/undecorateChild in LayoutEditPolicy

### DIFF
--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/policies/LayoutEditPolicy.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/policies/LayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,13 +12,13 @@
  *******************************************************************************/
 package org.eclipse.wb.gef.graphical.policies;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.IEditPartDecorationListener;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
 import org.eclipse.wb.gef.core.requests.CreateRequest;
 import org.eclipse.wb.gef.core.requests.PasteRequest;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPartListener;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.RequestConstants;
@@ -34,13 +34,13 @@ import java.util.Iterator;
 public abstract class LayoutEditPolicy extends GraphicalEditPolicy {
 	private final EditPartListener m_listener = new EditPartListener.Stub() {
 		@Override
-		public void childAdded(org.eclipse.gef.EditPart child, int index) {
-			decorateChild((EditPart) child);
+		public void childAdded(EditPart child, int index) {
+			decorateChild(child);
 		}
 
 		@Override
-		public void removingChild(org.eclipse.gef.EditPart child, int index) {
-			undecorateChild((EditPart) child);
+		public void removingChild(EditPart child, int index) {
+			undecorateChild(child);
 		}
 	};
 
@@ -136,7 +136,7 @@ public abstract class LayoutEditPolicy extends GraphicalEditPolicy {
 	 * {@link Request#REQ_PASTE}, {@link Request#REQ_MOVE} or {@link Request#REQ_ADD}.
 	 */
 	@Override
-	public EditPart getTargetEditPart(Request request) {
+	public org.eclipse.wb.gef.core.EditPart getTargetEditPart(Request request) {
 		return isRequestCondition(request) ? getHost() : null;
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/generic/FlowContainerLayoutEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/generic/FlowContainerLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -57,7 +57,7 @@ public final class FlowContainerLayoutEditPolicy extends ObjectFlowLayoutEditPol
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void decorateChild(org.eclipse.wb.gef.core.EditPart child) {
+	protected void decorateChild(EditPart child) {
 		if (m_container.validateComponent(child.getModel())) {
 			child.installEditPolicy(EditPolicy.SELECTION_FEEDBACK_ROLE, new NonResizableSelectionEditPolicy());
 			new SelectionEditPolicyInstaller(m_model, child).decorate();

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/generic/SelectionEditPolicyInstaller.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/generic/SelectionEditPolicyInstaller.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,11 +12,12 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.gef.policy.layout.generic;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.gef.graphical.policies.SelectionEditPolicy;
 import org.eclipse.wb.internal.core.utils.state.GlobalState;
 import org.eclipse.wb.internal.core.utils.state.IParametersProvider;
+
+import org.eclipse.gef.EditPart;
 
 import org.apache.commons.lang3.StringUtils;
 

--- a/org.eclipse.wb.layout.group/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.layout.group/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.layout.group;singleton:=true
-Bundle-Version: 1.9.1000.qualifier
+Bundle-Version: 1.9.1100.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
@@ -14,7 +14,7 @@ Bundle-ClassPath: .
 Require-Bundle: org.eclipse.core.resources;bundle-version="[3.20.200,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.31.100,4.0.0)",
  org.eclipse.jface;bundle-version="[3.34.0,4.0.0)",
- org.eclipse.wb.core;bundle-version="[1.20.0,2.0.0)",
+ org.eclipse.wb.core;bundle-version="[1.21.0,2.0.0)",
  org.eclipse.wb.core.java;bundle-version="[1.13.100,2.0.0)",
  org.eclipse.draw2d;bundle-version="[3.20.0,4.0.0)",
  org.eclipse.gef;bundle-version="[3.21.100,4.0.0)"

--- a/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/gef/GroupLayoutEditPolicy2.java
+++ b/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/gef/GroupLayoutEditPolicy2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -88,7 +88,7 @@ public abstract class GroupLayoutEditPolicy2 extends LayoutEditPolicy implements
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void decorateChild(org.eclipse.wb.gef.core.EditPart child) {
+	protected void decorateChild(EditPart child) {
 		if (m_layout.isRelatedComponent((JavaInfo) child.getModel())) {
 			child.installEditPolicy(EditPolicy.SELECTION_FEEDBACK_ROLE, new GroupSelectionEditPolicy2(m_layout));
 		}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/TableWrapLayoutEditPolicy.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/TableWrapLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -111,7 +111,7 @@ AbstractGridLayoutEditPolicy {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void decorateChild(org.eclipse.wb.gef.core.EditPart child) {
+	protected void decorateChild(EditPart child) {
 		Object model = child.getModel();
 		if (isControl(model)) {
 			C control = toControl(model);

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/header/layout/ColumnsLayoutEditPolicy.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/header/layout/ColumnsLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -74,7 +74,7 @@ AbstractHeaderLayoutEditPolicy {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void decorateChild(org.eclipse.wb.gef.core.EditPart child) {
+	protected void decorateChild(EditPart child) {
 		child.installEditPolicy(
 				EditPolicy.SELECTION_FEEDBACK_ROLE,
 				new ColumnSelectionEditPolicy<>(m_mainPolicy));

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/header/layout/RowsLayoutEditPolicy.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/header/layout/RowsLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -74,7 +74,7 @@ AbstractHeaderLayoutEditPolicy {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void decorateChild(org.eclipse.wb.gef.core.EditPart child) {
+	protected void decorateChild(EditPart child) {
 		child.installEditPolicy(EditPolicy.SELECTION_FEEDBACK_ROLE, new RowSelectionEditPolicy<>(m_mainPolicy));
 	}
 

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/FormLayoutEditPolicy.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/FormLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -94,7 +94,7 @@ public final class FormLayoutEditPolicy extends AbstractGridLayoutEditPolicy {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void decorateChild(org.eclipse.wb.gef.core.EditPart child) {
+	protected void decorateChild(EditPart child) {
 		if (child.getModel() instanceof ComponentInfo) {
 			ComponentInfo component = (ComponentInfo) child.getModel();
 			EditPolicy selectionPolicy = new FormSelectionEditPolicy(m_layout, component);

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/layout/ColumnsLayoutEditPolicy.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/layout/ColumnsLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -20,7 +20,6 @@ import org.eclipse.wb.core.gef.policy.layout.grid.IGridInfo;
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.draw2d.Layer;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
@@ -35,6 +34,7 @@ import org.eclipse.wb.internal.swing.FormLayout.model.FormLayoutInfo;
 import org.eclipse.draw2d.geometry.Interval;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.requests.DropRequest;

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/layout/RowsLayoutEditPolicy.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/layout/RowsLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -20,7 +20,6 @@ import org.eclipse.wb.core.gef.policy.layout.grid.IGridInfo;
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.draw2d.Layer;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
@@ -35,6 +34,7 @@ import org.eclipse.wb.internal.swing.FormLayout.model.FormRowInfo;
 import org.eclipse.draw2d.geometry.Interval;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.requests.DropRequest;

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/MigLayoutEditPolicy.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/MigLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -117,7 +117,7 @@ public final class MigLayoutEditPolicy extends AbstractGridLayoutEditPolicy {
 	}
 
 	@Override
-	protected void decorateChild(org.eclipse.wb.gef.core.EditPart child) {
+	protected void decorateChild(EditPart child) {
 		if (child.getModel() instanceof ComponentInfo) {
 			ComponentInfo component = (ComponentInfo) child.getModel();
 			CellConstraintsSupport constraints = MigLayoutInfo.getConstraints(component);

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/layout/ColumnsLayoutEditPolicy.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/layout/ColumnsLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -20,7 +20,6 @@ import org.eclipse.wb.core.gef.policy.layout.grid.IGridInfo;
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.draw2d.Layer;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
@@ -34,6 +33,7 @@ import org.eclipse.wb.internal.swing.MigLayout.model.MigLayoutInfo;
 import org.eclipse.draw2d.geometry.Interval;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.requests.DropRequest;

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/layout/RowsLayoutEditPolicy.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/layout/RowsLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -20,7 +20,6 @@ import org.eclipse.wb.core.gef.policy.layout.grid.IGridInfo;
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.draw2d.Layer;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
@@ -34,6 +33,7 @@ import org.eclipse.wb.internal.swing.MigLayout.model.MigLayoutInfo;
 import org.eclipse.draw2d.geometry.Interval;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.requests.DropRequest;

--- a/org.eclipse.wb.swing.java6/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing.java6/META-INF/MANIFEST.MF
@@ -2,14 +2,14 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swing.java6;singleton:=true
-Bundle-Version: 1.9.1000.qualifier
+Bundle-Version: 1.9.1100.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.wb.internal.swing.java6.laf
-Require-Bundle: org.eclipse.wb.core;bundle-version="[1.20.0,2.0.0)",
+Require-Bundle: org.eclipse.wb.core;bundle-version="[1.21.0,2.0.0)",
  org.eclipse.wb.swing;bundle-version="[1.10.200,2.0.0)",
- org.eclipse.wb.layout.group;bundle-version="[1.9.1000,2.0.0)",
+ org.eclipse.wb.layout.group;bundle-version="[1.9.1100,2.0.0)",
  org.eclipse.swt;bundle-version="[3.126.0,4.0.0)",
  org.eclipse.osgi;bundle-version="[3.20.0,4.0.0)",
  org.eclipse.ui.workbench;bundle-version="[3.132.0,4.0.0)",

--- a/org.eclipse.wb.swing.java6/src/org/eclipse/wb/internal/swing/java6/gef/GroupLayoutEditPolicy.java
+++ b/org.eclipse.wb.swing.java6/src/org/eclipse/wb/internal/swing/java6/gef/GroupLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -58,7 +58,7 @@ public final class GroupLayoutEditPolicy extends AbsoluteBasedLayoutEditPolicySw
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void decorateChild(org.eclipse.wb.gef.core.EditPart child) {
+	protected void decorateChild(EditPart child) {
 		Object model = child.getModel();
 		if (model instanceof ComponentInfo) {
 			child.installEditPolicy(EditPolicy.SELECTION_FEEDBACK_ROLE, new GroupSelectionEditPolicy(m_layout));

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/AbsoluteLayoutEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/AbsoluteLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -88,7 +88,7 @@ public final class AbsoluteLayoutEditPolicy extends AbsoluteBasedLayoutEditPolic
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void decorateChild(org.eclipse.wb.gef.core.EditPart child) {
+	protected void decorateChild(EditPart child) {
 		Object childModel = child.getModel();
 		if (childModel instanceof ComponentInfo) {
 			EditPolicy policy = new AbsoluteLayoutSelectionEditPolicy<ComponentInfo>();

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/CardLayoutEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/CardLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -65,7 +65,7 @@ public final class CardLayoutEditPolicy extends ComponentFlowLayoutEditPolicy {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void decorateChild(org.eclipse.wb.gef.core.EditPart child) {
+	protected void decorateChild(EditPart child) {
 		Object model = child.getModel();
 		if (m_layout.isManagedObject(model)) {
 			EditPolicy policy = new CardLayoutSelectionEditPolicy(m_layout);

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/GenericFlowLayoutEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/GenericFlowLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -59,7 +59,7 @@ public abstract class GenericFlowLayoutEditPolicy extends ComponentFlowLayoutEdi
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void decorateChild(org.eclipse.wb.gef.core.EditPart child) {
+	protected void decorateChild(EditPart child) {
 		if (child.getModel() instanceof ComponentInfo) {
 			child.installEditPolicy(EditPolicy.SELECTION_FEEDBACK_ROLE, new NonResizableSelectionEditPolicy());
 		}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/SpringLayoutEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/SpringLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -62,7 +62,7 @@ public final class SpringLayoutEditPolicy extends AbsoluteBasedLayoutEditPolicyS
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void decorateChild(org.eclipse.wb.gef.core.EditPart child) {
+	protected void decorateChild(EditPart child) {
 		Object model = child.getModel();
 		if (model instanceof ComponentInfo) {
 			child.installEditPolicy(EditPolicy.SELECTION_FEEDBACK_ROLE, new SpringSelectionEditPolicy(m_layout));

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/GridBagLayoutEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/GridBagLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -92,7 +92,7 @@ public final class GridBagLayoutEditPolicy extends AbstractGridLayoutEditPolicy 
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void decorateChild(org.eclipse.wb.gef.core.EditPart child) {
+	protected void decorateChild(EditPart child) {
 		Object model = child.getModel();
 		if (m_layout.isManagedObject(model)) {
 			ComponentInfo component = (ComponentInfo) model;

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/header/layout/ColumnsLayoutEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/header/layout/ColumnsLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -20,7 +20,6 @@ import org.eclipse.wb.core.gef.policy.layout.grid.IGridInfo;
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.draw2d.Layer;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
@@ -35,6 +34,7 @@ import org.eclipse.wb.internal.swing.model.layout.gbl.ColumnInfo;
 import org.eclipse.draw2d.geometry.Interval;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.requests.DropRequest;
@@ -105,7 +105,7 @@ public final class ColumnsLayoutEditPolicy extends AbstractHeaderLayoutEditPolic
 		// prepare target header
 		ColumnHeaderEditPart target = null;
 		{
-			List<EditPart> children = getHost().getChildren();
+			List<? extends EditPart> children = getHost().getChildren();
 			for (EditPart child : children) {
 				ColumnHeaderEditPart columnEditPart = (ColumnHeaderEditPart) child;
 				Rectangle bounds = columnEditPart.getFigure().getBounds();

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/header/layout/RowsLayoutEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/header/layout/RowsLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -20,7 +20,6 @@ import org.eclipse.wb.core.gef.policy.layout.grid.IGridInfo;
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.draw2d.Layer;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
@@ -35,6 +34,7 @@ import org.eclipse.wb.internal.swing.model.layout.gbl.RowInfo;
 import org.eclipse.draw2d.geometry.Interval;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.requests.DropRequest;
@@ -104,7 +104,7 @@ public final class RowsLayoutEditPolicy extends AbstractHeaderLayoutEditPolicy {
 		// prepare target header
 		RowHeaderEditPart target = null;
 		{
-			List<EditPart> children = getHost().getChildren();
+			List<? extends EditPart> children = getHost().getChildren();
 			for (EditPart child : children) {
 				RowHeaderEditPart rowEditPart = (RowHeaderEditPart) child;
 				Rectangle bounds = rowEditPart.getFigure().getBounds();

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/AbsoluteLayoutEditPolicy.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/AbsoluteLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -158,7 +158,7 @@ AbsoluteBasedLayoutEditPolicySWT<C> {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void decorateChild(org.eclipse.wb.gef.core.EditPart child) {
+	protected void decorateChild(EditPart child) {
 		if (m_layout.getControls().contains(child.getModel())) {
 			child.installEditPolicy(EditPolicy.SELECTION_FEEDBACK_ROLE, new AbsoluteLayoutSelectionEditPolicy<>());
 		}

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/DefaultLayoutEditPolicy.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/DefaultLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,12 +13,13 @@
 package org.eclipse.wb.internal.swt.gef.policy.layout;
 
 import org.eclipse.wb.core.gef.policy.selection.NonResizableSelectionEditPolicy;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.gef.graphical.policies.LayoutEditPolicy;
 import org.eclipse.wb.internal.swt.model.layout.LayoutInfo;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
+
+import org.eclipse.gef.EditPart;
 
 /**
  * {@link LayoutEditPolicy} {@link CompositeInfo} without known {@link LayoutInfo}.

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormHeaderLayoutEditPolicy.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormHeaderLayoutEditPolicy.java
@@ -86,7 +86,7 @@ AbstractHeaderLayoutEditPolicy {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void decorateChild(org.eclipse.wb.gef.core.EditPart child) {
+	protected void decorateChild(EditPart child) {
 		child.installEditPolicy(
 				EditPolicy.SELECTION_FEEDBACK_ROLE,
 				new FormHeaderSelectionEditPolicy(mainPolicy));

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormLayoutEditPolicy.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -90,7 +90,7 @@ AbsoluteBasedLayoutEditPolicySWT<C> {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void decorateChild(org.eclipse.wb.gef.core.EditPart child) {
+	protected void decorateChild(EditPart child) {
 		if (layout.getControls().contains(child.getModel())) {
 			child.installEditPolicy(EditPolicy.SELECTION_FEEDBACK_ROLE, new FormSelectionEditPolicy<>(layout));
 		}

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormLayoutEditPolicy2.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormLayoutEditPolicy2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -86,7 +86,7 @@ IHeadersProvider {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void decorateChild(org.eclipse.wb.gef.core.EditPart child) {
+	protected void decorateChild(EditPart child) {
 		if (m_layout.getControls().contains(child.getModel())) {
 			child.installEditPolicy(EditPolicy.SELECTION_FEEDBACK_ROLE, new FormSelectionEditPolicy2(m_layout));
 		}

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormLayoutEditPolicyClassic.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormLayoutEditPolicyClassic.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -120,7 +120,7 @@ implements IHeadersProvider {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void decorateChild(org.eclipse.wb.gef.core.EditPart child) {
+	protected void decorateChild(EditPart child) {
 		if (layout.getControls().contains(child.getModel())) {
 			child.installEditPolicy(EditPolicy.SELECTION_FEEDBACK_ROLE, new FormSelectionEditPolicyClassic<>(layout));
 		}

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/GridLayoutEditPolicy.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/GridLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -114,7 +114,7 @@ AbstractGridLayoutEditPolicy implements IRefreshableEditPolicy {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void decorateChild(org.eclipse.wb.gef.core.EditPart child) {
+	protected void decorateChild(EditPart child) {
 		Object model = child.getModel();
 		if (m_layout.isManagedObject(model)) {
 			C control = toControl(model);

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/header/layout/ColumnsLayoutEditPolicy.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/header/layout/ColumnsLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -20,7 +20,6 @@ import org.eclipse.wb.core.gef.policy.layout.grid.IGridInfo;
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.draw2d.Layer;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
@@ -37,6 +36,7 @@ import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 import org.eclipse.draw2d.geometry.Interval;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.requests.DropRequest;
@@ -119,7 +119,7 @@ AbstractHeaderLayoutEditPolicy {
 		// prepare target header
 		DimensionHeaderEditPart<C> target = null;
 		{
-			List<EditPart> children = getHost().getChildren();
+			List<? extends EditPart> children = getHost().getChildren();
 			for (EditPart child : children) {
 				DimensionHeaderEditPart<C> columnEditPart = (DimensionHeaderEditPart<C>) child;
 				Rectangle bounds = columnEditPart.getFigure().getBounds();

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/header/layout/RowsLayoutEditPolicy.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/header/layout/RowsLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -20,7 +20,6 @@ import org.eclipse.wb.core.gef.policy.layout.grid.IGridInfo;
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.draw2d.Layer;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
@@ -37,6 +36,7 @@ import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 import org.eclipse.draw2d.geometry.Interval;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.requests.DropRequest;
@@ -118,7 +118,7 @@ AbstractHeaderLayoutEditPolicy {
 		// prepare target header
 		DimensionHeaderEditPart<C> target = null;
 		{
-			List<EditPart> children = getHost().getChildren();
+			List<? extends EditPart> children = getHost().getChildren();
 			for (EditPart child : children) {
 				DimensionHeaderEditPart<C> rowEditPart = (DimensionHeaderEditPart<C>) child;
 				Rectangle bounds = rowEditPart.getFigure().getBounds();


### PR DESCRIPTION
This avoids an ugly type-cast to the WindowBuilder EditPart