### PR TITLE
[GEF] Harmonize findTargetEditPart method

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/tools/TabOrderTool.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/gef/tools/TabOrderTool.java
@@ -196,18 +196,16 @@ public final class TabOrderTool extends TargetingTool {
 	protected void updateTargetUnderMouse() {
 		// find on clickable layer
 		EditPart editPart =
-				getCurrentViewer().findTargetEditPart(
-						getLocation().x,
-						getLocation().y,
+				getCurrentViewer().findObjectAtExcluding(
+						getLocation(),
 						getExclusionSet(),
 						getTargetingConditional(),
 						IEditPartViewer.CLICKABLE_LAYER);
 		// common find target part
 		if (editPart == null) {
 			editPart =
-					getCurrentViewer().findTargetEditPart(
-							getLocation().x,
-							getLocation().y,
+					getCurrentViewer().findObjectAtExcluding(
+							getLocation(),
 							getExclusionSet(),
 							getTargetingConditional());
 		}

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/IEditPartViewer.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/IEditPartViewer.java
@@ -16,6 +16,8 @@ import org.eclipse.wb.gef.graphical.handles.Handle;
 import org.eclipse.wb.internal.gef.core.EditDomain;
 
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.gef.EditPart;
 import org.eclipse.jface.viewers.ISelectionProvider;
 
 import java.util.Collection;
@@ -124,28 +126,19 @@ public interface IEditPartViewer extends ISelectionProvider, org.eclipse.gef.Edi
 	 * current selection. The last EditPart in the new selection is made
 	 * {@link EditPart#SELECTED_PRIMARY primary}.
 	 */
-	void deselect(List<? extends org.eclipse.gef.EditPart> editParts);
+	void deselect(List<? extends EditPart> editParts);
 
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Finding
 	//
 	////////////////////////////////////////////////////////////////////////////
-	/**
-	 * Returns <code>null</code> or the <code>{@link EditPart}</code> at the specified location, using
-	 * the given exclusion set and conditional.
-	 */
-	EditPart findTargetEditPart(int x,
-			int y,
-			final Collection<IFigure> exclude,
-			final Conditional conditional);
 
 	/**
 	 * Returns <code>null</code> or the <code>{@link EditPart}</code> at the specified location on
 	 * specified given layer, using the given exclusion set and conditional.
 	 */
-	EditPart findTargetEditPart(int x,
-			int y,
+	EditPart findObjectAtExcluding(Point location,
 			final Collection<IFigure> exclude,
 			final Conditional conditional,
 			String layer);

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/TargetingTool.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/TargetingTool.java
@@ -169,9 +169,8 @@ public abstract class TargetingTool extends Tool {
 	protected void updateTargetUnderMouse() {
 		if (!m_isLockTarget) {
 			EditPart editPart =
-					getCurrentViewer().findTargetEditPart(
-							getLocation().x,
-							getLocation().y,
+					getCurrentViewer().findObjectAtExcluding(
+							getLocation(),
 							getExclusionSet(),
 							getTargetingConditional());
 			if (editPart != null) {

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/core/AbstractEditPartViewer.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/core/AbstractEditPartViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -18,8 +18,6 @@ import org.eclipse.wb.gef.core.IEditPartViewer;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.draw2d.EventListenerList;
-import org.eclipse.draw2d.IFigure;
-import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.RootEditPart;
 import org.eclipse.jface.action.MenuManager;
@@ -32,7 +30,6 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Menu;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
@@ -339,10 +336,6 @@ public abstract class AbstractEditPartViewer extends org.eclipse.gef.ui.parts.Ab
 	// GEF
 	//
 	////////////////////////////////////////////////////////////////////////////
-	@Override
-	public org.eclipse.wb.gef.core.EditPart findObjectAtExcluding(Point location, Collection<IFigure> exclusionSet, Conditional conditional) {
-		return null;
-	}
 
 	@Override
 	public Control createControl(Composite parent) {

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/graphical/GraphicalViewer.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/graphical/GraphicalViewer.java
@@ -151,13 +151,12 @@ public class GraphicalViewer extends AbstractEditPartViewer implements org.eclip
 	 * primary layers, using the given exclusion set and conditional.
 	 */
 	@Override
-	public EditPart findTargetEditPart(int x,
-			int y,
+	public EditPart findObjectAtExcluding(Point location,
 			final Collection<IFigure> exclude,
 			final Conditional conditional) {
-		EditPart editPart = findTargetEditPart(x, y, exclude, conditional, MENU_PRIMARY_LAYER);
+		EditPart editPart = findObjectAtExcluding(location, exclude, conditional, MENU_PRIMARY_LAYER);
 		if (editPart == null) {
-			editPart = findTargetEditPart(x, y, exclude, conditional, PRIMARY_LAYER);
+			editPart = findObjectAtExcluding(location, exclude, conditional, PRIMARY_LAYER);
 		}
 		return editPart;
 	}
@@ -167,12 +166,11 @@ public class GraphicalViewer extends AbstractEditPartViewer implements org.eclip
 	 * specified given layer, using the given exclusion set and conditional.
 	 */
 	@Override
-	public EditPart findTargetEditPart(int x,
-			int y,
+	public EditPart findObjectAtExcluding(Point location,
 			final Collection<IFigure> exclude,
 			final Conditional conditional,
 			String layer) {
-		TargetEditPartFindVisitor visitor = new TargetEditPartFindVisitor(m_canvas, x, y, this) {
+		TargetEditPartFindVisitor visitor = new TargetEditPartFindVisitor(m_canvas, location.x, location.y, this) {
 			@Override
 			protected boolean acceptVisit(Figure figure) {
 				for (IFigure exclusionFigure : exclude) {

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/tree/TreeViewer.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/tree/TreeViewer.java
@@ -18,6 +18,7 @@ import org.eclipse.wb.internal.gef.core.AbstractEditPartViewer;
 import org.eclipse.wb.internal.gef.core.EditDomain;
 
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.gef.EditPart;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
@@ -220,22 +221,21 @@ public class TreeViewer extends AbstractEditPartViewer {
 	 * the given exclusion set and conditional.
 	 */
 	@Override
-	public org.eclipse.wb.gef.core.EditPart findTargetEditPart(int x,
-			int y,
+	public EditPart findObjectAtExcluding(Point location,
 			Collection<IFigure> exclude,
 			Conditional conditional) {
 		// simple check location
 		Rectangle clientArea = m_tree.getClientArea();
-		if (x < 0 || y < 0 || x > clientArea.width || y > clientArea.height) {
+		if (location.x < 0 || location.y < 0 || location.x > clientArea.width || location.y > clientArea.height) {
 			return null;
 		}
 		// find EditPart
-		org.eclipse.wb.gef.core.EditPart result = null;
-		TreeItem item = m_tree.getItem(new org.eclipse.swt.graphics.Point(x, y));
+		EditPart result = null;
+		TreeItem item = m_tree.getItem(new org.eclipse.swt.graphics.Point(location.x, location.y));
 		if (item == null) {
 			result = m_rootEditPart;
 		} else {
-			result = (org.eclipse.wb.gef.core.EditPart) item.getData();
+			result = (EditPart) item.getData();
 		}
 		// apply conditional
 		while (result != null) {
@@ -248,8 +248,7 @@ public class TreeViewer extends AbstractEditPartViewer {
 	}
 
 	@Override
-	public org.eclipse.wb.gef.core.EditPart findTargetEditPart(int x,
-			int y,
+	public EditPart findObjectAtExcluding(Point location,
 			Collection<IFigure> exclude,
 			Conditional conditional,
 			String layer) {

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/tree/dnd/TreeDropListener.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/tree/dnd/TreeDropListener.java
@@ -218,9 +218,8 @@ public class TreeDropListener implements DropTargetListener {
 		Point location = getDropLocation();
 		Collection<? extends EditPart> editParts = includeChildren(getDragSource());
 		EditPart editPart =
-				m_viewer.findTargetEditPart(
-						location.x,
-						location.y,
+				m_viewer.findObjectAtExcluding(
+						location,
 						Collections.emptyList(),
 						getTargetingConditional(editParts));
 		if (editPart != null) {

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/EmptyEditPartViewer.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/EmptyEditPartViewer.java
@@ -18,6 +18,7 @@ import org.eclipse.wb.internal.gef.core.AbstractEditPartViewer;
 import org.eclipse.wb.internal.gef.core.EditDomain;
 
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.RootEditPart;
 import org.eclipse.jface.action.MenuManager;
@@ -53,16 +54,14 @@ public class EmptyEditPartViewer extends AbstractEditPartViewer implements IEdit
 	}
 
 	@Override
-	public org.eclipse.wb.gef.core.EditPart findTargetEditPart(int x,
-			int y,
+	public EditPart findObjectAtExcluding(Point location,
 			Collection<IFigure> exclude,
 			Conditional conditional) {
 		return null;
 	}
 
 	@Override
-	public org.eclipse.wb.gef.core.EditPart findTargetEditPart(int x,
-			int y,
+	public EditPart findObjectAtExcluding(Point location,
 			Collection<IFigure> exclude,
 			Conditional conditional,
 			String layer) {


### PR DESCRIPTION
This renames the findTargetEditPart() to findObjectAtExcluding() to match the signature of the corresponding GEF method.