### PR TITLE
Use plain Draw2D for column/row header edit parts

### DIFF
--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
@@ -108,7 +108,11 @@ public class Figure extends org.eclipse.draw2d.Figure {
 			if (childFigure.isVisible() && childFigure.intersects(graphics.getClip(new Rectangle()))) {
 				Rectangle childBounds = childFigure.getBounds();
 				graphics.clipRect(childBounds);
-				graphics.translate(childBounds.x, childBounds.y);
+				if (childFigure instanceof Figure f && f.useLocalCoordinates()) {
+					graphics.translate(childBounds.x, childBounds.y);
+				} else {
+					System.out.println(childFigure);
+				}
 				childFigure.paint(graphics);
 				graphics.restoreState();
 			}

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/header/edit/ColumnHeaderEditPart.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/header/edit/ColumnHeaderEditPart.java
@@ -14,7 +14,6 @@ package org.eclipse.wb.internal.rcp.gef.policy.forms.layout.grid.header.edit;
 
 import org.eclipse.wb.core.editor.constants.CoreImages;
 import org.eclipse.wb.core.gef.policy.layout.grid.IGridInfo;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.rcp.gef.GefMessages;
@@ -27,6 +26,7 @@ import org.eclipse.wb.internal.rcp.model.forms.layout.table.TableWrapDimensionIn
 import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.TextUtilities;
@@ -65,7 +65,8 @@ public final class ColumnHeaderEditPart<C extends IControlInfo> extends Dimensio
 	protected IFigure createFigure() {
 		IFigure newFigure = new Figure() {
 			@Override
-			protected void paintClientArea(Graphics graphics) {
+			protected void paintFigure(Graphics graphics) {
+				super.paintFigure(graphics);
 				Rectangle r = getClientArea();
 				// draw rectangle
 				graphics.setForegroundColor(ColorConstants.buttonDarker);

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/header/edit/RowHeaderEditPart.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/forms/layout/grid/header/edit/RowHeaderEditPart.java
@@ -14,7 +14,6 @@ package org.eclipse.wb.internal.rcp.gef.policy.forms.layout.grid.header.edit;
 
 import org.eclipse.wb.core.editor.constants.CoreImages;
 import org.eclipse.wb.core.gef.policy.layout.grid.IGridInfo;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.rcp.gef.GefMessages;
@@ -27,6 +26,7 @@ import org.eclipse.wb.internal.rcp.model.forms.layout.table.TableWrapRowInfo;
 import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.TextUtilities;
@@ -65,7 +65,8 @@ public final class RowHeaderEditPart<C extends IControlInfo> extends DimensionHe
 	protected IFigure createFigure() {
 		IFigure newFigure = new Figure() {
 			@Override
-			protected void paintClientArea(Graphics graphics) {
+			protected void paintFigure(Graphics graphics) {
+				super.paintFigure(graphics);
 				Rectangle r = getClientArea();
 				// draw rectangle
 				graphics.setForegroundColor(ColorConstants.buttonDarker);

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/edit/ColumnHeaderEditPart.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/edit/ColumnHeaderEditPart.java
@@ -13,7 +13,6 @@
 package org.eclipse.wb.internal.swing.FormLayout.gef.header.edit;
 
 import org.eclipse.wb.core.editor.constants.CoreImages;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.model.util.ObjectInfoAction;
@@ -26,6 +25,7 @@ import org.eclipse.wb.internal.swing.FormLayout.model.FormLayoutInfo;
 import org.eclipse.wb.internal.swing.FormLayout.model.ui.ColumnEditDialog;
 
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.TextUtilities;
@@ -70,7 +70,8 @@ public class ColumnHeaderEditPart extends DimensionHeaderEditPart<FormColumnInfo
 	protected IFigure createFigure() {
 		IFigure newFigure = new Figure() {
 			@Override
-			protected void paintClientArea(Graphics graphics) {
+			protected void paintFigure(Graphics graphics) {
+				super.paintFigure(graphics);
 				Rectangle r = getClientArea();
 				// draw rectangle
 				graphics.setForegroundColor(ColorConstants.buttonDarker);

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/edit/RowHeaderEditPart.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/gef/header/edit/RowHeaderEditPart.java
@@ -13,7 +13,6 @@
 package org.eclipse.wb.internal.swing.FormLayout.gef.header.edit;
 
 import org.eclipse.wb.core.editor.constants.CoreImages;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.model.util.ObjectInfoAction;
@@ -26,6 +25,7 @@ import org.eclipse.wb.internal.swing.FormLayout.model.FormRowInfo;
 import org.eclipse.wb.internal.swing.FormLayout.model.ui.RowEditDialog;
 
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.TextUtilities;
@@ -70,7 +70,8 @@ public class RowHeaderEditPart extends DimensionHeaderEditPart<FormRowInfo> {
 	protected IFigure createFigure() {
 		IFigure newFigure = new Figure() {
 			@Override
-			protected void paintClientArea(Graphics graphics) {
+			protected void paintFigure(Graphics graphics) {
+				super.paintFigure(graphics);
 				Rectangle r = getClientArea();
 				// draw rectangle
 				graphics.setForegroundColor(ColorConstants.buttonDarker);

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/edit/ColumnHeaderEditPart.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/edit/ColumnHeaderEditPart.java
@@ -13,7 +13,6 @@
 package org.eclipse.wb.internal.swing.MigLayout.gef.header.edit;
 
 import org.eclipse.wb.core.editor.constants.CoreImages;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.core.DesignerPlugin;
@@ -28,6 +27,7 @@ import org.eclipse.wb.internal.swing.MigLayout.model.MigLayoutInfo;
 import org.eclipse.wb.internal.swing.MigLayout.model.ui.ColumnEditDialog;
 
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.TextUtilities;
@@ -75,7 +75,8 @@ public class ColumnHeaderEditPart extends DimensionHeaderEditPart<MigColumnInfo>
 	protected IFigure createFigure() {
 		IFigure newFigure = new Figure() {
 			@Override
-			protected void paintClientArea(Graphics graphics) {
+			protected void paintFigure(Graphics graphics) {
+				super.paintFigure(graphics);
 				Rectangle r = getClientArea();
 				// draw rectangle
 				graphics.setForegroundColor(ColorConstants.buttonDarker);
@@ -100,10 +101,10 @@ public class ColumnHeaderEditPart extends DimensionHeaderEditPart<MigColumnInfo>
 				}
 				// draw alignment indicator
 				if (titleLeft - r.x > 3 + 7 + 3) {
-					Image image = m_column.getAlignment(true).getSmallImageDescriptor().createImage();
+					ImageDescriptor imageDescriptor = m_column.getAlignment(true).getSmallImageDescriptor();
+					Image image = getViewer().getResourceManager().create(imageDescriptor);
 					int x = r.x + 2;
 					drawCentered(graphics, image, x);
-					image.dispose();
 				}
 				// draw grow indicator
 				if (m_column.hasGrow()) {

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/edit/RowHeaderEditPart.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/gef/header/edit/RowHeaderEditPart.java
@@ -13,7 +13,6 @@
 package org.eclipse.wb.internal.swing.MigLayout.gef.header.edit;
 
 import org.eclipse.wb.core.editor.constants.CoreImages;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.core.DesignerPlugin;
@@ -28,6 +27,7 @@ import org.eclipse.wb.internal.swing.MigLayout.model.MigRowInfo;
 import org.eclipse.wb.internal.swing.MigLayout.model.ui.RowEditDialog;
 
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.TextUtilities;
@@ -75,7 +75,8 @@ public class RowHeaderEditPart extends DimensionHeaderEditPart<MigRowInfo> {
 	protected IFigure createFigure() {
 		IFigure newFigure = new Figure() {
 			@Override
-			protected void paintClientArea(Graphics graphics) {
+			protected void paintFigure(Graphics graphics) {
+				super.paintFigure(graphics);
 				Rectangle r = getClientArea();
 				// draw rectangle
 				graphics.setForegroundColor(ColorConstants.buttonDarker);
@@ -100,10 +101,10 @@ public class RowHeaderEditPart extends DimensionHeaderEditPart<MigRowInfo> {
 				}
 				// draw alignment indicator
 				if (titleTop - r.y > 3 + 7 + 3) {
-					Image image = m_row.getAlignment(true).getSmallImageDescriptor().createImage();
+					ImageDescriptor imageDescriptor = m_row.getAlignment(true).getSmallImageDescriptor();
+					Image image = getViewer().getResourceManager().create(imageDescriptor);
 					int y = r.y + 2;
 					drawCentered(graphics, image, y);
-					image.dispose();
 				}
 				// draw grow indicator
 				if (m_dimension.hasGrow()) {

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/header/edit/ColumnHeaderEditPart.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/header/edit/ColumnHeaderEditPart.java
@@ -13,7 +13,6 @@
 package org.eclipse.wb.internal.swing.gef.policy.layout.gbl.header.edit;
 
 import org.eclipse.wb.core.editor.constants.CoreImages;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.core.DesignerPlugin;
@@ -27,6 +26,7 @@ import org.eclipse.wb.internal.swing.model.layout.gbl.ColumnInfo.Alignment;
 import org.eclipse.wb.internal.swing.model.layout.gbl.ui.ColumnEditDialog;
 
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.TextUtilities;
@@ -68,12 +68,13 @@ public final class ColumnHeaderEditPart extends DimensionHeaderEditPart<ColumnIn
 	protected IFigure createFigure() {
 		IFigure figure = new Figure() {
 			@Override
-			protected void paintClientArea(Graphics graphics) {
+			protected void paintFigure(Graphics graphics) {
 				Rectangle r = getClientArea();
 				// ignore paint when Layout already replaced, but event loop happens
 				if (!m_layout.isActive()) {
 					return;
 				}
+				super.paintFigure(graphics);
 				// draw rectangle
 				graphics.setForegroundColor(ColorConstants.buttonDarker);
 				graphics.drawLine(r.x, r.y, r.x, r.bottom());

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/header/edit/RowHeaderEditPart.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/gbl/header/edit/RowHeaderEditPart.java
@@ -13,7 +13,6 @@
 package org.eclipse.wb.internal.swing.gef.policy.layout.gbl.header.edit;
 
 import org.eclipse.wb.core.editor.constants.CoreImages;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.core.DesignerPlugin;
@@ -28,6 +27,7 @@ import org.eclipse.wb.internal.swing.model.layout.gbl.ui.RowEditDialog;
 import org.eclipse.wb.swing.SwingImages;
 
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.TextUtilities;
@@ -69,12 +69,13 @@ public final class RowHeaderEditPart extends DimensionHeaderEditPart<RowInfo> {
 	protected IFigure createFigure() {
 		IFigure figure = new Figure() {
 			@Override
-			protected void paintClientArea(Graphics graphics) {
+			protected void paintFigure(Graphics graphics) {
 				Rectangle r = getClientArea();
 				// ignore paint when Layout already replaced, but event loop happens
 				if (!m_layout.isActive()) {
 					return;
 				}
+				super.paintFigure(graphics);
 				// draw rectangle
 				graphics.setForegroundColor(ColorConstants.buttonDarker);
 				graphics.drawLine(r.x, r.y, r.right(), r.y);

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/header/edit/ColumnHeaderEditPart.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/header/edit/ColumnHeaderEditPart.java
@@ -15,7 +15,6 @@ package org.eclipse.wb.internal.swt.gef.policy.layout.grid.header.edit;
 import org.eclipse.wb.core.editor.constants.CoreImages;
 import org.eclipse.wb.core.gef.policy.PolicyUtils;
 import org.eclipse.wb.core.gef.policy.layout.grid.IGridInfo;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.swt.gef.GefMessages;
@@ -28,6 +27,7 @@ import org.eclipse.wb.internal.swt.model.layout.grid.IGridLayoutInfo;
 import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.TextUtilities;
@@ -66,7 +66,8 @@ public final class ColumnHeaderEditPart<C extends IControlInfo> extends Dimensio
 	protected IFigure createFigure() {
 		IFigure newFigure = new Figure() {
 			@Override
-			protected void paintClientArea(Graphics graphics) {
+			protected void paintFigure(Graphics graphics) {
+				super.paintFigure(graphics);
 				Rectangle r = getClientArea();
 				// draw rectangle
 				graphics.setForegroundColor(ColorConstants.buttonDarker);

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/header/edit/RowHeaderEditPart.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/grid/header/edit/RowHeaderEditPart.java
@@ -14,7 +14,6 @@ package org.eclipse.wb.internal.swt.gef.policy.layout.grid.header.edit;
 
 import org.eclipse.wb.core.editor.constants.CoreImages;
 import org.eclipse.wb.core.gef.policy.layout.grid.IGridInfo;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.swt.gef.GefMessages;
@@ -27,6 +26,7 @@ import org.eclipse.wb.internal.swt.model.layout.grid.IGridLayoutInfo;
 import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.TextUtilities;
@@ -63,7 +63,8 @@ public final class RowHeaderEditPart<C extends IControlInfo> extends DimensionHe
 	protected IFigure createFigure() {
 		IFigure newFigure = new Figure() {
 			@Override
-			protected void paintClientArea(Graphics graphics) {
+			protected void paintFigure(Graphics graphics) {
+				super.paintFigure(graphics);
 				Rectangle r = getClientArea();
 				// draw rectangle
 				graphics.setForegroundColor(ColorConstants.buttonDarker);


### PR DESCRIPTION
This migrates the figures used by the following layouts away from our "Designer" figures:

- FormLayout (Swing)
- MigLayout (Swing)
- GridBagLayout (Swing)
- FormLayout (SWT)
- TableWrapLayout (RCP)