### PR TITLE
Disable "Basic UI" mode by default

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/errors/ExceptionComposite.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/errors/ExceptionComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -64,7 +64,7 @@ public abstract class ExceptionComposite extends Composite {
 		wbBasic = InstanceScope.INSTANCE.getNode(
 				IEditorPreferenceConstants.WB_BASIC_UI_PREFERENCE_NODE).getBoolean(
 						IEditorPreferenceConstants.WB_BASIC_UI,
-						true);
+						false);
 		// create GUI elements
 		GridLayoutFactory.create(this);
 		{

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/errors/WarningComposite.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/errors/WarningComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -57,7 +57,7 @@ public abstract class WarningComposite extends Composite {
 		wbBasic = InstanceScope.INSTANCE.getNode(
 				IEditorPreferenceConstants.WB_BASIC_UI_PREFERENCE_NODE).getBoolean(
 						IEditorPreferenceConstants.WB_BASIC_UI,
-						true);
+						false);
 		GridLayoutFactory.create(this);
 		{
 			Composite titleComposite = new Composite(this, SWT.NONE);


### PR DESCRIPTION
With https://github.com/eclipse-windowbuilder/windowbuilder/pull/156, a new mode was added that supresses e.g. the buttons generated in the error dialog. This mode is activated via a preference, but can't be done within the UI. Meaning that those buttons are never visible to the user and thus make error reporting more difficult.

Given that this was added as a new functionality, the mode needs to be opt-in, rather than opt-out.