### PR TITLE
Use 3.24.0 release repository in target platform

### DIFF
--- a/target-platform/wb-2024-06.target
+++ b/target-platform/wb-2024-06.target
@@ -8,7 +8,7 @@
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/staging/2024-06/"/>
-			<repository location="https://download.eclipse.org/tools/gef/classic/nightly/latest/"/>
+			<repository location="https://download.eclipse.org/tools/gef/classic/release/3.24.0"/>
 			<repository location="https://download.eclipse.org/technology/swtbot/releases/4.2.1/"/>
 			<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.gef.feature.group" version="0.0.0"/>


### PR DESCRIPTION
The nightly build raised the minimum Eclipse version to 2024-09, conflicting with the 2024-06 target platform.