### PR TITLE
Fix: "Unlikely Argument: ControlInfo" warning in LayoutAssistant

### DIFF
--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/AnchorFiguresClassic.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/AnchorFiguresClassic.java
@@ -20,6 +20,7 @@ import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.graphical.policies.SelectionEditPolicy;
 import org.eclipse.wb.internal.core.gef.policy.snapping.PlacementUtils;
 import org.eclipse.wb.internal.swt.model.layout.form.FormLayoutInfoImplClassic;
+import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
 import org.eclipse.draw2d.IFigure;
@@ -41,7 +42,7 @@ import java.util.List;
  *
  * @author mitin_aa
  */
-public final class AnchorFiguresClassic<C extends IControlInfo> {
+public final class AnchorFiguresClassic<C extends ControlInfo> {
 	// fields
 	private List<IFigure> m_alignmentFigures;
 	private final SelectionEditPolicy m_policy;

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormLayoutEditPolicy.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormLayoutEditPolicy.java
@@ -31,6 +31,7 @@ import org.eclipse.wb.internal.core.utils.ui.TabFactory;
 import org.eclipse.wb.internal.swt.gef.policy.layout.AbsoluteBasedLayoutEditPolicySWT;
 import org.eclipse.wb.internal.swt.model.layout.form.IFormLayoutInfo;
 import org.eclipse.wb.internal.swt.model.layout.form.LayoutAssistantPage;
+import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
 import org.eclipse.draw2d.geometry.Dimension;
@@ -50,7 +51,7 @@ import java.util.List;
  * @author mitin_aa
  * @coverage swt.gef.policy.form
  */
-public final class FormLayoutEditPolicy<C extends IControlInfo>
+public final class FormLayoutEditPolicy<C extends ControlInfo>
 extends
 AbsoluteBasedLayoutEditPolicySWT<C> {
 	private final IFormLayoutInfo<C> layout;

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormLayoutEditPolicyClassic.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormLayoutEditPolicyClassic.java
@@ -46,6 +46,7 @@ import org.eclipse.wb.internal.swt.model.layout.form.FormLayoutInfoImplClassic;
 import org.eclipse.wb.internal.swt.model.layout.form.FormLayoutPreferences;
 import org.eclipse.wb.internal.swt.model.layout.form.IFormAttachmentInfo;
 import org.eclipse.wb.internal.swt.model.layout.form.IFormLayoutInfo;
+import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ICompositeInfo;
 import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
@@ -80,7 +81,7 @@ import java.util.Map;
  *
  * @author mitin_aa
  */
-public class FormLayoutEditPolicyClassic<C extends IControlInfo> extends KeyboardMovingLayoutEditPolicy
+public class FormLayoutEditPolicyClassic<C extends ControlInfo> extends KeyboardMovingLayoutEditPolicy
 implements IHeadersProvider {
 	private static final int EXTENSION = 8;
 	// model

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormSelectionEditPolicyClassic.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormSelectionEditPolicyClassic.java
@@ -40,6 +40,7 @@ import org.eclipse.wb.internal.swt.model.layout.form.FormLayoutInfoImplClassic;
 import org.eclipse.wb.internal.swt.model.layout.form.IFormAttachmentInfo;
 import org.eclipse.wb.internal.swt.model.layout.form.IFormDataInfo;
 import org.eclipse.wb.internal.swt.model.layout.form.IFormLayoutInfo;
+import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ICompositeInfo;
 import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
@@ -75,7 +76,7 @@ import java.util.Map;
  *
  * @author mitin_aa
  */
-public final class FormSelectionEditPolicyClassic<C extends IControlInfo>
+public final class FormSelectionEditPolicyClassic<C extends ControlInfo>
 extends
 SelectionEditPolicy {
 	private static final int EXTENSION = 8;

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormUtils.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,6 +16,7 @@ import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.swt.model.layout.form.FormLayoutInfoImplClassic;
 import org.eclipse.wb.internal.swt.model.layout.form.IFormLayoutInfo;
+import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
 import org.eclipse.draw2d.PositionConstants;
@@ -41,7 +42,7 @@ public final class FormUtils {
 	// Utils
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public static <C extends IControlInfo> List<C> getAttachableControls(IFormLayoutInfo<C> layout,
+	public static <C extends ControlInfo> List<C> getAttachableControls(IFormLayoutInfo<C> layout,
 			C firstControl,
 			boolean horizontal) throws Exception {
 		int side = horizontal ? PositionConstants.LEFT : PositionConstants.TOP;

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/FormLayoutInfoImplClassic.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/FormLayoutInfoImplClassic.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -26,7 +26,7 @@ import org.eclipse.wb.internal.core.utils.ui.TabFactory;
 import org.eclipse.wb.internal.swt.gef.policy.layout.form.FormUtils;
 import org.eclipse.wb.internal.swt.model.ModelMessages;
 import org.eclipse.wb.internal.swt.model.layout.form.actions.AnchorActionsClassic;
-import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
+import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -47,7 +47,7 @@ import java.util.Set;
  *
  * @author mitin_aa
  */
-public class FormLayoutInfoImplClassic<C extends IControlInfo> extends FormLayoutInfoImpl<C> {
+public class FormLayoutInfoImplClassic<C extends ControlInfo> extends FormLayoutInfoImpl<C> {
 	private final IFormLayoutInfo<C> layout;
 	private final AnchorActionsClassic<C> anchorActions;
 	private final AbstractAlignmentActionsSupport<C> alignmentActions;

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/LayoutAssistantPage.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/LayoutAssistantPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -23,7 +23,7 @@ import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
 import org.eclipse.wb.internal.swt.gef.policy.layout.form.FormLayoutEditPolicy;
 import org.eclipse.wb.internal.swt.model.ModelMessages;
-import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
+import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.jface.action.IAction;
@@ -44,7 +44,7 @@ import java.util.List;
  *
  * @author mitin_aa
  */
-public final class LayoutAssistantPage<C extends IControlInfo> extends Composite
+public final class LayoutAssistantPage<C extends ControlInfo> extends Composite
 implements
 ILayoutAssistantPage {
 	private final List<C> m_selection;

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/LayoutAssistantPageClassic.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/LayoutAssistantPageClassic.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -18,7 +18,7 @@ import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
 import org.eclipse.wb.internal.swt.model.ModelMessages;
 import org.eclipse.wb.internal.swt.model.layout.form.actions.PredefinedAnchorsActions;
-import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
+import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.IContributionItem;
@@ -37,7 +37,7 @@ import java.util.List;
  *
  * @author mitin_aa
  */
-public final class LayoutAssistantPageClassic<C extends IControlInfo> extends Composite
+public final class LayoutAssistantPageClassic<C extends ControlInfo> extends Composite
 implements
 ILayoutAssistantPage {
 	private final List<C> m_selection;

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/actions/AnchorActionsClassic.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/actions/AnchorActionsClassic.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -20,7 +20,7 @@ import org.eclipse.wb.internal.swt.model.ModelMessages;
 import org.eclipse.wb.internal.swt.model.layout.form.FormLayoutInfoImplClassic;
 import org.eclipse.wb.internal.swt.model.layout.form.FormLayoutUtils;
 import org.eclipse.wb.internal.swt.model.layout.form.IFormAttachmentInfo;
-import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
+import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.jface.action.IMenuManager;
@@ -32,7 +32,7 @@ import org.eclipse.jface.resource.ImageDescriptor;
  * @author mitin_aa
  * @coverage swt.model.layout.form
  */
-public class AnchorActionsClassic<C extends IControlInfo> {
+public class AnchorActionsClassic<C extends ControlInfo> {
 	private static final String IMAGE_PREFIX = "info/layout/FormLayoutClassic/";
 	private final FormLayoutInfoImplClassic<C> m_layoutImpl;
 

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/grid/actions/SelectionActionsSupport.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/grid/actions/SelectionActionsSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -19,7 +19,7 @@ import org.eclipse.wb.internal.core.model.util.ObjectInfoAction;
 import org.eclipse.wb.internal.swt.model.ModelMessages;
 import org.eclipse.wb.internal.swt.model.layout.grid.IGridDataInfo;
 import org.eclipse.wb.internal.swt.model.layout.grid.IGridLayoutInfo;
-import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
+import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 
 import org.eclipse.jface.action.Separator;
 import org.eclipse.jface.resource.ImageDescriptor;
@@ -34,7 +34,7 @@ import java.util.List;
  * @author lobas_av
  * @coverage swt.model.layout
  */
-public final class SelectionActionsSupport<C extends IControlInfo> extends ObjectEventListener {
+public final class SelectionActionsSupport<C extends ControlInfo> extends ObjectEventListener {
 	private final IGridLayoutInfo<C> m_layout;
 
 	////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This warning is produced because the selection is a list of ObjectInfos is compared with an IObjectInfo. To solve this warning, adapt the generic type of the implementing classes to work with the correct type.