### PR TITLE
Try to fix sporadic "Build path contains duplicate entry" exception

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/TestProject.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/TestProject.java
@@ -53,6 +53,7 @@ import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.Objects;
 import java.util.logging.Logger;
 
 /**
@@ -114,6 +115,12 @@ public class TestProject {
 		IPackageFragmentRoot root = m_javaProject.getPackageFragmentRoot(srcFolder);
 		//
 		IClasspathEntry[] oldEntries = m_javaProject.getRawClasspath();
+		IClasspathEntry newEntry = JavaCore.newSourceEntry(root.getPath());
+		for (IClasspathEntry oldEntry : oldEntries) {
+			if (Objects.equals(oldEntry.getPath(), newEntry.getPath())) {
+				return root;
+			}
+		}
 		IClasspathEntry[] newEntries = new IClasspathEntry[oldEntries.length + 1];
 		System.arraycopy(oldEntries, 0, newEntries, 0, oldEntries.length);
 		newEntries[oldEntries.length] = JavaCore.newSourceEntry(root.getPath());


### PR DESCRIPTION
This is a follow-up to 7e26260d821b085e99d43fdf7d690c5ad5ddcd22. In case the src folder already exist, it might also still be part of the project class-path. If we try to add it again, this then causes a CoreException.