### PR TITLE
Add default message if no LAS is selected

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/preferences/Messages.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/preferences/Messages.java
@@ -42,6 +42,7 @@ public class Messages extends NLS {
 	public static String LafPreferencePage_editCategoryMessage;
 	public static String LafPreferencePage_editCategoryTitle;
 	public static String LafPreferencePage_expandAllButton;
+	public static String LafPreferencePage_noSelection;
 	public static String LafPreferencePage_preview;
 	public static String LafPreferencePage_previewButton;
 	public static String LafPreferencePage_previewCheck;

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/preferences/laf/LafPreferencePage.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/preferences/laf/LafPreferencePage.java
@@ -50,6 +50,7 @@ import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.ViewerDropAdapter;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.CLabel;
 import org.eclipse.swt.dnd.ByteArrayTransfer;
 import org.eclipse.swt.dnd.DND;
 import org.eclipse.swt.dnd.DragSourceAdapter;
@@ -92,6 +93,7 @@ import swingintegration.example.EmbeddedSwingComposite;
  */
 public class LafPreferencePage extends PreferencePage implements IWorkbenchPreferencePage, IPreferenceConstants {
 	// constants
+	private static final int DEFAULT_PREVIEW_MARGIN = 50;
 	private static final Image CATEGORY_IMAGE = CoreImages.getSharedImage(CoreImages.FOLDER_OPEN);
 	private static final Image LAF_ITEM_IMAGE = Activator.getImage("info/laf/laf.png");
 	// variables
@@ -163,6 +165,7 @@ public class LafPreferencePage extends PreferencePage implements IWorkbenchPrefe
 			GridDataFactory.create(m_previewGroup).grabH().fill();
 			m_previewGroup.setText(Messages.LafPreferencePage_preview);
 			m_previewGroup.setLayout(new FillLayout());
+			updatePreview0();
 		}
 		// return back LAF
 		container.addDisposeListener(e -> {
@@ -548,7 +551,10 @@ public class LafPreferencePage extends PreferencePage implements IWorkbenchPrefe
 					}
 					LafInfo selectedLAF = getSelectedLAF();
 					if (selectedLAF == null) {
-						// nothing selected
+						CLabel nothingSelected = new CLabel(m_previewGroup, SWT.CENTER);
+						nothingSelected.setText(Messages.LafPreferencePage_noSelection);
+						nothingSelected.setMargins(0, DEFAULT_PREVIEW_MARGIN, 0, DEFAULT_PREVIEW_MARGIN);
+						m_previewGroup.requestLayout();
 						return;
 					}
 					m_previewGroup.getParent().layout(true);

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/preferences/messages.properties
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/preferences/messages.properties
@@ -36,6 +36,7 @@ LafPreferencePage_editButton=Edit...
 LafPreferencePage_editCategoryMessage=Enter new category name:
 LafPreferencePage_editCategoryTitle=Category
 LafPreferencePage_expandAllButton=Expand All
+LafPreferencePage_noSelection=Select LookAndFeel for preview
 LafPreferencePage_preview=Preview:
 LafPreferencePage_previewButton=Push Button
 LafPreferencePage_previewCheck=CheckBox


### PR DESCRIPTION
When no preview is selected, an empty group is shown. In such a case, a label should be created, telling the user to select a LaF.