### PR TITLE
Increase bottom right margin of design viewer

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/core/gef/part/AbstractComponentEditPart.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/core/gef/part/AbstractComponentEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -24,6 +24,7 @@ import org.eclipse.wb.gef.core.requests.DragPermissionRequest;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.gef.graphical.policies.LayoutEditPolicy;
 import org.eclipse.wb.internal.core.EnvironmentUtils;
+import org.eclipse.wb.internal.core.gef.part.DesignRootEditPart;
 import org.eclipse.wb.internal.core.gef.policy.OpenErrorLogEditPolicy;
 import org.eclipse.wb.internal.core.gef.policy.OpenListenerEditPolicy;
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
@@ -51,6 +52,10 @@ import java.util.List;
  * @coverage core.gef
  */
 public abstract class AbstractComponentEditPart extends GraphicalEditPart implements IObjectInfoEditPart {
+	/**
+	 * Counterpart to {@link DesignRootEditPart#BOTTOM_MARGIN} which describes the
+	 * margin at the top left of the design viewer.
+	 */
 	public static final Point TOP_LOCATION = EnvironmentUtils.IS_MAC
 			? new Point(20, 28)
 					: new Point(20, 20);

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/part/DesignRootEditPart.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/part/DesignRootEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,9 +12,12 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.gef.part;
 
+import org.eclipse.wb.core.gef.part.AbstractComponentEditPart;
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.broadcast.ObjectEventListener;
 import org.eclipse.wb.draw2d.Figure;
+import org.eclipse.wb.draw2d.border.Border;
+import org.eclipse.wb.draw2d.border.MarginBorder;
 import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.core.gef.part.nonvisual.NonVisualBeanEditPart;
@@ -26,6 +29,7 @@ import org.eclipse.wb.internal.draw2d.IPreferredSizeProvider;
 
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.EditPart;
@@ -39,6 +43,14 @@ import java.util.List;
  * @coverage core.gef
  */
 public final class DesignRootEditPart extends GraphicalEditPart {
+	/**
+	 * Counterpart to {@link AbstractComponentEditPart#TOP_LOCATION} which describes
+	 * the margin at the bottom right of the design viewer. This is necessary if the
+	 * widget is larger than the viewer, because then the edges of the figure touch
+	 * the edges of the root figure, thus making it harder to e.g. select the resize
+	 * tool.
+	 */
+	private static final Point BOTTOM_MARGIN = new Point(8, 8);
 	private final DesignRootObject m_designRootObject;
 
 	////////////////////////////////////////////////////////////////////////////
@@ -142,7 +154,10 @@ public final class DesignRootEditPart extends GraphicalEditPart {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	protected Figure createFigure() {
-		return new TopFigure();
+		Figure figure = new TopFigure();
+		Border border = new MarginBorder(new Insets(0, 0, BOTTOM_MARGIN.x, BOTTOM_MARGIN.y));
+		figure.setBorder(border);
+		return figure;
 	}
 
 	/**
@@ -176,6 +191,7 @@ public final class DesignRootEditPart extends GraphicalEditPart {
 					preferred.union(figure.getBounds());
 				}
 			}
+			preferred.expand(getInsets());
 			return preferred.getSize();
 		}
 	}


### PR DESCRIPTION
If the widget is larger than the viewer, the edges of the figure touch the edges of the editor, which makes it difficult to e.g. select the resize tool. This change adds an additional margin of 8 pixel.