### PR TITLE
Add missing `@Deprecated` annotations

### DIFF
--- a/org.eclipse.wb.core.databinding/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core.databinding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.core.databinding;singleton:=true
-Bundle-Version: 1.9.900.qualifier
+Bundle-Version: 1.9.1000.qualifier
 Bundle-Activator: org.eclipse.wb.internal.core.databinding.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui;bundle-version="[3.206.0,4.0.0)",

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/UiUtils.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/UiUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -260,20 +260,24 @@ public final class UiUtils {
 		}
 
 		@Override
+		@Deprecated
 		public boolean includesBinaries() {
 			return true;
 		}
 
 		@Override
+		@Deprecated
 		public boolean includesClasspaths() {
 			return true;
 		}
 
 		@Override
+		@Deprecated
 		public void setIncludesBinaries(boolean includesBinaries) {
 		}
 
 		@Override
+		@Deprecated
 		public void setIncludesClasspaths(boolean includesClasspaths) {
 		}
 	}

--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/editor/contentproviders/CheckboxTreeViewerWrapper.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/editor/contentproviders/CheckboxTreeViewerWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -60,6 +60,7 @@ public class CheckboxTreeViewerWrapper implements ICheckboxViewerWrapper {
 	}
 
 	@Override
+	@Deprecated
 	public void setAllChecked(boolean state) {
 		m_viewer.setAllChecked(state);
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPalette.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPalette.java
@@ -354,6 +354,7 @@ public class DesignerPalette {
 						//
 						////////////////////////////////////////////////////////////////////////////
 						@Override
+						@Deprecated
 						public boolean activate(boolean reload) {
 							return entryInfo.createTool(reload) != null;
 						}
@@ -422,11 +423,13 @@ public class DesignerPalette {
 				}
 
 				@Override
+				@Deprecated
 				public boolean isOpen() {
 					return m_open;
 				}
 
 				@Override
+				@Deprecated
 				public void setOpen(boolean open) {
 					m_open = open;
 					m_openCategories.put(categoryId, open);
@@ -452,6 +455,7 @@ public class DesignerPalette {
 		// set IPalette
 		m_paletteRoot = new DesignerRoot() {
 			@Override
+			@Deprecated
 			public void addPopupActions(IMenuManager menuManager, Object target, int iconsType) {
 				new DesignerPalettePopupActions(getOperations()).addPopupActions(
 						menuManager,
@@ -460,11 +464,13 @@ public class DesignerPalette {
 			}
 
 			@Override
+			@Deprecated
 			public void selectDefault() {
 				m_editPartViewer.getEditDomain().loadDefaultTool();
 			}
 
 			@Override
+			@Deprecated
 			public void moveCategory(ICategory _category, ICategory _nextCategory) {
 				CategoryInfo category = m_visualToCategoryInfo.get(_category);
 				CategoryInfo nextCategory = m_visualToCategoryInfo.get(_nextCategory);
@@ -472,6 +478,7 @@ public class DesignerPalette {
 			}
 
 			@Override
+			@Deprecated
 			public void moveEntry(IEntry _entry, ICategory _targetCategory, IEntry _nextEntry) {
 				EntryInfo entry = m_visualToEntryInfo.get(_entry);
 				CategoryInfo category = m_visualToCategoryInfo.get(_targetCategory);

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/binding/DesignerTypeBinding.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/binding/DesignerTypeBinding.java
@@ -330,6 +330,7 @@ public final class DesignerTypeBinding implements ITypeBinding {
 	}
 
 	@Override
+	@Deprecated
 	public int getDeclaredModifiers() {
 		return m_declaredModifiers;
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/core/SubtypesScope.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/core/SubtypesScope.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -93,21 +93,25 @@ public final class SubtypesScope implements IJavaSearchScope {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
+	@Deprecated
 	public boolean includesBinaries() {
 		return m_hierarchyScope.includesBinaries();
 	}
 
 	@Override
+	@Deprecated
 	public boolean includesClasspaths() {
 		return m_hierarchyScope.includesClasspaths();
 	}
 
 	@Override
+	@Deprecated
 	public void setIncludesBinaries(boolean includesBinaries) {
 		m_hierarchyScope.setIncludesBinaries(includesBinaries);
 	}
 
 	@Override
+	@Deprecated
 	public void setIncludesClasspaths(boolean includesClasspaths) {
 		m_hierarchyScope.setIncludesClasspaths(includesClasspaths);
 	}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/test/PaletteTest.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/test/PaletteTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -156,6 +156,7 @@ public class PaletteTest implements ColorConstants {
 
 		/** {@inheritDoc} */
 		@Override
+		@Deprecated
 		public void addPopupActions(IMenuManager menuManager, Object target, int iconType) {
 		}
 
@@ -165,14 +166,17 @@ public class PaletteTest implements ColorConstants {
 		//
 		////////////////////////////////////////////////////////////////////////////
 		@Override
+		@Deprecated
 		public void selectDefault() {
 		}
 
 		@Override
+		@Deprecated
 		public void moveCategory(ICategory category, ICategory nextCategory) {
 		}
 
 		@Override
+		@Deprecated
 		public void moveEntry(IEntry entry, ICategory targetCategory, IEntry nextEntry) {
 		}
 	}
@@ -201,11 +205,13 @@ public class PaletteTest implements ColorConstants {
 		////////////////////////////////////////////////////////////////////////////
 
 		@Override
+		@Deprecated
 		public boolean isOpen() {
 			return m_open;
 		}
 
 		@Override
+		@Deprecated
 		public void setOpen(boolean b) {
 			m_open = b;
 		}
@@ -244,6 +250,7 @@ public class PaletteTest implements ColorConstants {
 		//
 		////////////////////////////////////////////////////////////////////////////
 		@Override
+		@Deprecated
 		public boolean activate(boolean reload) {
 			return true;
 		}


### PR DESCRIPTION
The methods need to be implemented because they are specified by the interface. Mark them as deprecated to avoid the resulting deprecation warning.