### PR TITLE
Avoid usage of deprecated Locale constructor

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/nls/model/LocaleInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/nls/model/LocaleInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -182,9 +182,9 @@ public final class LocaleInfo implements Comparable<LocaleInfo> {
 			if (separatorIndex != -1) {
 				String language = localeName.substring(0, separatorIndex);
 				String country = localeName.substring(separatorIndex + 1);
-				locale = new Locale(language, country);
+				locale = Locale.of(language, country);
 			} else {
-				locale = new Locale(localeName);
+				locale = Locale.of(localeName);
 			}
 			return new LocaleInfo(locale);
 		} catch (Throwable e) {

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/nls/model/LocalePartInfos.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/nls/model/LocalePartInfos.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -76,7 +76,7 @@ public final class LocalePartInfos {
 				Set<LocalePartInfo> languagesSet = new HashSet<>();
 				// fill
 				for (String language : Locale.getISOLanguages()) {
-					Locale locale = new Locale(language);
+					Locale locale = Locale.of(language);
 					Image flagImage = FlagImagesRepository.getFlagImage(locale);
 					languagesSet.add(new LocalePartInfo(locale.getLanguage(),
 							locale.getDisplayLanguage(),
@@ -92,7 +92,7 @@ public final class LocalePartInfos {
 				countriesSet.add(new LocalePartInfo("", "(none)", FlagImagesRepository.getEmptyFlagImage()));
 				// fill
 				for (String country : Locale.getISOCountries()) {
-					Locale locale = new Locale("", country);
+					Locale locale = Locale.of("", country);
 					Image flagImage = FlagImagesRepository.getFlagImage(locale);
 					countriesSet.add(new LocalePartInfo(locale.getCountry(),
 							locale.getDisplayCountry(),

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/nls/ui/ChooseLocaleDialog.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/nls/ui/ChooseLocaleDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -291,9 +291,9 @@ public class ChooseLocaleDialog extends TitleAreaDialog {
 						LocalePartInfos.getLanguages()[m_languageCombo.getSelectionIndex()];
 				LocalePartInfo country = LocalePartInfos.getCountries()[m_countryCombo.getSelectionIndex()];
 				if (country.getName().length() == 0) {
-					locale = new Locale(language.getName());
+					locale = Locale.of(language.getName());
 				} else {
-					locale = new Locale(language.getName(), country.getName());
+					locale = Locale.of(language.getName(), country.getName());
 				}
 			}
 			// create selected locale information

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/StandardConvertersTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/StandardConvertersTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -252,15 +252,15 @@ public class StandardConvertersTest extends SwingModelTest {
 		assertEquals("java.util.Locale.ENGLISH", converter.toJavaSource(null, Locale.ENGLISH));
 		assertEquals(
 				"java.util.Locale.CANADA_FRENCH",
-				converter.toJavaSource(null, new Locale("fr", "CA")));
+				converter.toJavaSource(null, Locale.of("fr", "CA")));
 		assertEquals("java.util.Locale.US", converter.toJavaSource(null, Locale.US));
-		assertEquals("new java.util.Locale(\"ru\")", converter.toJavaSource(null, new Locale("ru")));
+		assertEquals("new java.util.Locale(\"ru\")", converter.toJavaSource(null, Locale.of("ru")));
 		assertEquals(
 				"new java.util.Locale(\"ru\", \"RU\")",
-				converter.toJavaSource(null, new Locale("ru", "RU")));
+				converter.toJavaSource(null, Locale.of("ru", "RU")));
 		assertEquals(
 				"new java.util.Locale(\"no\\tlocale\")",
-				converter.toJavaSource(null, new Locale("no\tlocale")));
+				converter.toJavaSource(null, Locale.of("no\tlocale")));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/BundleInfoTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/BundleInfoTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -61,7 +61,7 @@ public class BundleInfoTest extends SwingModelTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_createBundle() throws Exception {
-		LocaleInfo localeInfo = new LocaleInfo(new Locale("it"));
+		LocaleInfo localeInfo = new LocaleInfo(Locale.ITALIAN);
 		IFile[] files =
 				new IFile[]{
 						getFileSrc("test", "messages.properties"),
@@ -81,7 +81,7 @@ public class BundleInfoTest extends SwingModelTest {
 
 	@Test
 	public void test_createBundle_no() throws Exception {
-		LocaleInfo localeInfo = new LocaleInfo(new Locale("fr"));
+		LocaleInfo localeInfo = new LocaleInfo(Locale.FRENCH);
 		IFile[] files =
 				new IFile[]{
 						getFileSrc("test", "messages.properties"),

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/EditableSupportTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/EditableSupportTest.java
@@ -225,7 +225,7 @@ public class EditableSupportTest extends AbstractNlsTest {
 			editableSource = editableSources.get(0);
 		}
 		// add locale
-		LocaleInfo newLocale = new LocaleInfo(new Locale("it"));
+		LocaleInfo newLocale = new LocaleInfo(Locale.of("it"));
 		{
 			// check locales
 			assertEquals(1, editableSource.getLocales().length);
@@ -611,8 +611,8 @@ public class EditableSupportTest extends AbstractNlsTest {
 					assertEquals("(default)", locales[0].getTitle());
 				}
 				// add locales
-				editableSource.addLocale(new LocaleInfo(new Locale("it")), LocaleInfo.DEFAULT);
-				editableSource.addLocale(new LocaleInfo(new Locale("fr")), null);
+				editableSource.addLocale(new LocaleInfo(Locale.ITALIAN), LocaleInfo.DEFAULT);
+				editableSource.addLocale(new LocaleInfo(Locale.FRENCH), null);
 				{
 					LocaleInfo[] locales = editableSource.getLocales();
 					assertEquals(3, locales.length);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/LocaleInfoTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/LocaleInfoTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -64,8 +64,8 @@ public class LocaleInfoTest extends DesignerTestCase {
 	@Test
 	public void test_getParent() throws Exception {
 		LocaleInfo[] locales =
-				new LocaleInfo[]{new LocaleInfo(new Locale("fr", "FR")), new LocaleInfo(new Locale("ru"))};
-		assertSame(locales[1], new LocaleInfo(new Locale("ru", "RU")).getParent(locales));
-		assertSame(LocaleInfo.DEFAULT, new LocaleInfo(new Locale("ru")).getParent(locales));
+				new LocaleInfo[]{new LocaleInfo(Locale.of("fr", "FR")), new LocaleInfo(Locale.of("ru"))};
+		assertSame(locales[1], new LocaleInfo(Locale.of("ru", "RU")).getParent(locales));
+		assertSame(LocaleInfo.DEFAULT, new LocaleInfo(Locale.of("ru")).getParent(locales));
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/NlsSupportTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/NlsSupportTest.java
@@ -165,7 +165,7 @@ public class NlsSupportTest extends SwingModelTest {
 	public void test_getValue_it() throws Exception {
 		prepareUsualState();
 		// check with Italian locale (I don't use Russian because it will be used as default in my case...)
-		AbstractSource.setLocaleInfo(m_frame, new LocaleInfo(new Locale("it")));
+		AbstractSource.setLocaleInfo(m_frame, new LocaleInfo(Locale.of("it")));
 		m_frame.refresh();
 		assertEquals("My JFrame IT", ((JFrame) m_frame.getObject()).getTitle());
 	}
@@ -173,7 +173,7 @@ public class NlsSupportTest extends SwingModelTest {
 	@Test
 	public void test_getValue_it_IT() throws Exception {
 		prepareUsualState();
-		AbstractSource.setLocaleInfo(m_frame, new LocaleInfo(new Locale("it_IT")));
+		AbstractSource.setLocaleInfo(m_frame, new LocaleInfo(Locale.of("it_IT")));
 		m_frame.refresh();
 		assertEquals("My JFrame IT", ((JFrame) m_frame.getObject()).getTitle());
 	}
@@ -235,7 +235,7 @@ public class NlsSupportTest extends SwingModelTest {
 		// check that "name" is set
 		assertEquals("My JFrame", panel.getComponent().getName());
 		// set new locale
-		AbstractSource.setLocaleInfo(panel, new LocaleInfo(new Locale("it")));
+		AbstractSource.setLocaleInfo(panel, new LocaleInfo(Locale.of("it")));
 		panel.refresh();
 		assertEquals("My JFrame IT", panel.getComponent().getName());
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/FlagRepositoryTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/FlagRepositoryTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -38,13 +38,13 @@ public class FlagRepositoryTest extends DesignerTestCase {
 		Locale[] sortedLocales = FlagImagesRepository.getSortedLocales();
 		assertTrue(sortedLocales.length >= 140);
 		{
-			int index_1 = ArrayUtils.indexOf(sortedLocales, new Locale("en"));
-			int index_2 = ArrayUtils.indexOf(sortedLocales, new Locale("ru"));
+			int index_1 = ArrayUtils.indexOf(sortedLocales, Locale.of("en"));
+			int index_2 = ArrayUtils.indexOf(sortedLocales, Locale.of("ru"));
 			assertTrue(index_1 < index_2);
 		}
 		{
-			int index_1 = ArrayUtils.indexOf(sortedLocales, new Locale("de"));
-			int index_2 = ArrayUtils.indexOf(sortedLocales, new Locale("it"));
+			int index_1 = ArrayUtils.indexOf(sortedLocales, Locale.of("de"));
+			int index_2 = ArrayUtils.indexOf(sortedLocales, Locale.of("it"));
 			assertTrue(index_1 < index_2);
 		}
 	}
@@ -66,39 +66,39 @@ public class FlagRepositoryTest extends DesignerTestCase {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_getFlagImage_noSuchLocale() throws Exception {
-		assertNull(FlagImagesRepository.getFlagImage(new Locale("noSuchLocale")));
+		assertNull(FlagImagesRepository.getFlagImage(Locale.of("noSuchLocale")));
 	}
 
 	@Test
 	public void test_getFlagImage_ru() throws Exception {
-		Image ruImage = FlagImagesRepository.getFlagImage(new Locale("ru"));
+		Image ruImage = FlagImagesRepository.getFlagImage(Locale.of("ru"));
 		assertNotNull(ruImage);
-		assertSame(FlagImagesRepository.getFlagImage(new Locale("ru", "RU")), ruImage);
+		assertSame(FlagImagesRepository.getFlagImage(Locale.of("ru", "RU")), ruImage);
 	}
 
 	@Test
 	public void test_getFlagImage_en() throws Exception {
 		assertSame(
-				FlagImagesRepository.getFlagImage(new Locale("en", "US")),
-				FlagImagesRepository.getFlagImage(new Locale("en")));
+				FlagImagesRepository.getFlagImage(Locale.of("en", "US")),
+				FlagImagesRepository.getFlagImage(Locale.of("en")));
 	}
 
 	@Test
 	public void test_getFlagImage_zh() throws Exception {
 		assertSame(
-				FlagImagesRepository.getFlagImage(new Locale("zh", "CN")),
-				FlagImagesRepository.getFlagImage(new Locale("zh")));
+				FlagImagesRepository.getFlagImage(Locale.of("zh", "CN")),
+				FlagImagesRepository.getFlagImage(Locale.of("zh")));
 	}
 
 	@Test
 	public void test_getFlagImage_ar() throws Exception {
 		assertSame(
-				FlagImagesRepository.getFlagImage(new Locale("ar", "AE")),
-				FlagImagesRepository.getFlagImage(new Locale("ar")));
+				FlagImagesRepository.getFlagImage(Locale.of("ar", "AE")),
+				FlagImagesRepository.getFlagImage(Locale.of("ar")));
 	}
 
 	@Test
 	public void test_getFlagImage_YU() throws Exception {
-		assertNotNull(FlagImagesRepository.getFlagImage(new Locale("se", "YU")));
+		assertNotNull(FlagImagesRepository.getFlagImage(Locale.of("se", "YU")));
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/LocaleUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/nls/ui/LocaleUtilsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -53,9 +53,9 @@ public class LocaleUtilsTest extends DesignerTestCase {
 	public void test_sortByTitle() throws Exception {
 		LocaleInfo locales[] =
 				new LocaleInfo[]{
-						new LocaleInfo(new Locale("en")),
-						new LocaleInfo(new Locale("ar")),
-						new LocaleInfo(new Locale("ru")),};
+						new LocaleInfo(Locale.of("en")),
+						new LocaleInfo(Locale.of("ar")),
+						new LocaleInfo(Locale.of("ru")),};
 		// initial check
 		assertEquals("en", locales[0].getTitle());
 		assertEquals("ar", locales[1].getTitle());


### PR DESCRIPTION
The "new Locale(...)" constructor has been deprecated with Java 20 and replaced by the static "Locale.of(...)" factory. Given that WindowBuilder already requires Java 21, there is no benefit to keep using the constructor.