### PR TITLE
[GEF] Calculate target handle using findFigureAt()

### DIFF
--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Layer.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Layer.java
@@ -80,4 +80,9 @@ public class Layer extends Figure {
 	@Override
 	public void setOpaque(boolean opaque) {
 	}
+
+	@Override
+	public String toString() {
+		return "[%s] %s".formatted(getClass().getSimpleName(), getName());
+	}
 }

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/handles/Handle.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/handles/Handle.java
@@ -164,4 +164,9 @@ public abstract class Handle extends Figure implements AncestorListener, org.ecl
 		translateToAbsolute(p);
 		return p;
 	}
+
+	@Override
+	public String toString() {
+		return "[%s] %s".formatted(getClass().getSimpleName(), getBounds());
+	}
 }

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/graphical/GraphicalViewer.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/graphical/GraphicalViewer.java
@@ -18,12 +18,12 @@ import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.internal.draw2d.FigureCanvas;
 import org.eclipse.wb.internal.draw2d.IRootFigure;
 import org.eclipse.wb.internal.draw2d.RootFigure;
-import org.eclipse.wb.internal.draw2d.TargetFigureFindVisitor;
 import org.eclipse.wb.internal.gef.core.AbstractEditPartViewer;
 import org.eclipse.wb.internal.gef.core.EditDomain;
 import org.eclipse.wb.internal.gef.core.TargetEditPartFindVisitor;
 
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.TreeSearch;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.gef.Handle;
 import org.eclipse.swt.SWT;
@@ -221,9 +221,17 @@ public class GraphicalViewer extends AbstractEditPartViewer implements org.eclip
 	 * given location <code>(x, y)</code>.
 	 */
 	private Handle findTargetHandle(String layer, Point p) {
-		TargetFigureFindVisitor visitor = new TargetFigureFindVisitor(m_canvas, p.x, p.y);
-		((Layer) m_rootEditPart.getLayer(layer)).accept(visitor, false);
-		Figure targetFigure = visitor.getTargetFigure();
-		return targetFigure instanceof Handle ? (Handle) targetFigure : null;
+		return (Handle) m_canvas.getLightweightSystem().getRootFigure().findFigureAt(p.x, p.y,
+				new TreeSearch() {
+			@Override
+			public boolean accept(IFigure figure) {
+				return figure instanceof Handle;
+			}
+
+			@Override
+			public boolean prune(IFigure figure) {
+				return figure instanceof Layer layerFigure && !layer.equals(layerFigure.getName());
+			}
+		});
 	}
 }


### PR DESCRIPTION
This replaces the TargetFigureFindVisitor used in the findTargetHandle() method with call to findFigureAt(), which is provided by Draw2D. A custom filter is used to restrict the search to only accept Handles and to only look in the specified layer.