### PR TITLE
[GEF] Generalize AbstractComponentEditPart to work with IFigures

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/core/gef/part/AbstractComponentEditPart.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/core/gef/part/AbstractComponentEditPart.java
@@ -32,6 +32,7 @@ import org.eclipse.wb.internal.draw2d.EventManager;
 import org.eclipse.wb.internal.gef.core.IObjectInfoEditPart;
 
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.EditPart;
@@ -104,9 +105,9 @@ public abstract class AbstractComponentEditPart extends GraphicalEditPart implem
 	}
 
 	/**
-	 * Draw custom "control specific" graphics objects for given {@link Figure}.
+	 * Draw custom "control specific" graphics objects for given {@link IFigure}.
 	 */
-	protected void drawCustomBorder(Figure figure, Graphics graphics) {
+	protected void drawCustomBorder(IFigure figure, Graphics graphics) {
 	}
 
 	@Override

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/part/widgets/ScrolledCompositeEditPart.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/part/widgets/ScrolledCompositeEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.gef.part.widgets;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.graphical.policies.TerminatorLayoutEditPolicy;
 import org.eclipse.wb.internal.rcp.gef.GefMessages;
@@ -22,6 +21,7 @@ import org.eclipse.wb.internal.swt.gef.part.CompositeEditPart;
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.TextUtilities;
 import org.eclipse.draw2d.geometry.Dimension;
 
@@ -50,7 +50,7 @@ public final class ScrolledCompositeEditPart extends CompositeEditPart {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void drawCustomBorder(Figure figure, Graphics graphics) {
+	protected void drawCustomBorder(IFigure figure, Graphics graphics) {
 		super.drawCustomBorder(figure, graphics);
 		if (!m_composite.hasRequired_setContent()) {
 			String message = GefMessages.ScrolledCompositeEditPart_setContentWarning;

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/part/ContainerEditPart.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/part/ContainerEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,7 +15,6 @@ package org.eclipse.wb.internal.swing.gef.part;
 import org.eclipse.wb.core.editor.constants.IEditorPreferenceConstants;
 import org.eclipse.wb.core.gef.policy.TabOrderContainerEditPolicy;
 import org.eclipse.wb.core.gef.policy.layout.LayoutPolicyUtils;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.IRefreshableEditPolicy;
 import org.eclipse.wb.gef.graphical.policies.LayoutEditPolicy;
@@ -26,6 +25,7 @@ import org.eclipse.wb.internal.swing.model.layout.LayoutInfo;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.swt.SWT;
@@ -55,7 +55,7 @@ public final class ContainerEditPart extends ComponentEditPart {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void drawCustomBorder(Figure figure, Graphics graphics) {
+	protected void drawCustomBorder(IFigure figure, Graphics graphics) {
 		try {
 			if (m_container.shouldDrawDotsBorder()) {
 				graphics.setForegroundColor(ColorConstants.gray);

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/part/CompositeEditPart.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/part/CompositeEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc. and others
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,7 +17,6 @@ package org.eclipse.wb.internal.swt.gef.part;
 import org.eclipse.wb.core.editor.constants.IEditorPreferenceConstants;
 import org.eclipse.wb.core.gef.policy.TabOrderContainerEditPolicy;
 import org.eclipse.wb.core.gef.policy.layout.LayoutPolicyUtils;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.IRefreshableEditPolicy;
 import org.eclipse.wb.gef.graphical.policies.LayoutEditPolicy;
@@ -29,6 +28,7 @@ import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.swt.SWT;
@@ -58,7 +58,7 @@ public class CompositeEditPart extends ControlEditPart {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void drawCustomBorder(Figure figure, Graphics graphics) {
+	protected void drawCustomBorder(IFigure figure, Graphics graphics) {
 		try {
 			if (m_composite.shouldDrawDotsBorder()) {
 				graphics.setForegroundColor(ColorConstants.gray);


### PR DESCRIPTION
Drawing the custom border for a Figure doesn't require any methods from the WindowBuilder figure. The signature is therefore updated to only expect a generic IFigure.