### PR TITLE
Move setting of LookAndFeel to AWT event thread

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/laf/model/LafInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/laf/model/LafInfo.java
@@ -18,10 +18,12 @@ import org.eclipse.wb.internal.core.utils.ast.DomGenerics;
 import org.eclipse.wb.internal.core.utils.ast.StatementTarget;
 import org.eclipse.wb.internal.swing.laf.LafSupport;
 
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 
 import javax.swing.LookAndFeel;
+import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 
 /**
@@ -109,6 +111,7 @@ public class LafInfo extends LafEntryInfo {
 	 * @return the instance of LAF class.
 	 */
 	public LookAndFeel getLookAndFeelInstance() throws Exception {
+		Assert.isTrue(SwingUtilities.isEventDispatchThread(), "Must be called from the AWT event dispatch thread");
 		LookAndFeel oldLookAndFeel = UIManager.getLookAndFeel();
 		try {
 			UIManager.setLookAndFeel(getClassName());


### PR DESCRIPTION
The LookAndFeel is no longer set in the SWT UI thread. More specifically, it is set before the Swing preview is created and afterwards restored.

All of those updates are done asynchronously, so this should greatly reduce the change of a deadlock due to both threads waiting for one another.