### PR TITLE
Remove usage of deprecated ArrayUtils methods

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/GenericPropertyComposite.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/GenericPropertyComposite.java
@@ -17,8 +17,6 @@ import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 
 import org.eclipse.jdt.core.dom.Expression;
 
-import org.apache.commons.lang3.ArrayUtils;
-
 import java.util.Objects;
 
 /**
@@ -80,7 +78,7 @@ public final class GenericPropertyComposite extends GenericProperty {
 		}
 		//
 		if (obj instanceof GenericPropertyComposite property) {
-			return ArrayUtils.isEquals(m_properties, property.m_properties);
+			return Objects.deepEquals(m_properties, property.m_properties);
 		}
 		//
 		return false;

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/factory/FactoryActionsSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/factory/FactoryActionsSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -189,7 +189,7 @@ public final class FactoryActionsSupport {
 		String[] typeNames = getPreviousTypeNames(component);
 		// move element into head
 		typeNames = ArrayUtils.removeElement(typeNames, typeName);
-		typeNames = ArrayUtils.add(typeNames, 0, typeName);
+		typeNames = ArrayUtils.insert(0, typeNames, typeName);
 		// limit history size
 		if (typeNames.length > MAX_PREVIOUS_FACTORIES) {
 			typeNames = ArrayUtils.remove(typeNames, typeNames.length - 1);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/eval/other/ArrayTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/eval/other/ArrayTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,9 +14,10 @@ package org.eclipse.wb.tests.designer.core.eval.other;
 
 import org.eclipse.wb.tests.designer.core.eval.AbstractEngineTest;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.Objects;
 
 /**
  * @author scheglov_ke
@@ -50,12 +51,6 @@ public class ArrayTest extends AbstractEngineTest {
 	// Array
 	//
 	////////////////////////////////////////////////////////////////////////////
-	@Test
-	public void test_array_compare() throws Exception {
-		int[] a_1 = new int[]{1, 2, 3};
-		int[] a_2 = new int[]{1, 2, 3};
-		assertTrue(ArrayUtils.isEquals(a_1, a_2));
-	}
 
 	@Test
 	public void test_array_int_1() throws Exception {
@@ -160,6 +155,6 @@ public class ArrayTest extends AbstractEngineTest {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	private void check_array(Object expected, String expression, String returnType) throws Exception {
-		assertTrue(ArrayUtils.isEquals(expected, evaluateExpression(expression, returnType)));
+		assertTrue(Objects.deepEquals(expected, evaluateExpression(expression, returnType)));
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/ObjectInfoTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/ObjectInfoTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
@@ -379,7 +378,7 @@ public class ObjectInfoTest extends DesignerTestCase {
 		parent.addChild(child_1);
 		parent.addChild(child_2);
 		// test children and parent
-		assertTrue(ArrayUtils.isEquals(new Object[]{child_1, child_2}, parent.getChildren().toArray()));
+		assertArrayEquals(new Object[] { child_1, child_2 }, parent.getChildren().toArray());
 		assertSame(parent, child_1.getParent());
 		assertSame(parent, child_2.getParent());
 		// check getChildren(Class)
@@ -411,9 +410,7 @@ public class ObjectInfoTest extends DesignerTestCase {
 		parent.addChild(child_1);
 		parent.addChild(child_2);
 		parent.addChild(child_3, child_2);
-		assertTrue(ArrayUtils.isEquals(
-				new Object[]{child_1, child_3, child_2},
-				parent.getChildren().toArray()));
+		assertArrayEquals(new Object[] { child_1, child_3, child_2 }, parent.getChildren().toArray());
 		assertSame(parent, child_1.getParent());
 		assertSame(parent, child_2.getParent());
 		assertSame(parent, child_3.getParent());
@@ -471,9 +468,7 @@ public class ObjectInfoTest extends DesignerTestCase {
 		{
 			buffer.setLength(0);
 			parent.moveChild(child_3, child_1);
-			assertTrue(ArrayUtils.isEquals(
-					new Object[]{child_3, child_1, child_2},
-					parent.getChildren().toArray()));
+			assertArrayEquals(new Object[] { child_3, child_1, child_2 }, parent.getChildren().toArray());
 			assertEquals(
 					getSourceDQ(
 							"childMoveBefore parent child_3 child_1",
@@ -484,9 +479,7 @@ public class ObjectInfoTest extends DesignerTestCase {
 		{
 			buffer.setLength(0);
 			parent.moveChild(child_1, null);
-			assertTrue(ArrayUtils.isEquals(
-					new Object[]{child_3, child_2, child_1},
-					parent.getChildren().toArray()));
+			assertArrayEquals(new Object[] { child_3, child_2, child_1 }, parent.getChildren().toArray());
 			assertEquals(
 					getSourceDQ("childMoveBefore parent child_1 null", "childMoveAfter parent child_1 null"),
 					buffer.toString());
@@ -507,7 +500,7 @@ public class ObjectInfoTest extends DesignerTestCase {
 		parent.addChild(child_2);
 		// do move
 		parent.moveChild(child_2, child_2);
-		assertTrue(ArrayUtils.isEquals(new Object[]{child_1, child_2}, parent.getChildren().toArray()));
+		assertArrayEquals(new Object[] { child_1, child_2 }, parent.getChildren().toArray());
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/ConstructorCreationSupportTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/ConstructorCreationSupportTest.java
@@ -45,7 +45,6 @@ import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jface.preference.FieldEditor;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.Test;
 
 import javax.swing.JButton;
@@ -391,11 +390,11 @@ public class ConstructorCreationSupportTest extends SwingModelTest {
 		assertEquals("scrollbars", subProperties[3].getTitle());
 		// check that last property has static field editor
 		StaticFieldPropertyEditor editor = (StaticFieldPropertyEditor) subProperties[3].getEditor();
-		assertTrue(ArrayUtils.isEquals(new String[]{
+		assertArrayEquals(new String[]{
 				"SCROLLBARS_BOTH",
 				"SCROLLBARS_VERTICAL_ONLY",
 				"SCROLLBARS_HORIZONTAL_ONLY",
-		"SCROLLBARS_NONE"}, getFieldValue(editor, "m_titles")));
+				"SCROLLBARS_NONE" }, (String[]) getFieldValue(editor, "m_titles"));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/editor/StaticFieldPropertyEditorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/editor/StaticFieldPropertyEditorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -234,7 +233,7 @@ public class StaticFieldPropertyEditorTest extends SwingModelTest {
 		assertEquals(e_classSourceName, getFieldValue(editor, "m_classSourceName"));
 		Assertions.<Object>assertThat((String[]) getFieldValue(editor, "m_names")).containsOnly(e_names);
 		Assertions.<Object>assertThat((String[]) getFieldValue(editor, "m_titles")).containsOnly(e_titles);
-		assertTrue(ArrayUtils.isEquals(e_values, getFieldValue(editor, "m_values")));
+		assertArrayEquals(e_values, (Object[]) getFieldValue(editor, "m_values"));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/editor/StringsAddPropertyTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/editor/StringsAddPropertyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -18,7 +18,6 @@ import org.eclipse.wb.internal.core.model.property.configurable.StringsAddProper
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 import org.eclipse.wb.tests.designer.swing.SwingModelTest;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -67,7 +66,7 @@ public class StringsAddPropertyTest extends SwingModelTest {
 		{
 			assertEquals("[aaa,bbb]", getPropertyText(itemsProperty));
 			assertTrue(itemsProperty.isModified());
-			assertTrue(ArrayUtils.isEquals(new String[]{"aaa", "bbb"}, itemsProperty.getValue()));
+			assertArrayEquals(new String[] { "aaa", "bbb" }, (String[]) itemsProperty.getValue());
 		}
 		// set new items
 		{
@@ -82,7 +81,7 @@ public class StringsAddPropertyTest extends SwingModelTest {
 					"}");
 			assertEquals("[000,111,222]", getPropertyText(itemsProperty));
 			assertTrue(itemsProperty.isModified());
-			assertTrue(ArrayUtils.isEquals(new String[]{"000", "111", "222"}, itemsProperty.getValue()));
+			assertArrayEquals(new String[] { "000", "111", "222" }, (String[]) itemsProperty.getValue());
 		}
 	}
 
@@ -124,7 +123,7 @@ public class StringsAddPropertyTest extends SwingModelTest {
 		{
 			assertEquals("[aaa,bbb]", getPropertyText(itemsProperty));
 			assertTrue(itemsProperty.isModified());
-			assertTrue(ArrayUtils.isEquals(new String[]{"aaa", "bbb"}, itemsProperty.getValue()));
+			assertArrayEquals(new String[] { "aaa", "bbb" }, (String[]) itemsProperty.getValue());
 		}
 		// set new items
 		{
@@ -139,7 +138,7 @@ public class StringsAddPropertyTest extends SwingModelTest {
 					"}");
 			assertEquals("[000,111,222]", getPropertyText(itemsProperty));
 			assertTrue(itemsProperty.isModified());
-			assertTrue(ArrayUtils.isEquals(new String[]{"000", "111", "222"}, itemsProperty.getValue()));
+			assertArrayEquals(new String[] { "000", "111", "222" }, (String[]) itemsProperty.getValue());
 		}
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/ast/AstEditorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/ast/AstEditorTest.java
@@ -83,7 +83,6 @@ import org.eclipse.ui.ide.IDE;
 
 import static org.mockito.Mockito.mock;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.util.Lists;
@@ -2235,7 +2234,7 @@ public class AstEditorTest extends AbstractJavaTest {
 					}
 				}""");
 		MethodDeclaration method = typeDeclaration.getMethods()[0];
-		assertTrue(ArrayUtils.isEquals(new String[]{"s", "d"}, m_lastEditor.getParameterNames(method)));
+		assertArrayEquals(new String[] { "s", "d" }, m_lastEditor.getParameterNames(method));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/ast/AstNodeUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/ast/AstNodeUtilsTest.java
@@ -60,7 +60,6 @@ import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.BeforeEach;
@@ -3676,14 +3675,14 @@ public class AstNodeUtilsTest extends AbstractJavaTest {
 		Statement[] statements = new Statement[]{statement_1, statement_3, statement_2};
 		// forward comparator
 		Arrays.sort(statements, AstNodeUtils.SORT_BY_POSITION);
-		assertTrue(ArrayUtils.isEquals(
+		assertArrayEquals(
 				new Statement[]{statement_1, statement_2, statement_3},
-				statements));
+				statements);
 		// reverse comparator
 		Arrays.sort(statements, AstNodeUtils.SORT_BY_REVERSE_POSITION);
-		assertTrue(ArrayUtils.isEquals(
+		assertArrayEquals(
 				new Statement[]{statement_3, statement_2, statement_1},
-				statements));
+				statements);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/jdt/core/CodeUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/jdt/core/CodeUtilsTest.java
@@ -112,23 +112,18 @@ public class CodeUtilsTest extends AbstractJavaTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_join_1() {
-		assertTrue(ArrayUtils.isEquals(new String[]{"aaa"}, CodeUtils.join(null, "aaa")));
-		assertTrue(ArrayUtils.isEquals(
-				new String[]{"aaa", "bbb", "ccc"},
-				CodeUtils.join(new String[]{"aaa", "bbb"}, "ccc")));
+		assertArrayEquals(new String[] { "aaa" }, CodeUtils.join(null, "aaa"));
+		assertArrayEquals(new String[] { "aaa", "bbb", "ccc" }, CodeUtils.join(new String[] { "aaa", "bbb" }, "ccc"));
 	}
 
 	@Test
 	public void test_join_2() {
-		assertTrue(ArrayUtils.isEquals(
-				new String[]{"aaa", "bbb"},
-				CodeUtils.join(null, new String[]{"aaa", "bbb"})));
-		assertTrue(ArrayUtils.isEquals(
-				new String[]{"aaa", "bbb"},
-				CodeUtils.join(new String[]{"aaa", "bbb"}, (String[]) null)));
-		assertTrue(ArrayUtils.isEquals(
-				new String[]{"aaa", "bbb", "ccc"},
-				CodeUtils.join(new String[]{"aaa", "bbb"}, new String[]{"ccc"})));
+		assertArrayEquals(new String[] { "aaa", "bbb" },
+				CodeUtils.join(null, new String[] { "aaa", "bbb" }));
+		assertArrayEquals(new String[] { "aaa", "bbb" },
+				CodeUtils.join(new String[] { "aaa", "bbb" }, (String[]) null));
+		assertArrayEquals(new String[] { "aaa", "bbb", "ccc" },
+				CodeUtils.join(new String[] { "aaa", "bbb" }, new String[] { "ccc" }));
 	}
 
 	@Test

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/DesignerEditorTestCase.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/DesignerEditorTestCase.java
@@ -61,7 +61,6 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.actions.ActionFactory;
 import org.eclipse.ui.ide.IDE;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.function.FailableConsumer;
 import org.apache.commons.lang3.function.FailableRunnable;
 import org.junit.jupiter.api.AfterEach;
@@ -288,7 +287,7 @@ public abstract class DesignerEditorTestCase extends AbstractJavaInfoRelatedTest
 		IStructuredSelection selection =
 				(IStructuredSelection) m_componentsTree.getSelectionProvider().getSelection();
 		Object[] actualModels = selection.toArray();
-		assertTrue(ArrayUtils.isEquals(models, actualModels));
+		assertArrayEquals(models, actualModels);
 	}
 
 	/**

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/AbstractButtonTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/AbstractButtonTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -19,7 +19,6 @@ import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 import org.eclipse.wb.tests.designer.swing.SwingModelTest;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
@@ -76,6 +75,6 @@ public class AbstractButtonTest extends SwingModelTest {
 		// check fields
 		Field namesField = editor.getClass().getDeclaredField("m_names");
 		namesField.setAccessible(true);
-		ArrayUtils.isEquals(expectedNames, namesField.get(editor));
+		assertArrayEquals(expectedNames, (String[]) namesField.get(editor));
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/JListTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/JListTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,7 +17,6 @@ import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.property.editor.models.list.ListModelPropertyEditor;
 import org.eclipse.wb.tests.designer.swing.SwingModelTest;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.Test;
 
 import javax.swing.JList;
@@ -68,7 +67,7 @@ public class JListTest extends SwingModelTest {
 		{
 			Property modelProperty = listInfo.getPropertyByTitle("model");
 			String[] actualItems = ListModelPropertyEditor.getItems(modelProperty);
-			assertTrue(ArrayUtils.isEquals(new String[]{"111", "222", "333"}, actualItems));
+			assertArrayEquals(new String[] { "111", "222", "333" }, actualItems);
 		}
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/FormLayout/FormLayoutTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/FormLayout/FormLayoutTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -39,7 +39,6 @@ import org.eclipse.jface.action.MenuManager;
 import com.jgoodies.forms.layout.CellConstraints;
 import com.jgoodies.forms.layout.FormLayout;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -600,8 +599,8 @@ public class FormLayoutTest extends AbstractFormLayoutTest {
 						"  }",
 						"}");
 		FormLayoutInfo layout = (FormLayoutInfo) panel.getLayout();
-		assertTrue(ArrayUtils.isEquals(new int[]{2, 0, 1}, layout.getColumnComponentsCounts()));
-		assertTrue(ArrayUtils.isEquals(new int[]{1, 2}, layout.getRowComponentsCounts()));
+		assertArrayEquals(new int[] { 2, 0, 1 }, layout.getColumnComponentsCounts());
+		assertArrayEquals(new int[] { 1, 2 }, layout.getRowComponentsCounts());
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/layouts/AbsoluteLayoutTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/layouts/AbsoluteLayoutTest.java
@@ -487,14 +487,14 @@ public class AbsoluteLayoutTest extends RcpModelTest {
 		String[] initialLines = ArrayUtils.clone(initialCode);
 		for (int i = 0; i < initial.length; i++) {
 			if (!StringUtils.isEmpty(initial[i])) {
-				initialLines = ArrayUtils.add(initialLines, 4 + i, initial[i]);
+				initialLines = ArrayUtils.insert(4 + i, initialLines, initial[i]);
 			}
 		}
 		// prepare expected code
 		String[] expectedLines = ArrayUtils.clone(initialCode);
 		for (int i = 0; i < expected.length; i++) {
 			if (!StringUtils.isEmpty(expected[i])) {
-				expectedLines = ArrayUtils.add(expectedLines, 4 + i, expected[i]);
+				expectedLines = ArrayUtils.insert(4 + i, expectedLines, expected[i]);
 			}
 		}
 		// prepare model

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/utils/StringUtilitiesTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/utils/StringUtilitiesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -197,8 +197,7 @@ public class StringUtilitiesTest extends DesignerTestCase {
 	 * Asserts that two given int's arrays are equals.
 	 */
 	private static void assertIntervals(int[] expected, int[] actual) {
-		assertTrue(
-				ArrayUtils.isEquals(expected, actual),
+		assertArrayEquals(expected, actual,
 				ArrayUtils.toString(expected) + " != " + ArrayUtils.toString(actual));
 	}
 


### PR DESCRIPTION
The add() method has been replaced with an insert() method. For the isEquals() method, one should use Objects.deepEquals(). However, those are only used in tests where one can simply use assertArrayEquals() instead.