### PR TITLE
Mark CompositeClassLoader.getPackage(...) as deprecated

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/reflect/CompositeClassLoader.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/reflect/CompositeClassLoader.java
@@ -112,6 +112,7 @@ public class CompositeClassLoader extends ClassLoader {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
+	@Deprecated
 	protected Package getPackage(String name) {
 		try {
 			Method method_getPackage =


### PR DESCRIPTION
The ClassLoader.getPackage(..) method has been deprecated with Java 9. Overriding a deprecated method produces a warning, unless it is also marked as deprecated.