### PR TITLE
Deprecate support for Applet/JApplet API #383

### DIFF
--- a/org.eclipse.wb.doc.user/html-src/whatsnew/v122.asciidoc
+++ b/org.eclipse.wb.doc.user/html-src/whatsnew/v122.asciidoc
@@ -1,0 +1,17 @@
+ifdef::env-github[]
+:imagesdir: ../../html/whatsnew
+endif::[]
+
+= What's New - v1.22.0
+
+== Swing
+
+- Deprecated support for Applet/JApplet
+
+The Applet API has been deprecated for removal with Java 9 and formally been
+removed with Java 26. Support for those conainers will be removed after the
+2027-12 release.
+
+See https://bugs.openjdk.org/browse/JDK-8359053
+
+What's new - xref:v110.adoc[*v1.21.0*]

--- a/org.eclipse.wb.doc.user/toc.xml
+++ b/org.eclipse.wb.doc.user/toc.xml
@@ -2,7 +2,7 @@
 <?NLS TYPE="org.eclipse.help.toc"?>
 <toc label="WindowBuilder Pro User Guide" topic="html/index.html">
 	<topic label="Quick Start" href="html/quick_start.html" />
-	<topic label="What's New" href="html/whatsnew/v121.html" />
+	<topic label="What's New" href="html/whatsnew/v122.html" />
 	<topic label="Installation" href="html/installation/index.html">
 		<link toc="toc_installation.xml" />
 	</topic>

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/Activator.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/Activator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,6 +13,7 @@
 package org.eclipse.wb.internal.swing;
 
 import org.eclipse.wb.internal.core.BundleResourceProvider;
+import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
@@ -30,6 +31,10 @@ import java.io.InputStream;
  */
 public final class Activator extends AbstractUIPlugin {
 	public static final String PLUGIN_ID = "org.eclipse.wb.swing";
+	private static final Class<?> APPLET_CLASS = ExecutionUtils
+			.runObjectIgnore(() -> Activator.class.getClassLoader().loadClass("java.applet.Applet"), null);
+	private static final Class<?> JAPPLET_CLASS = ExecutionUtils
+			.runObjectIgnore(() -> Activator.class.getClassLoader().loadClass("javax.swing.JApplet"), null);
 	private static Activator m_plugin;
 
 	////////////////////////////////////////////////////////////////////////////
@@ -60,6 +65,28 @@ public final class Activator extends AbstractUIPlugin {
 	 */
 	public static Activator getDefault() {
 		return m_plugin;
+	}
+
+	/**
+	 * @return {@code true}, if {@code clazz} extends {@link java.applet.Applet
+	 *         Applet}.
+	 */
+	public static boolean isAssignableFromApplet(Class<?> clazz) {
+		if (APPLET_CLASS == null) {
+			return false;
+		}
+		return APPLET_CLASS.isAssignableFrom(clazz);
+	}
+
+	/**
+	 * @return {@code true}, if {@code clazz} extends {@link javax.swing.JApplet
+	 *         JApplet}.
+	 */
+	public static boolean isAssignableFromJApplet(Class<?> clazz) {
+		if (JAPPLET_CLASS == null) {
+			return false;
+		}
+		return JAPPLET_CLASS.isAssignableFrom(clazz);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/menu/MenuBarDropLayoutEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/menu/MenuBarDropLayoutEditPolicy.java
@@ -34,13 +34,12 @@ import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 
-import javax.swing.JApplet;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
 
 /**
  * {@link LayoutEditPolicy} allowing drop {@link JMenuBarInfo} on {@link JFrame}, {@link JDialog} or
- * {@link JApplet}.
+ * {@link javax.swing.JApplet JApplet}.
  *
  * @author scheglov_ke
  * @coverage swing.gef.policy

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/menu/MenuDropPolicyConfigurator.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/menu/MenuDropPolicyConfigurator.java
@@ -13,13 +13,13 @@
 package org.eclipse.wb.internal.swing.gef.policy.menu;
 
 import org.eclipse.wb.core.gef.IEditPartConfigurator;
+import org.eclipse.wb.internal.swing.Activator;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPolicy;
 
-import javax.swing.JApplet;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JInternalFrame;
@@ -30,7 +30,6 @@ import javax.swing.JInternalFrame;
  * @author scheglov_ke
  * @coverage swing.gef.policy
  */
-@SuppressWarnings("removal")
 public final class MenuDropPolicyConfigurator implements IEditPartConfigurator {
 	@Override
 	public void configure(EditPart context, org.eclipse.wb.gef.core.EditPart editPart) {
@@ -41,7 +40,7 @@ public final class MenuDropPolicyConfigurator implements IEditPartConfigurator {
 			if (JFrame.class.isAssignableFrom(componentClass)
 					|| JInternalFrame.class.isAssignableFrom(componentClass)
 					|| JDialog.class.isAssignableFrom(componentClass)
-					|| JApplet.class.isAssignableFrom(componentClass)) {
+					|| Activator.isAssignableFromJApplet(componentClass)) {
 				editPart.installEditPolicy(new MenuBarDropLayoutEditPolicy(container));
 			}
 		}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/ModelMessages.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/ModelMessages.java
@@ -24,6 +24,7 @@ public class ModelMessages extends NLS {
 	public static String ActionJavaInfoParticipator_none;
 	public static String ActionJavaInfoParticipator_setActionManager;
 	public static String ActionUseEntryInfo_description;
+	public static String AppletInfo_deprecated;
 	public static String BevelBorderComposite_bevelType;
 	public static String BevelBorderComposite_highlightInnerColor;
 	public static String BevelBorderComposite_highlightOuterColor;

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/ModelMessages.properties
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/ModelMessages.properties
@@ -18,6 +18,7 @@ ActionJavaInfoParticipator_new=New...
 ActionJavaInfoParticipator_none=None
 ActionJavaInfoParticipator_setActionManager=Set Action
 ActionUseEntryInfo_description=Allows to use already existing Action instance to drop it on one more AbstractButton or add it to JMenu, JToolBar.
+AppletInfo_deprecated=<Deprecated> {0}
 BevelBorderComposite_bevelType=&Bevel type:
 BevelBorderComposite_highlightInnerColor=&Highlight inner color:
 BevelBorderComposite_highlightOuterColor=&Highlight outer color:

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/AppletInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/AppletInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,20 +15,27 @@ package org.eclipse.wb.internal.swing.model.component;
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
 import org.eclipse.wb.internal.core.model.creation.CreationSupport;
 import org.eclipse.wb.internal.core.model.description.ComponentDescription;
+import org.eclipse.wb.internal.core.model.presentation.DefaultJavaInfoPresentation;
+import org.eclipse.wb.internal.core.model.presentation.IObjectPresentation;
 import org.eclipse.wb.internal.core.model.util.IJavaInfoRendering;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
+import org.eclipse.wb.internal.swing.model.ModelMessages;
 
-import java.applet.Applet;
-
-import javax.swing.JApplet;
+import org.eclipse.osgi.util.NLS;
 
 /**
- * Model for {@link Applet} and {@link JApplet}.
+ * Model for {@link java.applet.Applet Applet} and {@link javax.swing.JApplet
+ * JApplet}.
  *
  * @author scheglov_ke
  * @coverage swing.model
+ * @deprecated Applets have been removed with Java 26
+ *             (https://bugs.openjdk.org/browse/JDK-8359053) This class and
+ *             general support for applets will be removed after the 2027-12
+ *             release.
  */
+@Deprecated(since = "2025-12", forRemoval = true)
 public final class AppletInfo extends ContainerInfo implements IJavaInfoRendering {
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -51,5 +58,22 @@ public final class AppletInfo extends ContainerInfo implements IJavaInfoRenderin
 	public void render() throws Exception {
 		Object applet = getObject();
 		ReflectionUtils.invokeMethod(applet, "init()");
+	}
+
+	////////////////////////////////////////////////////////////////////////////
+	//
+	// Presentation
+	//
+	////////////////////////////////////////////////////////////////////////////
+	private final IObjectPresentation presentation = new DefaultJavaInfoPresentation(this) {
+		@Override
+		public String getText() throws Exception {
+			return NLS.bind(ModelMessages.AppletInfo_deprecated, super.getText());
+		}
+	};
+
+	@Override
+	public IObjectPresentation getPresentation() {
+		return presentation;
 	}
 }

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/menu/JMenuBarInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/menu/JMenuBarInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -36,7 +36,6 @@ import java.awt.Component;
 import java.awt.Container;
 import java.util.List;
 
-import javax.swing.JApplet;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JMenu;
@@ -124,8 +123,8 @@ public final class JMenuBarInfo extends ContainerInfo implements IAdaptable {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * Adds this {@link JMenuBarInfo} to given {@link ContainerInfo}, such as {@link JFrame},
-	 * {@link JDialog} and {@link JApplet}.
+	 * Adds this {@link JMenuBarInfo} to given {@link ContainerInfo}, such as
+	 * {@link JFrame}, {@link JDialog} and {@link javax.swing.JApplet JApplet}.
 	 */
 	public void command_CREATE(ContainerInfo container) throws Exception {
 		AssociationObject association =

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingScreenshotMaker.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingScreenshotMaker.java
@@ -16,6 +16,7 @@ import org.eclipse.wb.core.model.AbstractComponentInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.EnvironmentUtils;
 import org.eclipse.wb.internal.core.model.ObjectInfoVisitor;
+import org.eclipse.wb.internal.swing.Activator;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -23,7 +24,6 @@ import org.eclipse.swt.graphics.Image;
 
 import org.apache.commons.lang3.StringUtils;
 
-import java.applet.Applet;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Container;
@@ -162,7 +162,7 @@ public final class SwingScreenshotMaker {
 			Point componentLocation;
 			{
 				Point p_component;
-				if (m_component instanceof Applet) {
+				if (Activator.isAssignableFromApplet(m_component.getClass())) {
 					// Applet reports "screen location" as (0,0), but we want location on "window"
 					p_component = SwingUtils.getScreenLocation(m_component.getParent());
 				} else {

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/wizards/applet/NewJAppletWizard.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/wizards/applet/NewJAppletWizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -18,10 +18,8 @@ import org.eclipse.wb.internal.swing.wizards.SwingWizard;
 
 import org.eclipse.jface.wizard.Wizard;
 
-import javax.swing.JApplet;
-
 /**
- * {@link Wizard} that creates new Swing {@link JApplet}.
+ * {@link Wizard} that creates new Swing {@link javax.swing.JApplet JApplet}.
  *
  * @author lobas_av
  * @coverage swing.wizards.ui

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/wizards/applet/NewJAppletWizardPage.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/wizards/applet/NewJAppletWizardPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -24,10 +24,9 @@ import org.eclipse.jface.wizard.WizardPage;
 
 import java.io.InputStream;
 
-import javax.swing.JApplet;
-
 /**
- * {@link WizardPage} that creates new Swing {@link JApplet}.
+ * {@link WizardPage} that creates new Swing {@link javax.swing.JApplet
+ * JApplet}.
  *
  * @author lobas_av
  * @coverage swing.wizards.ui

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/AppletTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/AppletTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -23,13 +23,11 @@ import org.eclipse.swt.graphics.RGB;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.applet.Applet;
-
-import javax.swing.JApplet;
 import javax.swing.JFrame;
 
 /**
- * Test for {@link Applet} and {@link JApplet}.
+ * Test for {@link java.applet.Applet Applet} and {@link javax.swing.JApplet
+ * JApplet}.
  *
  * @author scheglov_ke
  */
@@ -49,8 +47,9 @@ public class AppletTest extends SwingModelTest {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * Java thinks that {@link Applet} is root of hierarchy, but we wrap it in {@link JFrame}. So, we
-	 * test that we handle {@link Applet} correctly.
+	 * Java thinks that {@link java.applet.Applet Applet} is root of hierarchy, but
+	 * we wrap it in {@link JFrame}. So, we test that we handle
+	 * {@link java.applet.Applet Applet} correctly.
 	 */
 	@Test
 	public void test_Applet_bounds() throws Exception {
@@ -77,8 +76,9 @@ public class AppletTest extends SwingModelTest {
 	}
 
 	/**
-	 * Java thinks that {@link JApplet} is root of hierarchy, but we wrap it in {@link JFrame}. So, we
-	 * test that we handle {@link JApplet} correctly.
+	 * Java thinks that {@link javax.swing.JApplet JApplet} is root of hierarchy,
+	 * but we wrap it in {@link JFrame}. So, we test that we handle
+	 * {@link javax.swing.JApplet JApplet} correctly.
 	 */
 	@Test
 	public void test_JApplet_bounds() throws Exception {
@@ -104,8 +104,8 @@ public class AppletTest extends SwingModelTest {
 	}
 
 	/**
-	 * {@link JApplet#getParent()} returns <code>null</code>, but we should not fail, and it is not
-	 * included into hierarchy.
+	 * {@link javax.swing.JApplet#getParent()} returns <code>null</code>, but we
+	 * should not fail, and it is not included into hierarchy.
 	 */
 	@Test
 	public void test_JApplet_getParent() throws Exception {
@@ -132,8 +132,9 @@ public class AppletTest extends SwingModelTest {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * Java thinks that {@link Applet} is root of hierarchy, but we wrap it in {@link JFrame}. So, we
-	 * test that we get correct screen shot of {@link Applet}.
+	 * Java thinks that {@link java.applet.Applet Applet} is root of hierarchy, but
+	 * we wrap it in {@link JFrame}. So, we test that we get correct screen shot of
+	 * {@link java.applet.Applet Applet}.
 	 */
 	@Test
 	public void test_Applet_screenShot() throws Exception {
@@ -151,8 +152,9 @@ public class AppletTest extends SwingModelTest {
 	}
 
 	/**
-	 * Java thinks that {@link JApplet} is root of hierarchy, but we wrap it in {@link JFrame}. So, we
-	 * test that we get correct screen shot of {@link JApplet}.
+	 * Java thinks that {@link javax.swing.JApplet JApplet} is root of hierarchy,
+	 * but we wrap it in {@link JFrame}. So, we test that we get correct screen shot
+	 * of {@link javax.swing.JApplet JApplet}.
 	 */
 	@Test
 	public void test_JApplet_screenShot() throws Exception {


### PR DESCRIPTION
This formally deprecates the support for java.applet.Applet and javax.swing.JApplet in WindowBuilder. When such a container is used, a "Deprecated" label will be shown in the components tree, in addition to the deprecation warnings already generated by JDT.

All internal references (excluding the embedded previews) and imports have been removed and where necessary replaced by their fully qualified names.

In places where we check whether a container is an instance of such an Applet, the class is dynamically loaded. If the class can't be found, those check silently fail, rather than causing runtime errors.

Closes https://github.com/eclipse-windowbuilder/windowbuilder/issues/383