### PR TITLE
Restrict execution of dash-license tool

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -1,5 +1,9 @@
 name: WindowBuilder verification build
 
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 on:
   push:
     branches:
@@ -7,8 +11,15 @@ on:
   pull_request:
     branches:
       - master
+    types: 
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+
 jobs:
   check-dash-licenses:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'dash-license')
     uses: eclipse-dash/dash-licenses/.github/workflows/mavenLicenseCheck.yml@cbd9bd5d78742d3c9772ace91b129424b418c342 # 1.1.0
     with:
       projectId: tools.windowbuilder


### PR DESCRIPTION
This tool should only be executed when there are actual dependency changes. For the sake of security, the tool is now only executed when changes are done to the master and optionally on a PR, but only if the "dash-license" label is set.

Closes https://github.com/eclipse-windowbuilder/windowbuilder/issues/1125