### PR TITLE
Avoid usage of deprecated getType() method of IClassFile interface

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/core/CodeUtils.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/core/CodeUtils.java
@@ -24,7 +24,6 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IField;
@@ -32,6 +31,7 @@ import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IOrdinaryClassFile;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.ITypeHierarchy;
@@ -212,14 +212,14 @@ public class CodeUtils {
 	 * @return {@link IType} associated with given {@link IJavaElement}.
 	 */
 	public static IType getType(IJavaElement element) throws JavaModelException {
-		if (element instanceof IType) {
-			return (IType) element;
-		} else if (element instanceof IMember) {
-			return ((IMember) element).getDeclaringType();
-		} else if (element instanceof ICompilationUnit) {
-			return ((ICompilationUnit) element).findPrimaryType();
-		} else if (element instanceof IClassFile) {
-			return ((IClassFile) element).getType();
+		if (element instanceof IType type) {
+			return type;
+		} else if (element instanceof IMember member) {
+			return member.getDeclaringType();
+		} else if (element instanceof ICompilationUnit cu) {
+			return cu.findPrimaryType();
+		} else if (element instanceof IOrdinaryClassFile classFile) {
+			return classFile.getType();
 		}
 		return null;
 	}

--- a/org.eclipse.wb.rcp.databinding.emf/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp.databinding.emf/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.rcp.databinding.emf;singleton:=true
-Bundle-Version: 1.9.800.qualifier
+Bundle-Version: 1.9.900.qualifier
 Bundle-Activator: org.eclipse.wb.internal.rcp.databinding.emf.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui;bundle-version="[3.206.0,4.0.0)",

--- a/org.eclipse.wb.rcp.databinding.emf/src/org/eclipse/wb/internal/rcp/databinding/emf/model/bindables/PropertiesSupport.java
+++ b/org.eclipse.wb.rcp.databinding.emf/src/org/eclipse/wb/internal/rcp/databinding/emf/model/bindables/PropertiesSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -21,9 +21,9 @@ import org.eclipse.wb.internal.rcp.databinding.emf.preferences.IPreferenceConsta
 import org.eclipse.wb.internal.rcp.databinding.model.BindableInfo;
 import org.eclipse.wb.internal.rcp.databinding.model.beans.bindables.BeanSupport;
 
-import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IOrdinaryClassFile;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
@@ -312,7 +312,7 @@ public class PropertiesSupport {
 		IPackageFragment packageFragment = packageAnyType.getPackageFragment();
 		// collect all class names
 		{
-			for (IClassFile classFile : packageFragment.getClassFiles()) {
+			for (IOrdinaryClassFile classFile : packageFragment.getOrdinaryClassFiles()) {
 				IType type = classFile.getType();
 				if (type != null) {
 					allClasses.add(type.getFullyQualifiedName());
@@ -326,7 +326,7 @@ public class PropertiesSupport {
 			}
 		}
 		//
-		for (IClassFile classFile : packageFragment.getClassFiles()) {
+		for (IOrdinaryClassFile classFile : packageFragment.getOrdinaryClassFiles()) {
 			Map<String, ClassInfo> packageClasses = getPackageClassInfos(classFile.getType(), allClasses);
 			if (packageClasses != null) {
 				return new PackageInfo(packageFragment.getElementName(), packageClasses);


### PR DESCRIPTION
This method has been moved to the IOrdinaryClassFile interface. For all instances where we need to fetch the type, the IClassFile interface has been replaced with this new interface.