### PR TITLE
Reactivate BindingsTest and adapt Bindings classes to expected behavior

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/binding/DesignerMethodBinding.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/binding/DesignerMethodBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -40,6 +40,9 @@ public final class DesignerMethodBinding implements IMethodBinding {
 	private final String m_name;
 	private final int m_modifiers;
 	private final boolean m_constructor;
+	private final boolean m_compactConstructor;
+	private final boolean m_canonicalConstructor;
+	private final boolean m_syntheticRecordMethod;
 	private final boolean m_varargs;
 	private final ITypeBinding m_declaringClass;
 	private final ITypeBinding m_returnType;
@@ -59,6 +62,9 @@ public final class DesignerMethodBinding implements IMethodBinding {
 		m_name = binding.getName();
 		m_modifiers = binding.getModifiers();
 		m_constructor = binding.isConstructor();
+		m_compactConstructor = binding.isCompactConstructor();
+		m_canonicalConstructor = binding.isCanonicalConstructor();
+		m_syntheticRecordMethod = binding.isSyntheticRecordMethod();
 		m_varargs = binding.isVarargs();
 		m_declaringClass = context.get(binding.getDeclaringClass());
 		m_returnType = context.get(binding.getReturnType());
@@ -286,26 +292,26 @@ public final class DesignerMethodBinding implements IMethodBinding {
 
 	@Override
 	public IBinding getDeclaringMember() {
-		return null;
+		throw new IllegalArgumentException();
 	}
 
 	@Override
 	public IVariableBinding[] getSyntheticOuterLocals() {
-		return null;
+		throw new IllegalArgumentException();
 	}
 
 	@Override
 	public boolean isCompactConstructor() {
-		return false;
+		return m_compactConstructor;
 	}
 
 	@Override
 	public boolean isCanonicalConstructor() {
-		return false;
+		return m_canonicalConstructor;
 	}
 
 	@Override
 	public boolean isSyntheticRecordMethod() {
-		return false;
+		return m_syntheticRecordMethod;
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/binding/DesignerPackageBinding.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/binding/DesignerPackageBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,6 +14,7 @@ package org.eclipse.wb.internal.core.utils.ast.binding;
 
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.IModuleBinding;
 import org.eclipse.jdt.core.dom.IPackageBinding;
 
 /**
@@ -117,6 +118,11 @@ final class DesignerPackageBinding implements IPackageBinding {
 
 	@Override
 	public org.eclipse.jdt.core.dom.IAnnotationBinding[] getAnnotations() {
+		throw new IllegalArgumentException();
+	}
+
+	@Override
+	public IModuleBinding getModule() {
 		throw new IllegalArgumentException();
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/binding/DesignerTypeBinding.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/binding/DesignerTypeBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,6 +16,7 @@ import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.dom.IAnnotationBinding;
 import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.IModuleBinding;
 import org.eclipse.jdt.core.dom.IPackageBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
@@ -45,6 +46,8 @@ public final class DesignerTypeBinding implements ITypeBinding {
 	private final boolean m_nested;
 	private final boolean m_local;
 	private final boolean m_anonymous;
+	private final boolean m_record;
+	private final boolean m_intersectionType;
 	// generics
 	private final boolean m_genericType;
 	private final boolean m_parameterizedType;
@@ -96,6 +99,8 @@ public final class DesignerTypeBinding implements ITypeBinding {
 		m_member = binding.isMember();
 		m_local = binding.isLocal();
 		m_anonymous = binding.isAnonymous();
+		m_record = binding.isRecord();
+		m_intersectionType = binding.isIntersectionType();
 		// generics
 		m_genericType = binding.isGenericType();
 		m_parameterizedType = binding.isParameterizedType();
@@ -529,20 +534,39 @@ public final class DesignerTypeBinding implements ITypeBinding {
 		throw new IllegalArgumentException();
 	}
 
+	//
+	// New in Eclipse 3.11
+	//
+
 	@Override
 	public IBinding getDeclaringMember() {
-		return null;
+		throw new IllegalArgumentException();
 	}
+
+	//
+	// New in Eclipse 3.12
+	//
 
 	@Override
 	public boolean isIntersectionType() {
-		// TODO Auto-generated method stub
-		return false;
+		return m_intersectionType;
 	}
+
+	//
+	// New in Eclipse 3.14
+	//
+
+	@Override
+	public IModuleBinding getModule() {
+		throw new IllegalArgumentException();
+	}
+
+	//
+	// New in Eclipse 3.26
+	//
 
 	@Override
 	public boolean isRecord() {
-		// TODO Auto-generated method stub
-		return false;
+		return m_record;
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/ast/BindingsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/ast/BindingsTest.java
@@ -42,7 +42,6 @@ import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.apache.commons.lang3.ArrayUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Array;
@@ -84,7 +83,6 @@ public class BindingsTest extends AbstractJavaTest {
 	/**
 	 * Object type.
 	 */
-	@Disabled
 	@Test
 	public void test_DesignerTypeBinding_1() throws Exception {
 		String code = "private java.util.List foo() {return null;}";
@@ -94,7 +92,6 @@ public class BindingsTest extends AbstractJavaTest {
 	/**
 	 * Primitive type.
 	 */
-	@Disabled
 	@Test
 	public void test_DesignerTypeBinding_2() throws Exception {
 		String code = "private int foo() {return 0;}";
@@ -104,7 +101,6 @@ public class BindingsTest extends AbstractJavaTest {
 	/**
 	 * Array type.
 	 */
-	@Disabled
 	@Test
 	public void test_DesignerTypeBinding_3() throws Exception {
 		String code = "private int[] foo() {return null;}";
@@ -114,7 +110,6 @@ public class BindingsTest extends AbstractJavaTest {
 	/**
 	 * Inner type.
 	 */
-	@Disabled
 	@Test
 	public void test_DesignerTypeBinding_4() throws Exception {
 		String code = "class Foo {} private Foo foo() {return null;}";
@@ -307,15 +302,14 @@ public class BindingsTest extends AbstractJavaTest {
 	// DesignerPackageBinding
 	//
 	////////////////////////////////////////////////////////////////////////////
-	@Disabled
 	@Test
 	public void test_DesignerPackageBinding() throws Exception {
 		TypeDeclaration typeDeclaration = createTypeDeclaration_TestC("");
 		IPackageBinding originalBinding = typeDeclaration.resolveBinding().getPackage();
 		IPackageBinding ourBinding = m_lastEditor.getBindingContext().get(originalBinding);
-		assert_sameProperties(IPackageBinding.class, originalBinding, ourBinding, new String[]{
+		assert_sameProperties(IPackageBinding.class, originalBinding, ourBinding, 
 				"getName",
-		"isUnnamed"});
+				"isUnnamed");
 		assert_methodFails(ourBinding, "isEqualTo", NULL_ARG);
 	}
 
@@ -327,7 +321,6 @@ public class BindingsTest extends AbstractJavaTest {
 	/**
 	 * Basic test for {@link DesignerMethodBinding}.
 	 */
-	@Disabled
 	@Test
 	public void test_DesignerMethodBinding_1() throws Exception {
 		TypeDeclaration typeDeclaration =
@@ -335,17 +328,21 @@ public class BindingsTest extends AbstractJavaTest {
 		MethodDeclaration methodDeclaration = typeDeclaration.getMethods()[0];
 		IMethodBinding originalBinding = methodDeclaration.resolveBinding();
 		IMethodBinding ourBinding = m_lastEditor.getBindingContext().get(originalBinding);
-		assert_sameProperties(IMethodBinding.class, originalBinding, ourBinding, new String[]{
+		assert_sameProperties(IMethodBinding.class, originalBinding, ourBinding,
 				"getDeclaringClass",
 				"getName",
 				"getReturnType",
 				"getParameterTypes",
+				"getParameterNames",
 				"getExceptionTypes",
 				"getMethodDeclaration",
 				"isConstructor",
+				"isCanonicalConstructor",
+				"isCompactConstructor",
+				"isSyntheticRecordMethod",
 				"getModifiers",
-				"getDeclaringMember",
-		"isVarargs"});
+				"getKey",
+				"isVarargs");
 		assert_methodFails(ourBinding, "getParameterAnnotations", new Object[]{0});
 		assert_methodFails(ourBinding, "isSubsignature", NULL_ARG);
 		assert_methodFails(ourBinding, "overrides", NULL_ARG);
@@ -415,7 +412,6 @@ public class BindingsTest extends AbstractJavaTest {
 	 * When we remove parameter from generic {@link IMethodBinding} we should also update its
 	 * {@link IMethodBinding#getMethodDeclaration()}.
 	 */
-	@Disabled
 	@Test
 	public void test_DesignerMethodBinding_removeParameterType_whenGenerics() throws Exception {
 		createTypeDeclaration_TestC(getSourceDQ(
@@ -447,7 +443,6 @@ public class BindingsTest extends AbstractJavaTest {
 	/**
 	 * Basic test for {@link DesignerVariableBinding}.
 	 */
-	@Disabled
 	@Test
 	public void test_DesignerVariableBinding_1() throws Exception {
 		TypeDeclaration typeDeclaration = createTypeDeclaration_TestC("private int m_value;");
@@ -455,12 +450,13 @@ public class BindingsTest extends AbstractJavaTest {
 		IVariableBinding originalBinding =
 				((VariableDeclarationFragment) fieldDeclaration.fragments().get(0)).resolveBinding();
 		IVariableBinding ourBinding = m_lastEditor.getBindingContext().get(originalBinding);
-		assert_sameProperties(IVariableBinding.class, originalBinding, ourBinding, new String[]{
+		assert_sameProperties(IVariableBinding.class, originalBinding, ourBinding,
 				"getName",
 				"getDeclaringClass",
 				"getType",
 				"isField",
-		"getModifiers"});
+				"isRecordComponent",
+				"getModifiers");
 		assert_methodFails(ourBinding, "isEqualTo", NULL_ARG);
 	}
 
@@ -500,7 +496,6 @@ public class BindingsTest extends AbstractJavaTest {
 	/**
 	 * Test for {@link BindingContext#getCopy(ITypeBinding)}.
 	 */
-	@Disabled
 	@Test
 	public void test_getCopy() throws Exception {
 		TypeDeclaration typeDeclaration = createTypeDeclaration_Test("""
@@ -526,7 +521,7 @@ public class BindingsTest extends AbstractJavaTest {
 	 */
 	private static void assert_sameTypeBindings(ITypeBinding expectedBinding,
 			ITypeBinding actualBinding) throws Exception {
-		assert_sameProperties(ITypeBinding.class, expectedBinding, actualBinding, new String[]{
+		assert_sameProperties(ITypeBinding.class, expectedBinding, actualBinding,
 				"isPrimitive",
 				"isNullType",
 				"isArray",
@@ -549,6 +544,7 @@ public class BindingsTest extends AbstractJavaTest {
 				"isGenericType",
 				"isParameterizedType",
 				"isTypeVariable",
+				"isRecord",
 				"getTypeArguments",
 				"getTypeDeclaration",
 				"getTypeParameters",
@@ -556,8 +552,7 @@ public class BindingsTest extends AbstractJavaTest {
 				"getDeclaredMethods",
 				"getModifiers",
 				"getDeclaredModifiers",
-				"getDeclaringMember",
-		"isIntersectionType"});
+				"isIntersectionType");
 	}
 
 	/**
@@ -586,7 +581,7 @@ public class BindingsTest extends AbstractJavaTest {
 	private static void assert_sameProperties(Class<?> clazz,
 			Object expectedObject,
 			Object actualObject,
-			String methodNames[]) throws Exception {
+			String... methodNames) throws Exception {
 		Method[] allMethods = clazz.getMethods();
 		for (int i = 0; i < allMethods.length; i++) {
 			Method method = allMethods[i];


### PR DESCRIPTION
Whenever a new method is added to the IMethodBinding, IPackageBinding or the ITypeBinding, the Designer implementation must be either implemented properly or throw an IllegalArgumentException().

Instead, those methods have been implemented by returning a default value, which brings the risk of diverging from the value of the underlying binding and thus leading to inconsistent behavior.

The affected methods have been adapted to take this expected behavior into consideration and for trivial cases, been correctly implemented.

Affected commits:
- cf88ae1c0c0837c7e33868bfdc06aebe2a787219
- 6912838e8f92e2033f9cd26a7b0269a662c234b2
- 6648a1ca4e007c08f2645d44bdcbb719e717ca64
- a6af2a248562552c6fd3394f35dd81a666842e1f
- 9e522234c54ec85d55288cea11a5c8e6766fcc4d
- 2849290a635fe4c10b318520bac7d81473343f84