### PR TITLE
[GEF] Generalize GraphicalEditPolicy to work with IFigures

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/core/gef/policy/selection/TopSelectionEditPolicy.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/core/gef/policy/selection/TopSelectionEditPolicy.java
@@ -16,7 +16,6 @@ import org.eclipse.wb.core.gef.command.EditCommand;
 import org.eclipse.wb.core.model.AbstractComponentInfo;
 import org.eclipse.wb.core.model.IAbstractComponentInfo;
 import org.eclipse.wb.core.model.ITopBoundsSupport;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
 import org.eclipse.wb.gef.graphical.handles.Handle;
@@ -25,6 +24,7 @@ import org.eclipse.wb.gef.graphical.handles.ResizeHandle;
 import org.eclipse.wb.gef.graphical.policies.SelectionEditPolicy;
 import org.eclipse.wb.gef.graphical.tools.ResizeTracker;
 
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.Request;
@@ -139,7 +139,7 @@ public final class TopSelectionEditPolicy extends SelectionEditPolicy {
 			// prepare feedback bounds
 			Rectangle bounds;
 			{
-				Figure hostFigure = getHostFigure();
+				IFigure hostFigure = getHostFigure();
 				bounds = request.getTransformedRectangle(hostFigure.getBounds());
 				sanitizeBounds(bounds);
 				FigureUtils.translateFigureToAbsolute(hostFigure, bounds);

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/RelativeLocator.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/RelativeLocator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,28 +12,29 @@
  *******************************************************************************/
 package org.eclipse.wb.draw2d;
 
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Rectangle;
 
 /**
- * Implementation of {@link AbstractRelativeLocator} that uses some {@link Figure} as reference.
+ * Implementation of {@link AbstractRelativeLocator} that uses some {@link IFigure} as reference.
  *
  * @author lobas_av
  * @coverage gef.draw2d
  */
 public final class RelativeLocator extends AbstractRelativeLocator {
-	private final Figure m_reference;
+	private final IFigure m_reference;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Constructors
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public RelativeLocator(Figure reference, double relativeX, double relativeY) {
+	public RelativeLocator(IFigure reference, double relativeX, double relativeY) {
 		super(relativeX, relativeY);
 		m_reference = reference;
 	}
 
-	public RelativeLocator(Figure reference, int location) {
+	public RelativeLocator(IFigure reference, int location) {
 		super(location);
 		m_reference = reference;
 	}

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/policies/GraphicalEditPolicy.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/policies/GraphicalEditPolicy.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.wb.gef.graphical.policies;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.Layer;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
@@ -46,9 +45,9 @@ public class GraphicalEditPolicy extends EditPolicy {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * Convenience method to return the host's {@link Figure}.
+	 * Convenience method to return the host's {@link IFigure}.
 	 */
-	protected final Figure getHostFigure() {
+	protected final IFigure getHostFigure() {
 		return getHost().getFigure();
 	}
 
@@ -82,17 +81,17 @@ public class GraphicalEditPolicy extends EditPolicy {
 	}
 
 	/**
-	 * Adds the specified <code>{@link Figure}</code> to the {@link IEditPartViewer#FEEDBACK_LAYER}.
+	 * Adds the specified <code>{@link IFigure}</code> to the {@link IEditPartViewer#FEEDBACK_LAYER}.
 	 */
-	protected final void addFeedback(Figure figure) {
+	protected final void addFeedback(IFigure figure) {
 		getFeedbackLayer().add(figure);
 	}
 
 	/**
-	 * Removes the specified <code>{@link Figure}</code> to the {@link IEditPartViewer#FEEDBACK_LAYER}
+	 * Removes the specified <code>{@link IFigure}</code> to the {@link IEditPartViewer#FEEDBACK_LAYER}
 	 * .
 	 */
-	protected final void removeFeedback(Figure figure) {
+	protected final void removeFeedback(IFigure figure) {
 		getFeedbackLayer().remove(figure);
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/flow/AbstractFlowLayoutEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/flow/AbstractFlowLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,7 +13,6 @@
 package org.eclipse.wb.core.gef.policy.layout.flow;
 
 import org.eclipse.wb.core.gef.policy.PolicyUtils;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.draw2d.Polyline;
 import org.eclipse.wb.gef.core.requests.AbstractCreateRequest;
@@ -25,6 +24,7 @@ import org.eclipse.wb.gef.graphical.policies.LayoutEditPolicy;
 import org.eclipse.wb.internal.core.utils.GenericsUtils;
 
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.draw2d.geometry.Transposer;
@@ -373,7 +373,7 @@ public abstract class AbstractFlowLayoutEditPolicy extends LayoutEditPolicy {
 
 	private void showLayoutTargetFeedback_noReference(boolean horizontal, boolean rtl) {
 		Polyline feedbackLine = getLineFeedback();
-		Figure hostFigure = getHostFigure();
+		IFigure hostFigure = getHostFigure();
 		Rectangle bounds = hostFigure.getBounds().getCopy();
 		FigureUtils.translateFigureToAbsolute(hostFigure, bounds);
 		// prepare points
@@ -506,8 +506,8 @@ public abstract class AbstractFlowLayoutEditPolicy extends LayoutEditPolicy {
 	}
 
 	/**
-	 * @return absolute bounds of given {@link EditPart}'s {@link Figure}, transposed if needed by
-	 *         layout.
+	 * @return absolute bounds of given {@link EditPart}'s {@link IFigure},
+	 *         transposed if needed by layout.
 	 */
 	private static Rectangle getAbsoluteBounds(boolean horizontal, EditPart editPart) {
 		Rectangle bounds = PolicyUtils.getAbsoluteBounds((GraphicalEditPart) editPart);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/generic/AbstractColumnSelectionEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/generic/AbstractColumnSelectionEditPolicy.java
@@ -26,6 +26,7 @@ import org.eclipse.wb.gef.graphical.policies.SelectionEditPolicy;
 import org.eclipse.wb.gef.graphical.tools.ResizeTracker;
 
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.Request;
@@ -153,7 +154,7 @@ public class AbstractColumnSelectionEditPolicy extends SelectionEditPolicy {
 		// prepare bounds
 		Rectangle bounds;
 		{
-			Figure hostFigure = getHostFigure();
+			IFigure hostFigure = getHostFigure();
 			bounds = request.getTransformedRectangle(hostFigure.getBounds());
 			FigureUtils.translateFigureToAbsolute(hostFigure, bounds.shrink(-1, -1));
 		}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/grid/AbstractGridSelectionEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/grid/AbstractGridSelectionEditPolicy.java
@@ -599,7 +599,7 @@ public abstract class AbstractGridSelectionEditPolicy extends SelectionEditPolic
 	 * @return {@link Locator} that positions handles on component side.
 	 */
 	protected final Locator createComponentLocator(int direction, double percent) {
-		Figure reference = getHostFigure();
+		IFigure reference = getHostFigure();
 		if (direction == PositionConstants.WEST) {
 			return new RelativeLocator(reference, 0, percent);
 		} else if (direction == PositionConstants.EAST) {

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/AbsoluteBasedLayoutEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/AbsoluteBasedLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -372,7 +372,7 @@ IPreferenceConstants {
 		// is this edit parts moved by using a keyboard
 		boolean isKeyboardMoving = isKeyboardMoving();
 		// prepare dots feedback if enabled
-		Figure hostFigure = getHostFigure();
+		IFigure hostFigure = getHostFigure();
 		if (m_dotsFeedback == null) {
 			if ((useGridSnapping() || isKeyboardMoving()) && isShowGridFeedback()) {
 				m_dotsFeedback = new DotsFeedback<>(this, hostFigure);
@@ -664,7 +664,7 @@ IPreferenceConstants {
 			m_startLocation = widgetBounds.getLocation();
 		}
 		//
-		Figure hostFigure = getHostFigure();
+		IFigure hostFigure = getHostFigure();
 		// create dots feedback
 		if (m_dotsFeedback == null) {
 			if (useGridSnapping() || isKeyboardMoving()) {

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/DotsFeedback.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/DotsFeedback.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,6 +17,7 @@ import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Rectangle;
 
 /**
@@ -34,7 +35,7 @@ public class DotsFeedback<C extends IAbstractComponentInfo> extends Figure {
 	// Constructor
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public DotsFeedback(AbsoluteBasedLayoutEditPolicy<C> layoutEditPolicy, Figure hostFigure) {
+	public DotsFeedback(AbsoluteBasedLayoutEditPolicy<C> layoutEditPolicy, IFigure hostFigure) {
 		m_layoutEditPolicy = layoutEditPolicy;
 		// prepare bounds to draw on client-area only
 		Rectangle bounds = hostFigure.getBounds().getCopy();

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/menu/SubmenuAwareLayoutEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/menu/SubmenuAwareLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,7 +13,6 @@
 package org.eclipse.wb.internal.core.gef.policy.menu;
 
 import org.eclipse.wb.core.gef.policy.PolicyUtils;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.draw2d.Layer;
 import org.eclipse.wb.gef.core.IEditPartViewer;
@@ -29,6 +28,7 @@ import org.eclipse.wb.internal.core.model.menu.IMenuInfo;
 import org.eclipse.wb.internal.core.model.menu.IMenuObjectInfo;
 import org.eclipse.wb.internal.core.model.menu.MenuObjectInfoUtils;
 
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
@@ -98,7 +98,7 @@ public final class SubmenuAwareLayoutEditPolicy extends LayoutEditPolicy {
 			return null;
 		}
 		// prepare location in figure
-		Figure figure = getHostFigure();
+		IFigure figure = getHostFigure();
 		Point location = ((DropRequest) request).getLocation().getCopy();
 		FigureUtils.translateAbsoluteToFigure2(figure, location);
 		// if request's mouse location are in middle 1/3 height (width) of figure then return getHost()

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/ColumnLayoutSelectionEditPolicy.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/ColumnLayoutSelectionEditPolicy.java
@@ -29,6 +29,7 @@ import org.eclipse.wb.internal.rcp.model.forms.layout.column.IColumnLayoutInfo;
 import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.Request;
@@ -151,7 +152,7 @@ SelectionEditPolicy {
 		// prepare bounds
 		Rectangle bounds;
 		{
-			Figure hostFigure = getHostFigure();
+			IFigure hostFigure = getHostFigure();
 			bounds = request.getTransformedRectangle(hostFigure.getBounds());
 			FigureUtils.translateFigureToAbsolute(hostFigure, bounds);
 		}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/header/edit/ColumnHeaderEditPart.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/header/edit/ColumnHeaderEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -28,6 +28,7 @@ import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.TextUtilities;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Interval;
@@ -51,7 +52,7 @@ public final class ColumnHeaderEditPart<C extends IControlInfo> extends Dimensio
 	////////////////////////////////////////////////////////////////////////////
 	public ColumnHeaderEditPart(ITableWrapLayoutInfo<C> layout,
 			TableWrapColumnInfo<C> column,
-			Figure containerFigure) {
+			IFigure containerFigure) {
 		super(layout, column, containerFigure);
 	}
 

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/header/edit/DimensionHeaderEditPart.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/header/edit/DimensionHeaderEditPart.java
@@ -14,7 +14,6 @@ package org.eclipse.wb.internal.rcp.gef.policy.forms.layout.grid.header.edit;
 
 import org.eclipse.wb.core.gef.header.Headers;
 import org.eclipse.wb.core.gef.header.IHeaderMenuProvider;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.tools.ParentTargetDragEditPartTracker;
@@ -27,6 +26,7 @@ import org.eclipse.wb.internal.rcp.model.forms.layout.table.ITableWrapLayoutInfo
 import org.eclipse.wb.internal.rcp.model.forms.layout.table.TableWrapDimensionInfo;
 import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.RequestConstants;
@@ -52,7 +52,7 @@ IHeaderMenuProvider {
 	////////////////////////////////////////////////////////////////////////////
 	protected final ITableWrapLayoutInfo<C> m_layout;
 	protected final TableWrapDimensionInfo<C> m_dimension;
-	private final Figure m_containerFigure;
+	private final IFigure m_containerFigure;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -61,7 +61,7 @@ IHeaderMenuProvider {
 	////////////////////////////////////////////////////////////////////////////
 	public DimensionHeaderEditPart(ITableWrapLayoutInfo<C> layout,
 			TableWrapDimensionInfo<C> dimension,
-			Figure containerFigure) {
+			IFigure containerFigure) {
 		m_layout = layout;
 		m_dimension = dimension;
 		m_containerFigure = containerFigure;
@@ -88,7 +88,7 @@ IHeaderMenuProvider {
 	}
 
 	/**
-	 * @return the offset of {@link Figure} with headers relative to the absolute layer.
+	 * @return the offset of {@link IFigure} with headers relative to the absolute layer.
 	 */
 	public final Point getOffset() {
 		Point offset = new Point(0, 0);

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/header/edit/RowHeaderEditPart.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/header/edit/RowHeaderEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -28,6 +28,7 @@ import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.TextUtilities;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Interval;
@@ -51,7 +52,7 @@ public final class RowHeaderEditPart<C extends IControlInfo> extends DimensionHe
 	////////////////////////////////////////////////////////////////////////////
 	public RowHeaderEditPart(ITableWrapLayoutInfo<C> layout,
 			TableWrapRowInfo<C> row,
-			Figure containerFigure) {
+			IFigure containerFigure) {
 		super(layout, row, containerFigure);
 	}
 

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/header/selection/DimensionSelectionEditPolicy.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/header/selection/DimensionSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,7 +13,6 @@
 package org.eclipse.wb.internal.rcp.gef.policy.forms.layout.grid.header.selection;
 
 import org.eclipse.wb.core.gef.header.AbstractHeaderSelectionEditPolicy;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.gef.graphical.handles.Handle;
 import org.eclipse.wb.gef.graphical.handles.MoveHandle;
@@ -91,7 +90,7 @@ AbstractHeaderSelectionEditPolicy {
 	private class HeaderMoveHandleLocator implements Locator {
 		@Override
 		public void relocate(IFigure target) {
-			Figure reference = getHostFigure();
+			IFigure reference = getHostFigure();
 			Rectangle bounds = reference.getBounds().getCopy();
 			FigureUtils.translateFigureToFigure(reference, target, bounds);
 			target.setBounds(bounds);

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/layout/StackLayoutSelectionEditPolicy.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/layout/StackLayoutSelectionEditPolicy.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.gef.policy.layout;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
@@ -25,6 +24,7 @@ import org.eclipse.wb.internal.rcp.model.layout.IStackLayoutInfo;
 import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
 import org.eclipse.draw2d.Cursors;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Rectangle;
 
@@ -86,7 +86,7 @@ SelectionEditPolicy {
 		// add navigate feedback
 		if (m_navigationFigure == null) {
 			m_navigationFigure = new StackLayoutNavigationFigure(this);
-			Figure hostFigure = getHostFigure();
+			IFigure hostFigure = getHostFigure();
 			Rectangle bounds = hostFigure.getBounds().getCopy();
 			FigureUtils.translateFigureToAbsolute(hostFigure, bounds);
 			{

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/rcp/perspective/AbstractPartSelectionEditPolicy.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/rcp/perspective/AbstractPartSelectionEditPolicy.java
@@ -164,7 +164,7 @@ public final class AbstractPartSelectionEditPolicy extends SelectionEditPolicy {
 		// prepare bounds XXX
 		Rectangle bounds;
 		{
-			Figure hostFigure = getHostFigure();
+			IFigure hostFigure = getHostFigure();
 			bounds = m_line.getPartBounds().getCopy();
 			bounds = request.getTransformedRectangle(bounds);
 			FigureUtils.translateFigureToAbsolute(hostFigure, bounds.shrink(-1, -1));

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/widgets/SashFormSelectionEditPolicy.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/widgets/SashFormSelectionEditPolicy.java
@@ -28,6 +28,7 @@ import org.eclipse.wb.internal.rcp.model.widgets.ISashFormInfo;
 import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.Request;
@@ -163,7 +164,7 @@ public final class SashFormSelectionEditPolicy<C extends IControlInfo> extends S
 		// prepare bounds
 		Rectangle bounds;
 		{
-			Figure hostFigure = getHostFigure();
+			IFigure hostFigure = getHostFigure();
 			bounds = request.getTransformedRectangle(hostFigure.getBounds());
 			FigureUtils.translateFigureToAbsolute(hostFigure, bounds.shrink(-1, -1));
 		}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/widgets/TreeTreeColumnSelectionEditPolicy.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/widgets/TreeTreeColumnSelectionEditPolicy.java
@@ -26,6 +26,7 @@ import org.eclipse.wb.gef.graphical.tools.ResizeTracker;
 import org.eclipse.wb.internal.rcp.model.widgets.ITreeColumnInfo;
 
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.Request;
@@ -143,7 +144,7 @@ public final class TreeTreeColumnSelectionEditPolicy extends SelectionEditPolicy
 		// prepare bounds
 		Rectangle bounds;
 		{
-			Figure hostFigure = getHostFigure();
+			IFigure hostFigure = getHostFigure();
 			bounds = request.getTransformedRectangle(hostFigure.getBounds());
 			FigureUtils.translateFigureToAbsolute(hostFigure, bounds.shrink(-1, -1));
 		}

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/edit/ColumnHeaderEditPart.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/edit/ColumnHeaderEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -27,6 +27,7 @@ import org.eclipse.wb.internal.swing.FormLayout.model.ui.ColumnEditDialog;
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.TextUtilities;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Interval;
@@ -55,7 +56,7 @@ public class ColumnHeaderEditPart extends DimensionHeaderEditPart<FormColumnInfo
 	// Constructor
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public ColumnHeaderEditPart(FormLayoutInfo layout, FormColumnInfo column, Figure containerFigure) {
+	public ColumnHeaderEditPart(FormLayoutInfo layout, FormColumnInfo column, IFigure containerFigure) {
 		super(layout, column, containerFigure);
 		m_column = column;
 	}

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/edit/DimensionHeaderEditPart.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/edit/DimensionHeaderEditPart.java
@@ -14,7 +14,6 @@ package org.eclipse.wb.internal.swing.FormLayout.gef.header.edit;
 
 import org.eclipse.wb.core.gef.header.Headers;
 import org.eclipse.wb.core.gef.header.IHeaderMenuProvider;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.tools.ParentTargetDragEditPartTracker;
@@ -27,6 +26,7 @@ import org.eclipse.wb.internal.swing.FormLayout.model.FormDimensionInfo;
 import org.eclipse.wb.internal.swing.FormLayout.model.FormDimensionTemplate;
 import org.eclipse.wb.internal.swing.FormLayout.model.FormLayoutInfo;
 
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.RequestConstants;
@@ -60,14 +60,14 @@ GraphicalEditPart implements IHeaderMenuProvider {
 	////////////////////////////////////////////////////////////////////////////
 	protected final FormLayoutInfo m_layout;
 	protected final T m_dimension;
-	private final Figure m_containerFigure;
+	private final IFigure m_containerFigure;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Constructor
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public DimensionHeaderEditPart(FormLayoutInfo layout, T dimension, Figure containerFigure) {
+	public DimensionHeaderEditPart(FormLayoutInfo layout, T dimension, IFigure containerFigure) {
 		m_layout = layout;
 		m_dimension = dimension;
 		m_containerFigure = containerFigure;
@@ -99,7 +99,8 @@ GraphicalEditPart implements IHeaderMenuProvider {
 	}
 
 	/**
-	 * @return the offset of {@link Figure} with headers relative to the absolute layer.
+	 * @return the offset of {@link IFigure} with headers relative to the absolute
+	 *         layer.
 	 */
 	public final Point getOffset() {
 		Point offset = new Point(0, 0);

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/edit/RowHeaderEditPart.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/edit/RowHeaderEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -27,6 +27,7 @@ import org.eclipse.wb.internal.swing.FormLayout.model.ui.RowEditDialog;
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.TextUtilities;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Interval;
@@ -55,7 +56,7 @@ public class RowHeaderEditPart extends DimensionHeaderEditPart<FormRowInfo> {
 	// Constructor
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public RowHeaderEditPart(FormLayoutInfo layout, FormRowInfo row, Figure containerFigure) {
+	public RowHeaderEditPart(FormLayoutInfo layout, FormRowInfo row, IFigure containerFigure) {
 		super(layout, row, containerFigure);
 		m_row = row;
 	}

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/selection/DimensionSelectionEditPolicy.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/selection/DimensionSelectionEditPolicy.java
@@ -168,7 +168,7 @@ AbstractHeaderSelectionEditPolicy {
 			// prepare feedback bounds
 			Rectangle bounds;
 			{
-				Figure hostFigure = getHostFigure();
+				IFigure hostFigure = getHostFigure();
 				bounds = changeBoundsRequest.getTransformedRectangle(hostFigure.getBounds());
 				FigureUtils.translateFigureToAbsolute(hostFigure, bounds);
 			}
@@ -261,7 +261,7 @@ AbstractHeaderSelectionEditPolicy {
 	private class HeaderMoveHandleLocator implements Locator {
 		@Override
 		public void relocate(IFigure target) {
-			Figure reference = getHostFigure();
+			IFigure reference = getHostFigure();
 			Rectangle bounds = reference.getBounds().getCopy();
 			FigureUtils.translateFigureToFigure(reference, target, bounds);
 			target.setBounds(bounds);

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/edit/ColumnHeaderEditPart.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/edit/ColumnHeaderEditPart.java
@@ -29,6 +29,7 @@ import org.eclipse.wb.internal.swing.MigLayout.model.ui.ColumnEditDialog;
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.TextUtilities;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Interval;
@@ -60,7 +61,7 @@ public class ColumnHeaderEditPart extends DimensionHeaderEditPart<MigColumnInfo>
 	// Constructor
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public ColumnHeaderEditPart(MigLayoutInfo layout, MigColumnInfo column, Figure containerFigure) {
+	public ColumnHeaderEditPart(MigLayoutInfo layout, MigColumnInfo column, IFigure containerFigure) {
 		super(layout, column, containerFigure);
 		m_column = column;
 	}

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/edit/DimensionHeaderEditPart.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/edit/DimensionHeaderEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,7 +14,6 @@ package org.eclipse.wb.internal.swing.MigLayout.gef.header.edit;
 
 import org.eclipse.wb.core.gef.header.Headers;
 import org.eclipse.wb.core.gef.header.IHeaderMenuProvider;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.tools.ParentTargetDragEditPartTracker;
@@ -23,6 +22,7 @@ import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.swing.MigLayout.model.MigDimensionInfo;
 import org.eclipse.wb.internal.swing.MigLayout.model.MigLayoutInfo;
 
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.RequestConstants;
@@ -55,14 +55,14 @@ IHeaderMenuProvider {
 	////////////////////////////////////////////////////////////////////////////
 	protected final MigLayoutInfo m_layout;
 	protected final T m_dimension;
-	private final Figure m_containerFigure;
+	private final IFigure m_containerFigure;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Constructor
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public DimensionHeaderEditPart(MigLayoutInfo layout, T dimension, Figure containerFigure) {
+	public DimensionHeaderEditPart(MigLayoutInfo layout, T dimension, IFigure containerFigure) {
 		m_layout = layout;
 		m_dimension = dimension;
 		m_containerFigure = containerFigure;
@@ -94,7 +94,8 @@ IHeaderMenuProvider {
 	}
 
 	/**
-	 * @return the offset of {@link Figure} with headers relative to the absolute layer.
+	 * @return the offset of {@link IFigure} with headers relative to the absolute
+	 *         layer.
 	 */
 	public final Point getOffset() {
 		Point offset = new Point(0, 0);

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/edit/RowHeaderEditPart.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/edit/RowHeaderEditPart.java
@@ -29,6 +29,7 @@ import org.eclipse.wb.internal.swing.MigLayout.model.ui.RowEditDialog;
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.TextUtilities;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Interval;
@@ -60,7 +61,7 @@ public class RowHeaderEditPart extends DimensionHeaderEditPart<MigRowInfo> {
 	// Constructor
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public RowHeaderEditPart(MigLayoutInfo layout, MigRowInfo row, Figure containerFigure) {
+	public RowHeaderEditPart(MigLayoutInfo layout, MigRowInfo row, IFigure containerFigure) {
 		super(layout, row, containerFigure);
 		m_row = row;
 	}

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/selection/DimensionSelectionEditPolicy.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/selection/DimensionSelectionEditPolicy.java
@@ -173,7 +173,7 @@ AbstractHeaderSelectionEditPolicy {
 			// prepare feedback bounds
 			Rectangle bounds;
 			{
-				Figure hostFigure = getHostFigure();
+				IFigure hostFigure = getHostFigure();
 				bounds = changeBoundsRequest.getTransformedRectangle(hostFigure.getBounds());
 				FigureUtils.translateFigureToAbsolute(hostFigure, bounds);
 			}
@@ -354,7 +354,7 @@ AbstractHeaderSelectionEditPolicy {
 	private class HeaderMoveHandleLocator implements Locator {
 		@Override
 		public void relocate(IFigure target) {
-			Figure reference = getHostFigure();
+			IFigure reference = getHostFigure();
 			Rectangle bounds = reference.getBounds().getCopy();
 			FigureUtils.translateFigureToFigure(reference, target, bounds);
 			target.setBounds(bounds);

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/component/box/StrutSelectionEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/component/box/StrutSelectionEditPolicy.java
@@ -27,6 +27,7 @@ import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.layout.BoxSupport;
 
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
@@ -146,7 +147,7 @@ abstract class StrutSelectionEditPolicy extends SelectionEditPolicy {
 		// prepare bounds
 		Rectangle bounds;
 		{
-			Figure hostFigure = getHostFigure();
+			IFigure hostFigure = getHostFigure();
 			bounds = request.getTransformedRectangle(hostFigure.getBounds());
 			FigureUtils.translateFigureToAbsolute(hostFigure, bounds.shrink(-1, -1));
 		}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/CardLayoutSelectionEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/CardLayoutSelectionEditPolicy.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.gef.policy.layout;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
@@ -25,6 +24,7 @@ import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.layout.CardLayoutInfo;
 
 import org.eclipse.draw2d.Cursors;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.Request;
@@ -86,7 +86,7 @@ public final class CardLayoutSelectionEditPolicy extends SelectionEditPolicy {
 		// add navigate feedback
 		if (m_navigationFigure == null) {
 			m_navigationFigure = new CardNavigationFigure(this);
-			Figure hostFigure = getHostFigure();
+			IFigure hostFigure = getHostFigure();
 			Rectangle bounds = hostFigure.getBounds().getCopy();
 			FigureUtils.translateFigureToAbsolute(hostFigure, bounds);
 			m_navigationFigure.setBounds(new Rectangle(bounds.right()

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/header/edit/ColumnHeaderEditPart.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/header/edit/ColumnHeaderEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -28,6 +28,7 @@ import org.eclipse.wb.internal.swing.model.layout.gbl.ui.ColumnEditDialog;
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.TextUtilities;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Interval;
@@ -53,7 +54,7 @@ public final class ColumnHeaderEditPart extends DimensionHeaderEditPart<ColumnIn
 	////////////////////////////////////////////////////////////////////////////
 	public ColumnHeaderEditPart(AbstractGridBagLayoutInfo layout,
 			ColumnInfo column,
-			Figure containerFigure) {
+			IFigure containerFigure) {
 		super(layout, column, containerFigure);
 		m_column = column;
 	}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/header/edit/DimensionHeaderEditPart.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/header/edit/DimensionHeaderEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,7 +14,6 @@ package org.eclipse.wb.internal.swing.gef.policy.layout.gbl.header.edit;
 
 import org.eclipse.wb.core.gef.header.Headers;
 import org.eclipse.wb.core.gef.header.IHeaderMenuProvider;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.tools.ParentTargetDragEditPartTracker;
@@ -23,6 +22,7 @@ import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.swing.model.layout.gbl.AbstractGridBagLayoutInfo;
 import org.eclipse.wb.internal.swing.model.layout.gbl.DimensionInfo;
 
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.RequestConstants;
@@ -48,7 +48,7 @@ IHeaderMenuProvider {
 	////////////////////////////////////////////////////////////////////////////
 	protected final AbstractGridBagLayoutInfo m_layout;
 	protected final T m_dimension;
-	private final Figure m_containerFigure;
+	private final IFigure m_containerFigure;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -57,7 +57,7 @@ IHeaderMenuProvider {
 	////////////////////////////////////////////////////////////////////////////
 	public DimensionHeaderEditPart(AbstractGridBagLayoutInfo layout,
 			T dimension,
-			Figure containerFigure) {
+			IFigure containerFigure) {
 		m_layout = layout;
 		m_dimension = dimension;
 		m_containerFigure = containerFigure;
@@ -89,7 +89,8 @@ IHeaderMenuProvider {
 	}
 
 	/**
-	 * @return the offset of {@link Figure} with headers relative to the absolute layer.
+	 * @return the offset of {@link IFigure} with headers relative to the absolute
+	 *         layer.
 	 */
 	public final Point getOffset() {
 		Point offset = new Point(0, 0);

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/header/edit/RowHeaderEditPart.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/header/edit/RowHeaderEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -29,6 +29,7 @@ import org.eclipse.wb.swing.SwingImages;
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.TextUtilities;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Interval;
@@ -54,7 +55,7 @@ public final class RowHeaderEditPart extends DimensionHeaderEditPart<RowInfo> {
 	// Constructor
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public RowHeaderEditPart(AbstractGridBagLayoutInfo layout, RowInfo row, Figure containerFigure) {
+	public RowHeaderEditPart(AbstractGridBagLayoutInfo layout, RowInfo row, IFigure containerFigure) {
 		super(layout, row, containerFigure);
 		m_row = row;
 	}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/header/selection/DimensionSelectionEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/header/selection/DimensionSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -152,7 +152,7 @@ AbstractHeaderSelectionEditPolicy {
 			// prepare feedback bounds
 			Rectangle bounds;
 			{
-				Figure hostFigure = getHostFigure();
+				IFigure hostFigure = getHostFigure();
 				bounds = changeBoundsRequest.getTransformedRectangle(hostFigure.getBounds());
 				FigureUtils.translateFigureToAbsolute(hostFigure, bounds);
 			}
@@ -225,7 +225,7 @@ AbstractHeaderSelectionEditPolicy {
 	private class HeaderMoveHandleLocator implements Locator {
 		@Override
 		public void relocate(IFigure target) {
-			Figure reference = getHostFigure();
+			IFigure reference = getHostFigure();
 			Rectangle bounds = reference.getBounds().getCopy();
 			FigureUtils.translateFigureToFigure(reference, target, bounds);
 			target.setBounds(bounds);

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/TableTableColumnSelectionEditPolicy.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/TableTableColumnSelectionEditPolicy.java
@@ -27,6 +27,7 @@ import org.eclipse.wb.gef.graphical.tools.ResizeTracker;
 import org.eclipse.wb.internal.swt.model.widgets.ITableColumnInfo;
 
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.Request;
@@ -147,7 +148,7 @@ public final class TableTableColumnSelectionEditPolicy extends SelectionEditPoli
 		// prepare bounds
 		Rectangle bounds;
 		{
-			Figure hostFigure = getHostFigure();
+			IFigure hostFigure = getHostFigure();
 			bounds = request.getTransformedRectangle(hostFigure.getBounds());
 			FigureUtils.translateFigureToAbsolute(hostFigure, bounds.shrink(-1, -1));
 		}

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/RowLayoutSelectionEditPolicy.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/RowLayoutSelectionEditPolicy.java
@@ -30,6 +30,7 @@ import org.eclipse.wb.internal.swt.model.layout.RowLayoutInfo;
 import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.Request;
@@ -156,7 +157,7 @@ public final class RowLayoutSelectionEditPolicy<C extends IControlInfo> extends 
 		// prepare bounds
 		Rectangle bounds;
 		{
-			Figure hostFigure = getHostFigure();
+			IFigure hostFigure = getHostFigure();
 			bounds = request.getTransformedRectangle(hostFigure.getBounds());
 			FigureUtils.translateFigureToAbsolute(hostFigure, bounds);
 		}

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormHeaderEditPart.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormHeaderEditPart.java
@@ -24,6 +24,7 @@ import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.PointList;
@@ -40,7 +41,7 @@ public class FormHeaderEditPart<C extends IControlInfo> extends GraphicalEditPar
 	private final boolean isHorizontal;
 	private final IFormLayoutInfo<C> layout;
 	private final Transposer t;
-	private final Figure containerFigure;
+	private final IFigure containerFigure;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -50,7 +51,7 @@ public class FormHeaderEditPart<C extends IControlInfo> extends GraphicalEditPar
 	public FormHeaderEditPart(IFormLayoutInfo<C> layout,
 			Object model,
 			boolean isHorizontal,
-			Figure containerFigure) {
+			IFigure containerFigure) {
 		super();
 		this.layout = layout;
 		this.isHorizontal = isHorizontal;

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormHeaderLayoutEditPolicy.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormHeaderLayoutEditPolicy.java
@@ -31,6 +31,7 @@ import org.eclipse.wb.internal.swt.model.layout.form.IFormLayoutInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ICompositeInfo;
 import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Translatable;
 import org.eclipse.draw2d.geometry.Transposer;
@@ -220,7 +221,7 @@ AbstractHeaderLayoutEditPolicy {
 	/**
 	 * @return the offset of {@link Figure} with headers relative to the absolute layer.
 	 */
-	public static Point getOffset(Figure containerFigure, ICompositeInfo composite) {
+	public static Point getOffset(IFigure containerFigure, ICompositeInfo composite) {
 		Point offset = new Point(0, 0);
 		FigureUtils.translateFigureToAbsolute2(containerFigure, offset);
 		offset.performTranslate(composite.getClientAreaInsets());

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormHeaderSelectionEditPolicy.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormHeaderSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,7 +13,6 @@
 package org.eclipse.wb.internal.swt.gef.policy.layout.form;
 
 import org.eclipse.wb.core.gef.header.AbstractHeaderSelectionEditPolicy;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.gef.graphical.handles.Handle;
 import org.eclipse.wb.gef.graphical.handles.MoveHandle;
@@ -70,7 +69,7 @@ final class FormHeaderSelectionEditPolicy extends AbstractHeaderSelectionEditPol
 	private class HeaderMoveHandleLocator implements Locator {
 		@Override
 		public void relocate(IFigure target) {
-			Figure reference = getHostFigure();
+			IFigure reference = getHostFigure();
 			Rectangle bounds = reference.getBounds().getCopy();
 			FigureUtils.translateFigureToFigure(reference, target, bounds);
 			target.setBounds(bounds);

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormSelectionEditPolicyClassic.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormSelectionEditPolicyClassic.java
@@ -1166,7 +1166,7 @@ SelectionEditPolicy {
 
 	private void installQuadrantHandler() {
 		mouseQuadrant = -1;
-		final Figure figure = getHostFigure();
+		final IFigure figure = getHostFigure();
 		// add mouse listener
 		mouseMotionListener = new MouseMotionListener.Stub() {
 			@Override

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/header/edit/ColumnHeaderEditPart.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/header/edit/ColumnHeaderEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -29,6 +29,7 @@ import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.TextUtilities;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Interval;
@@ -52,7 +53,7 @@ public final class ColumnHeaderEditPart<C extends IControlInfo> extends Dimensio
 	////////////////////////////////////////////////////////////////////////////
 	public ColumnHeaderEditPart(IGridLayoutInfo<C> layout,
 			GridColumnInfo<C> column,
-			Figure containerFigure) {
+			IFigure containerFigure) {
 		super(layout, column, containerFigure);
 	}
 

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/header/edit/DimensionHeaderEditPart.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/header/edit/DimensionHeaderEditPart.java
@@ -14,7 +14,6 @@ package org.eclipse.wb.internal.swt.gef.policy.layout.grid.header.edit;
 
 import org.eclipse.wb.core.gef.header.Headers;
 import org.eclipse.wb.core.gef.header.IHeaderMenuProvider;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.tools.ParentTargetDragEditPartTracker;
@@ -27,6 +26,7 @@ import org.eclipse.wb.internal.swt.model.layout.grid.GridDimensionInfo;
 import org.eclipse.wb.internal.swt.model.layout.grid.IGridLayoutInfo;
 import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.RequestConstants;
@@ -52,7 +52,7 @@ IHeaderMenuProvider {
 	////////////////////////////////////////////////////////////////////////////
 	protected final IGridLayoutInfo<C> m_layout;
 	protected final GridDimensionInfo<C> m_dimension;
-	private final Figure m_containerFigure;
+	private final IFigure m_containerFigure;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -61,7 +61,7 @@ IHeaderMenuProvider {
 	////////////////////////////////////////////////////////////////////////////
 	public DimensionHeaderEditPart(IGridLayoutInfo<C> layout,
 			GridDimensionInfo<C> dimension,
-			Figure containerFigure) {
+			IFigure containerFigure) {
 		m_layout = layout;
 		m_dimension = dimension;
 		m_containerFigure = containerFigure;
@@ -88,7 +88,7 @@ IHeaderMenuProvider {
 	}
 
 	/**
-	 * @return the offset of {@link Figure} with headers relative to the absolute layer.
+	 * @return the offset of {@link IFigure} with headers relative to the absolute layer.
 	 */
 	public final Point getOffset() {
 		Point offset = new Point(0, 0);

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/header/edit/RowHeaderEditPart.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/header/edit/RowHeaderEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -28,6 +28,7 @@ import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.TextUtilities;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Interval;
@@ -49,7 +50,7 @@ public final class RowHeaderEditPart<C extends IControlInfo> extends DimensionHe
 	// Constructor
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public RowHeaderEditPart(IGridLayoutInfo<C> layout, GridRowInfo<C> row, Figure containerFigure) {
+	public RowHeaderEditPart(IGridLayoutInfo<C> layout, GridRowInfo<C> row, IFigure containerFigure) {
 		super(layout, row, containerFigure);
 	}
 

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/header/selection/DimensionSelectionEditPolicy.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/header/selection/DimensionSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,7 +13,6 @@
 package org.eclipse.wb.internal.swt.gef.policy.layout.grid.header.selection;
 
 import org.eclipse.wb.core.gef.header.AbstractHeaderSelectionEditPolicy;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.gef.graphical.handles.Handle;
 import org.eclipse.wb.gef.graphical.handles.MoveHandle;
@@ -91,7 +90,7 @@ AbstractHeaderSelectionEditPolicy {
 	private class HeaderMoveHandleLocator implements Locator {
 		@Override
 		public void relocate(IFigure target) {
-			Figure reference = getHostFigure();
+			IFigure reference = getHostFigure();
 			Rectangle bounds = reference.getBounds().getCopy();
 			FigureUtils.translateFigureToFigure(reference, target, bounds);
 			target.setBounds(bounds);


### PR DESCRIPTION
The edit policies don't require any methods declared by the WindowBuilder Figure subclass. The class should therefore use the base interface to avoid potential type casts.