### PR TITLE
[GEF] Avoid overloading of getChildren() method in EditPart

### DIFF
--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/EditPart.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/EditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -41,15 +41,6 @@ public abstract class EditPart extends org.eclipse.gef.editparts.AbstractEditPar
 	// Parent/Children
 	//
 	////////////////////////////////////////////////////////////////////////////
-	/**
-	 * Returns the List of children <code>EditParts</code>. This method should rarely be called, and
-	 * is only made public so that helper objects of this EditPart, such as EditPolicies, can obtain
-	 * the children. The returned List may be by reference, and should never be modified.
-	 */
-	@Override
-	public List<EditPart> getChildren() {
-		return (List<EditPart>) super.getChildren();
-	}
 	/**
 	 * Returns the parent <code>{@link EditPart}</code>. This method should only be called internally
 	 * or by helpers such as EditPolicies.
@@ -93,7 +84,7 @@ public abstract class EditPart extends org.eclipse.gef.editparts.AbstractEditPar
 	 */
 	public final void accept(EditPartVisitor visitor) {
 		if (visitor.visit(this)) {
-			for (EditPart childPart : getChildren()) {
+			for (EditPart childPart : (List<EditPart>) getChildren()) {
 				childPart.accept(visitor);
 			}
 			visitor.endVisit(this);
@@ -129,7 +120,7 @@ public abstract class EditPart extends org.eclipse.gef.editparts.AbstractEditPar
 	protected void refreshChildren() {
 		// prepare map[model, currentPart]
 		Map<Object, EditPart> modelToPart = new HashMap<>();
-		List<EditPart> children = getChildren();
+		List<EditPart> children = (List<EditPart>) getChildren();
 		for (EditPart editPart : children) {
 			modelToPart.put(editPart.getModel(), editPart);
 		}
@@ -185,7 +176,7 @@ public abstract class EditPart extends org.eclipse.gef.editparts.AbstractEditPar
 			removeChild(childPart);
 		}
 		// recurse refresh()
-		for (EditPart child : getChildren()) {
+		for (EditPart child : (List<EditPart>) getChildren()) {
 			child.refresh();
 		}
 	}

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/tree/TreeEditPart.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/tree/TreeEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,10 +12,10 @@
  *******************************************************************************/
 package org.eclipse.wb.gef.tree;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.tools.Tool;
 import org.eclipse.wb.internal.gef.tree.tools.DoubleClickEditPartTracker;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.DisposeEvent;
@@ -28,7 +28,7 @@ import java.util.List;
  * @author lobas_av
  * @coverage gef.tree
  */
-public abstract class TreeEditPart extends EditPart {
+public abstract class TreeEditPart extends org.eclipse.wb.gef.core.EditPart {
 	private TreeItem m_widget;
 	private boolean m_expandedShouldRestore;
 	private boolean m_expanded;
@@ -45,7 +45,7 @@ public abstract class TreeEditPart extends EditPart {
 	public void setWidget(TreeItem widget) {
 		m_widget = widget;
 		//
-		List<EditPart> children = getChildren();
+		List<? extends EditPart> children = getChildren();
 		if (m_widget == null) {
 			for (EditPart editPart : children) {
 				TreeEditPart treePart = (TreeEditPart) editPart;
@@ -69,13 +69,13 @@ public abstract class TreeEditPart extends EditPart {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void addChildVisual(org.eclipse.gef.EditPart childPart, int index) {
+	protected void addChildVisual(EditPart childPart, int index) {
 		TreeEditPart treePart = (TreeEditPart) childPart;
 		treePart.setWidget(new TreeItem(getWidget(), SWT.NONE, index));
 	}
 
 	@Override
-	protected void removeChildVisual(org.eclipse.gef.EditPart childPart) {
+	protected void removeChildVisual(EditPart childPart) {
 		TreeEditPart treePart = (TreeEditPart) childPart;
 		if (treePart.getWidget() != null) {
 			treePart.getWidget().dispose();
@@ -84,7 +84,7 @@ public abstract class TreeEditPart extends EditPart {
 	}
 
 	@Override
-	protected void updateChildVisual(EditPart childPart, int index) {
+	protected void updateChildVisual(org.eclipse.wb.gef.core.EditPart childPart, int index) {
 		TreeEditPart treePart = (TreeEditPart) childPart;
 		if (treePart.getWidget() == null) {
 			treePart.setWidget(new TreeItem(getWidget(), SWT.NONE, index));

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/tree/policies/LayoutEditPolicy.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/tree/policies/LayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -158,7 +158,7 @@ public abstract class LayoutEditPolicy extends EditPolicy {
 			return null;
 		}
 		// prepare children
-		List<org.eclipse.wb.gef.core.EditPart> children = getReferenceChildren(request);
+		List<EditPart> children = getReferenceChildren(request);
 		// calculate next reference
 		Object referenceObject = null;
 		if (targetItem == getHostWidget()) {
@@ -198,11 +198,11 @@ public abstract class LayoutEditPolicy extends EditPolicy {
 	/**
 	 * @return the {@link List} of {@link EditPart}'s that can be used as references.
 	 */
-	private List<org.eclipse.wb.gef.core.EditPart> getReferenceChildren(Request request) {
-		List<org.eclipse.wb.gef.core.EditPart> allChildren = getHost().getChildren();
-		List<org.eclipse.wb.gef.core.EditPart> referenceChildren = new ArrayList<>();
+	private List<EditPart> getReferenceChildren(Request request) {
+		List<? extends EditPart> allChildren = getHost().getChildren();
+		List<EditPart> referenceChildren = new ArrayList<>();
 		//
-		for (org.eclipse.wb.gef.core.EditPart editPart : allChildren) {
+		for (EditPart editPart : allChildren) {
 			if (isGoodReferenceChild(request, editPart)) {
 				referenceChildren.add(editPart);
 			}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/LayoutPolicyUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/LayoutPolicyUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,9 +12,10 @@
  *******************************************************************************/
 package org.eclipse.wb.core.gef.policy.layout;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.graphical.policies.LayoutEditPolicy;
 import org.eclipse.wb.internal.core.utils.external.ExternalFactoriesHelper;
+
+import org.eclipse.gef.EditPart;
 
 import java.util.List;
 
@@ -33,7 +34,7 @@ public class LayoutPolicyUtils {
 	/**
 	 * @return the {@link LayoutEditPolicy} for given model.
 	 */
-	public static LayoutEditPolicy createLayoutEditPolicy(EditPart context, Object model) {
+	public static LayoutEditPolicy createLayoutEditPolicy(org.eclipse.wb.gef.core.EditPart context, Object model) {
 		// try to create policy
 		List<ILayoutEditPolicyFactory> factories =
 				ExternalFactoriesHelper.getElementsInstances(

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/grid/AbstractGridSelectionEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/grid/AbstractGridSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -22,7 +22,6 @@ import org.eclipse.wb.draw2d.AbstractRelativeLocator;
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.RectangleFigure;
 import org.eclipse.wb.draw2d.RelativeLocator;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
 import org.eclipse.wb.gef.graphical.handles.Handle;
@@ -41,6 +40,7 @@ import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Interval;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.swt.graphics.Color;
@@ -196,7 +196,7 @@ public abstract class AbstractGridSelectionEditPolicy extends SelectionEditPolic
 			m_alignmentFigures = new ArrayList<>();
 			// show cell figures for all children of host's parent
 			{
-				Collection<EditPart> editParts = getHost().getParent().getChildren();
+				Collection<? extends EditPart> editParts = getHost().getParent().getChildren();
 				for (EditPart editPart : editParts) {
 					showCellFigures(editPart);
 				}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/MenuObjectEditPart.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/MenuObjectEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,7 +13,6 @@
 package org.eclipse.wb.internal.core.gef.part.menu;
 
 import org.eclipse.wb.core.gef.part.menu.IMenuObjectEditPart;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.requests.DragPermissionRequest;
 import org.eclipse.wb.gef.core.requests.PasteRequest;
 import org.eclipse.wb.gef.core.tools.Tool;
@@ -24,6 +23,7 @@ import org.eclipse.wb.internal.core.model.menu.MenuObjectInfoUtils;
 import org.eclipse.wb.internal.gef.core.EditPartVisitor;
 import org.eclipse.wb.internal.gef.core.IActiveToolListener;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.RequestConstants;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
@@ -163,10 +163,10 @@ public abstract class MenuObjectEditPart extends GraphicalEditPart implements IM
 
 			@Override
 			public void deleting(Object toolkitModel) {
-				EditPart objectPart = (EditPart) getViewer().getEditPartRegistry().get(toolkitModel);
+				EditPart objectPart = getViewer().getEditPartRegistry().get(toolkitModel);
 				if (objectPart != null) {
 					EditPart parentPart = objectPart.getParent();
-					List<EditPart> siblings = parentPart.getChildren();
+					List<? extends EditPart> siblings = parentPart.getChildren();
 					int index = siblings.indexOf(objectPart);
 					// move selection on sibling or parent item
 					if (siblings.size() == 1) {
@@ -191,9 +191,9 @@ public abstract class MenuObjectEditPart extends GraphicalEditPart implements IM
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public EditPart getTargetEditPart(org.eclipse.gef.Request request) {
+	public org.eclipse.wb.gef.core.EditPart getTargetEditPart(org.eclipse.gef.Request request) {
 		request = processRequestProcessors(request);
-		EditPart target = super.getTargetEditPart(request);
+		org.eclipse.wb.gef.core.EditPart target = super.getTargetEditPart(request);
 		boolean isOperationRequest =
 				request.getType() == RequestConstants.REQ_CREATE
 				|| request.getType() == PasteRequest.REQ_PASTE
@@ -206,9 +206,9 @@ public abstract class MenuObjectEditPart extends GraphicalEditPart implements IM
 				public void run() {
 					try {
 						MenuObjectInfoUtils.m_selectingObject = m_object;
-						((EditPart)getViewer().getRootEditPart()).accept(new EditPartVisitor() {
+						((org.eclipse.wb.gef.core.EditPart)getViewer().getRootEditPart()).accept(new EditPartVisitor() {
 							@Override
-							public boolean visit(EditPart editPart) {
+							public boolean visit(org.eclipse.wb.gef.core.EditPart editPart) {
 								if (editPart instanceof MenuObjectEditPart) {
 									editPart.refresh();
 									return false;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/AbsoluteComplexSelectionEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/AbsoluteComplexSelectionEditPolicy.java
@@ -20,7 +20,6 @@ import org.eclipse.wb.core.model.IAbstractComponentInfo;
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.draw2d.Polyline;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.internal.core.gef.policy.layout.absolute.actions.AnchorsActionsSupport;
 import org.eclipse.wb.internal.core.gef.policy.snapping.ComponentAttachmentInfo;
@@ -35,6 +34,7 @@ import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.draw2d.geometry.Transposer;
+import org.eclipse.gef.EditPart;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
@@ -241,7 +241,7 @@ public abstract class AbsoluteComplexSelectionEditPolicy<C extends IAbstractComp
 			m_alignmentFigures = new ArrayList<>();
 			// show cell figures for all children of host's parent
 			{
-				Collection<EditPart> editParts = getHost().getParent().getChildren();
+				Collection<? extends EditPart> editParts = getHost().getParent().getChildren();
 				for (EditPart editPart : editParts) {
 					showAlignmentFigures(editPart);
 				}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/gef/EditPartsContentProvider.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/gef/EditPartsContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.utils.gef;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.Viewer;
 
@@ -64,7 +64,7 @@ public final class EditPartsContentProvider implements ITreeContentProvider {
 
 	@Override
 	public Object[] getChildren(Object parentElement) {
-		EditPart parentEditPart = (EditPart) m_viewer.getEditPartRegistry().get(parentElement);
+		EditPart parentEditPart = m_viewer.getEditPartRegistry().get(parentElement);
 		if (parentEditPart != null) {
 			List<Object> children = new ArrayList<>();
 			for (EditPart editPart : parentEditPart.getChildren()) {
@@ -77,7 +77,7 @@ public final class EditPartsContentProvider implements ITreeContentProvider {
 
 	@Override
 	public Object getParent(Object element) {
-		EditPart editPart = (EditPart) m_viewer.getEditPartRegistry().get(element);
+		EditPart editPart = m_viewer.getEditPartRegistry().get(element);
 		if (editPart != null) {
 			return editPart.getParent().getModel();
 		}

--- a/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/gef/GroupSelectionEditPolicy2.java
+++ b/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/gef/GroupSelectionEditPolicy2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -22,7 +22,6 @@ import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.ObjectInfoUtils;
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.border.LineBorder;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
 import org.eclipse.wb.gef.graphical.handles.Handle;
@@ -42,6 +41,7 @@ import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.draw2d.geometry.Translatable;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.jface.action.IMenuManager;
@@ -312,7 +312,7 @@ LayoutConstants {
 			m_alignmentFigures = new ArrayList<>();
 			// show cell figures for all children of host's parent
 			{
-				Collection<EditPart> editParts = getHost().getParent().getChildren();
+				Collection<? extends EditPart> editParts = getHost().getParent().getChildren();
 				for (EditPart editPart : editParts) {
 					showAlignmentFigures(editPart);
 				}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/part/widgets/DialogEditPart.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/part/widgets/DialogEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,9 +14,10 @@ package org.eclipse.wb.internal.rcp.gef.part.widgets;
 
 import org.eclipse.wb.core.gef.part.AbstractComponentEditPart;
 import org.eclipse.wb.core.gef.policy.selection.TopSelectionEditPolicy;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.internal.rcp.model.widgets.DialogInfo;
+
+import org.eclipse.gef.EditPart;
 
 /**
  * {@link EditPart} for {@link DialogInfo}.

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/MigLayoutEditPolicy.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/MigLayoutEditPolicy.java
@@ -111,7 +111,7 @@ public final class MigLayoutEditPolicy extends AbstractGridLayoutEditPolicy {
 	 * different {@link SelectionEditPolicy}.
 	 */
 	private void decorateChildren() {
-		for (org.eclipse.wb.gef.core.EditPart child : getHost().getChildren()) {
+		for (EditPart child : getHost().getChildren()) {
 			decorateChild(child);
 		}
 	}

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/AnchorFiguresClassic.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/AnchorFiguresClassic.java
@@ -17,7 +17,6 @@ import org.eclipse.wb.core.gef.policy.layout.LayoutPolicyUtils;
 import org.eclipse.wb.core.gef.policy.layout.generic.AbstractPopupFigure;
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.Layer;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.graphical.policies.SelectionEditPolicy;
 import org.eclipse.wb.internal.core.gef.policy.snapping.PlacementUtils;
@@ -28,6 +27,7 @@ import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.editparts.LayerManager;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.resource.ImageDescriptor;
@@ -70,7 +70,7 @@ public final class AnchorFiguresClassic<C extends IControlInfo> {
 			m_alignmentFigures = new ArrayList<>();
 			// show alignment figures for all of the children of the host's parent
 			{
-				Collection<EditPart> editParts = m_policy.getHost().getParent().getChildren();
+				Collection<? extends EditPart> editParts = m_policy.getHost().getParent().getChildren();
 				for (EditPart editPart : editParts) {
 					showAlignmentFigures(editPart);
 				}

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/GridLayoutEditPolicy.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/GridLayoutEditPolicy.java
@@ -125,8 +125,8 @@ AbstractGridLayoutEditPolicy implements IRefreshableEditPolicy {
 
 	@Override
 	public void refreshEditPolicy() {
-		List<org.eclipse.wb.gef.core.EditPart> children = getHost().getChildren();
-		for (org.eclipse.wb.gef.core.EditPart child : children) {
+		List<? extends EditPart> children = getHost().getChildren();
+		for (EditPart child : children) {
 			Object model = child.getModel();
 			if (isControl(model)) {
 				// not managed: never was or excluded

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/widgets/ViewFormGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/widgets/ViewFormGefTest.java
@@ -12,10 +12,11 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.rcp.model.widgets;
 
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.internal.rcp.model.widgets.ViewFormInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 import org.eclipse.wb.tests.designer.rcp.RcpGefTest;
+
+import org.eclipse.gef.EditPart;
 
 import org.junit.jupiter.api.Test;
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuComplexTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuComplexTest.java
@@ -13,7 +13,6 @@
 package org.eclipse.wb.tests.designer.swt.model.menu;
 
 import org.eclipse.wb.core.model.JavaInfo;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.gef.core.tools.PasteTool;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
@@ -25,6 +24,7 @@ import org.eclipse.wb.internal.swt.model.widgets.menu.MenuItemInfo;
 import org.eclipse.wb.tests.designer.rcp.RcpGefTest;
 
 import org.eclipse.draw2d.PositionConstants;
+import org.eclipse.gef.EditPart;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuPopupSimpleTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuPopupSimpleTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,7 +13,6 @@
 package org.eclipse.wb.tests.designer.swt.model.menu;
 
 import org.eclipse.wb.core.model.JavaInfo;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.gef.core.tools.SelectEditPartTracker;
@@ -29,6 +28,7 @@ import org.eclipse.wb.tests.gef.GraphicalRobot;
 
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.EditPart;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -133,7 +133,7 @@ public class MenuPopupSimpleTest extends RcpGefTest {
 		// click on "popup": drop-down appears
 		canvas.click(popupPart);
 		{
-			List<EditPart> children = popupPart.getChildren();
+			List<? extends EditPart> children = popupPart.getChildren();
 			assertEquals(1, children.size());
 			EditPart dropPart = children.get(0);
 			// drop-down has simple "drag tracker"
@@ -184,7 +184,7 @@ public class MenuPopupSimpleTest extends RcpGefTest {
 		tree.select(popupInfo);
 		assertEquals(EditPart.SELECTED_PRIMARY, popupPart.getSelected());
 		{
-			List<EditPart> children = popupPart.getChildren();
+			List<? extends EditPart> children = popupPart.getChildren();
 			assertEquals(1, children.size());
 			assertInstanceOf(EditPart.class, children.get(0));
 		}
@@ -207,7 +207,7 @@ public class MenuPopupSimpleTest extends RcpGefTest {
 		tree.select(popupInfo);
 		assertEquals(EditPart.SELECTED_PRIMARY, popupPart.getSelected());
 		{
-			List<EditPart> children = popupPart.getChildren();
+			List<? extends EditPart> children = popupPart.getChildren();
 			assertEquals(1, children.size());
 			assertInstanceOf(EditPart.class, children.get(0));
 		}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/EditPartTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/EditPartTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,7 +13,6 @@
 package org.eclipse.wb.tests.gef;
 
 import org.eclipse.wb.draw2d.Figure;
-import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
@@ -21,6 +20,7 @@ import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
 import org.eclipse.draw2d.EventListenerList;
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPartListener;
 import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.Request;
@@ -278,7 +278,7 @@ public class EditPartTest extends GefTestCase {
 			}
 
 			@Override
-			public EditPart getTargetEditPart(Request request) {
+			public org.eclipse.wb.gef.core.EditPart getTargetEditPart(Request request) {
 				actualLogger.log(getHost(), "getTargetEditPart", request);
 				return getHost();
 			}
@@ -513,7 +513,7 @@ public class EditPartTest extends GefTestCase {
 		parent.test_access_addChild(child2, -1);
 		//
 		// check add child1 and child2
-		List<EditPart> children = parent.getChildren();
+		List<? extends EditPart> children = parent.getChildren();
 		assertNotNull(children);
 		assertEquals(2, children.size());
 		assertSame(child1, children.get(0));
@@ -557,7 +557,7 @@ public class EditPartTest extends GefTestCase {
 		};
 		parent.activate();
 		parent.refresh();
-		List<EditPart> children = parent.getChildren();
+		List<? extends EditPart> children = parent.getChildren();
 		assertEquals(4, children.size());
 		assertEquals("_child2_Model", children.get(0).getModel());
 		assertEquals("_child5_Model", children.get(1).getModel());
@@ -604,7 +604,7 @@ public class EditPartTest extends GefTestCase {
 		parent.test_access_addChild(child4, -1);
 		//
 		// check add child1 and child2
-		List<EditPart> children = parent.getChildren();
+		List<? extends EditPart> children = parent.getChildren();
 		assertNotNull(children);
 		assertEquals(3, children.size());
 		assertSame(child1, children.get(0));


### PR DESCRIPTION
At some point, the GraphicalEditPart should implement the GEF interface with the same name. For this, the getChildren() method needs to be overloaded to return a list of GraphicalEditParts, which is not possible when the method already returns a list of WindowBuilder EditParts.