### PR TITLE
Stabilize UndoManagerTest.test_expandRemembered_bug_0

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/UndoManagerTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/UndoManagerTest.java
@@ -310,7 +310,7 @@ public class UndoManagerTest extends SwingGefTest {
 		// organize imports
 		actionBars.getGlobalActionHandler(JdtActionConstants.ORGANIZE_IMPORTS).run();
 		// wait for "Organize Imports" job
-		waitEventLoop(50);
+		waitEventLoop(100);
 		assertEquals(
 				getSourceDQ(
 						"package test;",


### PR DESCRIPTION
Increase wait-loop from 50ms to 100ms because the "Organize Imports" may occasionally take longer than expected.