### PR TITLE
Avoid usage of deprecated StringUtils.chomp(...) method

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/core/CodeUtils.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/core/CodeUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -200,7 +200,7 @@ public class CodeUtils {
 	 */
 	public static IType findPrimaryType(ICompilationUnit compilationUnit) {
 		String unitName = compilationUnit.getElementName();
-		String typeName = StringUtils.chomp(unitName, ".java");
+		String typeName = StringUtils.removeEnd(unitName, ".java");
 		IType primaryType = compilationUnit.getType(typeName);
 		if (primaryType.exists()) {
 			return primaryType;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/MatchingEditPartFactory.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/MatchingEditPartFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -140,7 +140,7 @@ public final class MatchingEditPartFactory implements IEditPartFactory {
 				// prepare name of component, strip model package and "Info" suffix
 				String componentName = modelClassName;
 				componentName = componentName.substring(modelPackage.length());
-				componentName = StringUtils.chomp(componentName, modelSuffix);
+				componentName = StringUtils.removeEnd(componentName, modelSuffix);
 				// create corresponding EditPart, use "EditPart" prefix
 				{
 					String partClassName = partPackage + componentName + "EditPart";

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/laf/LafUtils.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/laf/LafUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -91,7 +91,7 @@ public final class LafUtils {
 				// use the class name as name of LAF
 				String shortClassName = CodeUtils.getShortClass(className);
 				// strip trailing "LookAndFeel"
-				String lafName = StringUtils.chomp(shortClassName, "LookAndFeel");
+				String lafName = StringUtils.removeEnd(shortClassName, "LookAndFeel");
 				lafList.add(new UserDefinedLafInfo(StringUtils.isEmpty(lafName) ? shortClassName : lafName,
 						className,
 						jarFileName));


### PR DESCRIPTION
Use StringUtils.removeEnd(...) as drop-in replacement.