### PR TITLE
Refactor Box edit-parts to use plain Draw2D Figures

### DIFF
--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
@@ -110,8 +110,6 @@ public class Figure extends org.eclipse.draw2d.Figure {
 				graphics.clipRect(childBounds);
 				if (childFigure instanceof Figure f && f.useLocalCoordinates()) {
 					graphics.translate(childBounds.x, childBounds.y);
-				} else {
-					System.out.println(childFigure);
 				}
 				childFigure.paint(graphics);
 				graphics.restoreState();

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/part/box/BoxGlueEditPart.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/part/box/BoxGlueEditPart.java
@@ -12,11 +12,11 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.gef.part.box;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.internal.swing.gef.policy.component.box.GlueSelectionEditPolicy;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -60,12 +60,13 @@ public final class BoxGlueEditPart extends BoxEditPart {
 	protected IFigure createFigure() {
 		return new Figure() {
 			@Override
-			protected void paintClientArea(Graphics graphics) {
+			protected void paintFigure(Graphics graphics) {
+				super.paintFigure(graphics);
 				Rectangle r = getClientArea();
-				int x = (r.width - SPRING_SIZE) / 2;
-				int y = (r.height - SPRING_SIZE) / 2;
-				BoxGlueHorizontalEditPart.draw(graphics, new Rectangle(0, y, r.width, SPRING_SIZE));
-				BoxGlueVerticalEditPart.draw(graphics, new Rectangle(x, 0, SPRING_SIZE, r.height));
+				int x = r.x + (r.width - SPRING_SIZE) / 2;
+				int y = r.y + (r.height - SPRING_SIZE) / 2;
+				BoxGlueHorizontalEditPart.draw(graphics, new Rectangle(r.x, y, r.width, SPRING_SIZE));
+				BoxGlueVerticalEditPart.draw(graphics, new Rectangle(x, r.y, SPRING_SIZE, r.height));
 			}
 		};
 	}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/part/box/BoxGlueHorizontalEditPart.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/part/box/BoxGlueHorizontalEditPart.java
@@ -12,11 +12,11 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.gef.part.box;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.internal.swing.gef.policy.component.box.GlueSelectionEditPolicy;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -60,7 +60,8 @@ public final class BoxGlueHorizontalEditPart extends BoxEditPart {
 	protected IFigure createFigure() {
 		return new Figure() {
 			@Override
-			protected void paintClientArea(Graphics graphics) {
+			protected void paintFigure(Graphics graphics) {
+				super.paintFigure(graphics);
 				Rectangle r = getClientArea();
 				draw(graphics, r);
 			}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/part/box/BoxGlueVerticalEditPart.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/part/box/BoxGlueVerticalEditPart.java
@@ -12,11 +12,11 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.gef.part.box;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.internal.swing.gef.policy.component.box.GlueSelectionEditPolicy;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -60,7 +60,8 @@ public final class BoxGlueVerticalEditPart extends BoxEditPart {
 	protected IFigure createFigure() {
 		return new Figure() {
 			@Override
-			protected void paintClientArea(Graphics graphics) {
+			protected void paintFigure(Graphics graphics) {
+				super.paintFigure(graphics);
 				Rectangle r = getClientArea();
 				draw(graphics, r);
 			}
@@ -77,8 +78,8 @@ public final class BoxGlueVerticalEditPart extends BoxEditPart {
 			// draw spring
 			{
 				graphics.setForegroundColor(COLOR_SPRING);
-				int y = r.y;
-				while (y < r.bottom()) {
+				int y = 0;
+				while (y < r.height) {
 					graphics.drawLine(3, y, 3 + 5, y + 2);
 					y += 2;
 					graphics.drawLine(3 + 5, y, 3, y + 2);

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/part/box/BoxRigidAreaEditPart.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/part/box/BoxRigidAreaEditPart.java
@@ -12,12 +12,12 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.gef.part.box;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.internal.swing.gef.policy.component.box.StrutDirectRigidEditPolicy;
 import org.eclipse.wb.internal.swing.gef.policy.component.box.StrutSelectionRigidEditPolicy;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -62,7 +62,8 @@ public final class BoxRigidAreaEditPart extends BoxEditPart {
 	protected IFigure createFigure() {
 		return new Figure() {
 			@Override
-			protected void paintClientArea(Graphics graphics) {
+			protected void paintFigure(Graphics graphics) {
+				super.paintFigure(graphics);
 				Rectangle r = getClientArea();
 				BoxStrutHorizontalEditPart.draw(graphics, r);
 				BoxStrutVerticalEditPart.draw(graphics, r);

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/part/box/BoxStrutHorizontalEditPart.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/part/box/BoxStrutHorizontalEditPart.java
@@ -12,12 +12,12 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.gef.part.box;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.internal.swing.gef.policy.component.box.StrutDirectHorizontalEditPolicy;
 import org.eclipse.wb.internal.swing.gef.policy.component.box.StrutSelectionHorizontalEditPolicy;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -64,7 +64,8 @@ public final class BoxStrutHorizontalEditPart extends BoxEditPart {
 	protected IFigure createFigure() {
 		return new Figure() {
 			@Override
-			protected void paintClientArea(Graphics graphics) {
+			protected void paintFigure(Graphics graphics) {
+				super.paintFigure(graphics);
 				Rectangle r = getClientArea();
 				draw(graphics, r);
 			}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/part/box/BoxStrutVerticalEditPart.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/part/box/BoxStrutVerticalEditPart.java
@@ -12,12 +12,12 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.gef.part.box;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.internal.swing.gef.policy.component.box.StrutDirectVerticalEditPolicy;
 import org.eclipse.wb.internal.swing.gef.policy.component.box.StrutSelectionVerticalEditPolicy;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -62,7 +62,8 @@ public final class BoxStrutVerticalEditPart extends BoxEditPart {
 	protected IFigure createFigure() {
 		return new Figure() {
 			@Override
-			protected void paintClientArea(Graphics graphics) {
+			protected void paintFigure(Graphics graphics) {
+				super.paintFigure(graphics);
 				Rectangle r = getClientArea();
 				draw(graphics, r);
 			}


### PR DESCRIPTION
There is no benefit in using our "Designer" figures, outside of dealing with relative instead of absolute coordinates.

This adapts the following edit parts:
- Horizontal Strut
- Vertical Strut
- Horizontal Glue
- Vertical Glue
- Rigid Area
- Glue