### PR TITLE
Try to stabilize NewSourceDialogTest

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/UiContext.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/UiContext.java
@@ -93,6 +93,9 @@ public class UiContext {
 			}
 			throw new Exception("Exception during running 'check' UIRunnable.", checkException[0]);
 		}
+		while (m_display.readAndDispatch()) {
+			Thread.yield();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Make sure the event loop is empty after running the executeAndCheck() method of the UiContext class. This is to make sure all events like closing the active shell have been processed.