### PR TITLE
[GEF] Rename getLocation() and getStartLocation() in Tool

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/tools/TabOrderTool.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/tools/TabOrderTool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -197,8 +197,8 @@ public final class TabOrderTool extends TargetingTool {
 		// find on clickable layer
 		EditPart editPart =
 				getCurrentViewer().findTargetEditPart(
-						getCurrentInput().getMouseLocation().x,
-						getCurrentInput().getMouseLocation().y,
+						getLocation().x,
+						getLocation().y,
 						getExclusionSet(),
 						getTargetingConditional(),
 						IEditPartViewer.CLICKABLE_LAYER);
@@ -206,8 +206,8 @@ public final class TabOrderTool extends TargetingTool {
 		if (editPart == null) {
 			editPart =
 					getCurrentViewer().findTargetEditPart(
-							getCurrentInput().getMouseLocation().x,
-							getCurrentInput().getMouseLocation().y,
+							getLocation().x,
+							getLocation().y,
 							getExclusionSet(),
 							getTargetingConditional());
 		}

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/AbstractCreationTool.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/AbstractCreationTool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -47,7 +47,7 @@ public abstract class AbstractCreationTool extends TargetingTool {
 		if (button == 1) {
 			if (m_state == STATE_INITIAL) {
 				m_state = STATE_DRAG;
-				((AbstractCreateRequest) getTargetRequest()).setLocation(getLocation());
+				((AbstractCreateRequest) getTargetRequest()).setLocation(getAbsoluteLocation());
 				lockTargetEditPart(getTargetEditPart());
 			}
 		} else {
@@ -117,13 +117,13 @@ public abstract class AbstractCreationTool extends TargetingTool {
 		super.updateTargetRequest();
 		AbstractCreateRequest request = (AbstractCreateRequest) getTargetRequest();
 		if (m_state == STATE_DRAG_IN_PROGRESS) {
-			Point start = getStartLocation();
+			Point start = getAbsoluteStartLocation();
 			Rectangle bounds = new Rectangle(start, getDragMoveDelta());
 			request.setLocation(bounds.getLocation());
 			request.setSize(bounds.getSize());
 		} else {
 			request.setSize(null);
-			request.setLocation(getLocation());
+			request.setLocation(getAbsoluteLocation());
 		}
 	}
 

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/DragEditPartTracker.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/DragEditPartTracker.java
@@ -209,7 +209,7 @@ public class DragEditPartTracker extends SelectEditPartTracker {
 		ChangeBoundsRequest request = (ChangeBoundsRequest) getTargetRequest();
 		request.setEditParts(getOperationSet());
 		request.setMoveDelta(new Point(getDragMoveDelta()));
-		request.setLocation(getLocation());
+		request.setLocation(getAbsoluteLocation());
 	}
 
 	@Override

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/SelectEditPartTracker.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/SelectEditPartTracker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -111,7 +111,7 @@ public class SelectEditPartTracker extends TargetingTool {
 		if (button == 1) {
 			SelectionRequest request = new SelectionRequest();
 			request.setType(RequestConstants.REQ_OPEN);
-			request.setLocation(getLocation());
+			request.setLocation(getAbsoluteLocation());
 			m_sourceEditPart.performRequest(request);
 		}
 		return true;

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/TargetingTool.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/TargetingTool.java
@@ -170,8 +170,8 @@ public abstract class TargetingTool extends Tool {
 		if (!m_isLockTarget) {
 			org.eclipse.wb.gef.core.EditPart editPart =
 					getCurrentViewer().findTargetEditPart(
-							getCurrentInput().getMouseLocation().x,
-							getCurrentInput().getMouseLocation().y,
+							getLocation().x,
+							getLocation().y,
 							getExclusionSet(),
 							getTargetingConditional());
 			if (editPart != null) {

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/Tool.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/Tool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -105,8 +105,8 @@ public abstract class Tool extends org.eclipse.gef.tools.AbstractTool implements
 				event.display = Display.getCurrent();
 				event.widget = getCurrentViewer().getControl();
 				event.type = SWT.MouseMove;
-				event.x = getCurrentInput().getMouseLocation().x;
-				event.y = getCurrentInput().getMouseLocation().y;
+				event.x = getLocation().x;
+				event.y = getLocation().y;
 				event.button = m_button;
 				event.stateMask = m_stateMask;
 			}
@@ -242,8 +242,8 @@ public abstract class Tool extends org.eclipse.gef.tools.AbstractTool implements
 
 	protected boolean movedPastThreshold() {
 		if (!getFlag(FLAG_PAST_THRESHOLD)) {
-			Point start = getStartLocation();
-			Point end = getLocation();
+			Point start = getAbsoluteStartLocation();
+			Point end = getAbsoluteLocation();
 			setFlag(FLAG_PAST_THRESHOLD, Math.abs(start.x - end.x) > DRAG_THRESHOLD || Math.abs(start.y - end.y) > DRAG_THRESHOLD);
 		}
 		return getFlag(FLAG_PAST_THRESHOLD);
@@ -351,9 +351,9 @@ public abstract class Tool extends org.eclipse.gef.tools.AbstractTool implements
 	/**
 	 * Returns the current x, y <b>*absolute*</b> position of the mouse cursor.
 	 */
-	public final Point getLocation() {
-		return new Point(getCurrentInput().getMouseLocation().x + getCurrentViewer().getHOffset(),
-				getCurrentInput().getMouseLocation().y + getCurrentViewer().getVOffset());
+	public final Point getAbsoluteLocation() {
+		return new Point(getLocation().x + getCurrentViewer().getHOffset(),
+				getLocation().y + getCurrentViewer().getVOffset());
 	}
 
 	/**
@@ -361,9 +361,9 @@ public abstract class Tool extends org.eclipse.gef.tools.AbstractTool implements
 	 * typically the mouse location where the user first pressed a mouse button. This is important for
 	 * tools that interpret mouse drags.
 	 */
-	protected Point getStartLocation() {
-		return new Point(super.getStartLocation().x + getCurrentViewer().getHOffset(),
-				super.getStartLocation().y + getCurrentViewer().getVOffset());
+	protected Point getAbsoluteStartLocation() {
+		return new Point(getStartLocation().x + getCurrentViewer().getHOffset(),
+				getStartLocation().y + getCurrentViewer().getVOffset());
 	}
 
 	/**

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/tools/MarqueeSelectionTool.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/tools/MarqueeSelectionTool.java
@@ -287,7 +287,7 @@ public class MarqueeSelectionTool extends Tool {
 	 * bottom-right corner <code>(m_currentX, m_currentY)</code>.
 	 */
 	private Rectangle getMarqueeSelectionRectangle() {
-		return new Rectangle(getStartLocation(), getLocation());
+		return new Rectangle(getAbsoluteStartLocation(), getAbsoluteLocation());
 	}
 
 	/**

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/tools/ResizeTracker.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/tools/ResizeTracker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -260,7 +260,7 @@ public class ResizeTracker extends Tool {
 		// set request data
 		getRequest().setMoveDelta(corner);
 		getRequest().setSizeDelta(resize);
-		getRequest().setLocation(getLocation());
+		getRequest().setLocation(getAbsoluteLocation());
 	}
 
 	/**

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/tools/SelectionTool.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/tools/SelectionTool.java
@@ -130,7 +130,7 @@ public class SelectionTool extends TargetingTool {
 				return true;
 			}
 			//
-			Point current = getCurrentInput().getMouseLocation();
+			Point current = getLocation();
 			if (getCurrentViewer() instanceof GraphicalViewer gv) {
 				Handle handle = (Handle) gv.findHandleAt(current);
 				if (handle != null) {
@@ -187,8 +187,8 @@ public class SelectionTool extends TargetingTool {
 		if (m_state == STATE_DRAG || m_state == STATE_DRAG_IN_PROGRESS) {
 			// send low level event to give current tracker a chance to process 'mouse up' event.
 			Event event = new Event();
-			event.x = getCurrentInput().getMouseLocation().x;
-			event.y = getCurrentInput().getMouseLocation().y;
+			event.x = getLocation().x;
+			event.y = getLocation().y;
 			event.stateMask = m_stateMask;
 			event.button = m_button;
 			event.widget = getCurrentViewer().getControl();
@@ -220,7 +220,7 @@ public class SelectionTool extends TargetingTool {
 	protected void updateTargetRequest() {
 		super.updateTargetRequest();
 		SelectionRequest request = (SelectionRequest) getTargetRequest();
-		request.setLocation(getLocation());
+		request.setLocation(getAbsoluteLocation());
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/tree/tools/DoubleClickEditPartTracker.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/tree/tools/DoubleClickEditPartTracker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -48,7 +48,7 @@ public class DoubleClickEditPartTracker extends Tool {
 		if (button == 1) {
 			SelectionRequest request = new SelectionRequest();
 			request.setType(RequestConstants.REQ_OPEN);
-			request.setLocation(getLocation());
+			request.setLocation(getAbsoluteLocation());
 			m_sourceEditPart.performRequest(request);
 		}
 		return true;

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormHeaderLayoutEditPolicy.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormHeaderLayoutEditPolicy.java
@@ -235,7 +235,7 @@ AbstractHeaderLayoutEditPolicy {
 	public void buildContextMenu(IMenuManager manager) {
 		IEditPartViewer viewer = getHost().getViewer();
 		Tool tool = viewer.getEditDomain().getActiveTool();
-		Point location = tool.getLocation().getCopy();
+		Point location = tool.getAbsoluteLocation().getCopy();
 		final int percent = calcPercent(location);
 		// add actions
 		if (percent > 0) {


### PR DESCRIPTION
The getLocation() and getStartLocation() defined by the GEF class describe the relative location, not the absolute locations. To avoid any confusion, our methods should be called getAbsoluteLocation() and getAbsoluteStartLocation().

Note: In the future we should also migrate to relative coordinates.