### PR TITLE
Improve access to JDT preference store

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/ui/PreferencesAdapter.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/ui/PreferencesAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -28,6 +28,7 @@ import org.eclipse.swt.widgets.Display;
  * @since 3.0
  * @coverage core.util.jdt.ui
  */
+@Deprecated
 public class PreferencesAdapter implements IPreferenceStore {
 	/**
 	 * Property change listener. Listens for events of type


### PR DESCRIPTION
This replaces the reflective access to the JDT UI preference store with a call to `PreferenceConstants.getPreferenceStore()`.

In addition, the PreferenceAdapter is marked as deprecated, to resolve the warnings produced by referencing the deprecated Eclipse Preferences. The class sadly can't be removed, because JDT Core doesn't have a public accessor for its preference store and because this deprecated class is required for the JavaTextTools.