### PR TITLE
Encapsulate the Swing LookAndFeel using an ObservableValue

### DIFF
--- a/org.eclipse.wb.swing/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing/META-INF/MANIFEST.MF
@@ -88,6 +88,7 @@ Import-Package: org.apache.commons.collections4;version="[4.4.0,5.0.0)",
  org.apache.commons.lang3.exception;version="[3.14.0,4.0.0)",
  org.apache.commons.lang3.time;version="[3.14.0,4.0.0)"
 Require-Bundle: org.eclipse.ui;bundle-version="[3.206.0,4.0.0)",
+ org.eclipse.core.databinding.observable;bundle-version="[1.13.300,2.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.31.100,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.20.200,4.0.0)",
  org.eclipse.wb.core;bundle-version="[1.21.0,2.0.0)";visibility:=reexport,

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/laf/LafSupport.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/laf/LafSupport.java
@@ -79,7 +79,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-import javax.swing.LookAndFeel;
 import javax.swing.UIManager;
 import javax.swing.UIManager.LookAndFeelInfo;
 import javax.xml.parsers.SAXParser;
@@ -333,7 +332,7 @@ public final class LafSupport {
 			SwingUtils.runLaterAndWait(new RunnableEx() {
 				@Override
 				public void run() throws Exception {
-					LookAndFeel lookAndFeelInstance = lafInfo.getLookAndFeelInstance();
+					javax.swing.LookAndFeel lookAndFeelInstance = lafInfo.getLookAndFeelInstance().getValue();
 					UIManager.setLookAndFeel(lookAndFeelInstance);
 				}
 			});
@@ -477,8 +476,7 @@ public final class LafSupport {
 					AstEvaluationEngine.evaluate(context, DomGenerics.arguments(setLookAndFeelMethod).get(0));
 			// it can be String or LookAndFeel only
 			if (SET_LOOK_AND_FEEL_LAF.equals(methodSignature)) {
-				LookAndFeel laf = (LookAndFeel) evaluateObject;
-				className = laf.getClass().getName();
+				className = evaluateObject.getClass().getName();
 			} else {
 				className = (String) evaluateObject;
 			}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/laf/model/LafInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/laf/model/LafInfo.java
@@ -18,16 +18,11 @@ import org.eclipse.wb.internal.core.utils.ast.DomGenerics;
 import org.eclipse.wb.internal.core.utils.ast.StatementTarget;
 import org.eclipse.wb.internal.swing.laf.LafSupport;
 
-import org.eclipse.core.runtime.Assert;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 
-import javax.swing.LookAndFeel;
-import javax.swing.SwingUtilities;
-import javax.swing.UIManager;
-
 /**
- * Base class for {@link LookAndFeel} info.
+ * Base class for {@link javax.swing.LookAndFeel LookAndFeel} info.
  *
  * @author mitin_aa
  * @coverage swing.laf.models
@@ -110,14 +105,13 @@ public class LafInfo extends LafEntryInfo {
 	 *
 	 * @return the instance of LAF class.
 	 */
-	public LookAndFeel getLookAndFeelInstance() throws Exception {
-		Assert.isTrue(SwingUtilities.isEventDispatchThread(), "Must be called from the AWT event dispatch thread");
-		LookAndFeel oldLookAndFeel = UIManager.getLookAndFeel();
+	public LafValue getLookAndFeelInstance() throws Exception {
+		javax.swing.LookAndFeel oldLookAndFeel = javax.swing.UIManager.getLookAndFeel();
 		try {
-			UIManager.setLookAndFeel(getClassName());
-			return UIManager.getLookAndFeel();
+			javax.swing.UIManager.setLookAndFeel(getClassName());
+			return new LafValue(javax.swing.UIManager.getLookAndFeel());
 		} finally {
-			UIManager.setLookAndFeel(oldLookAndFeel);
+			javax.swing.UIManager.setLookAndFeel(oldLookAndFeel);
 		}
 	}
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/laf/model/LafValue.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/laf/model/LafValue.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.internal.swing.laf.model;
+
+import org.eclipse.wb.internal.swing.model.SwingRealm;
+
+import org.eclipse.core.databinding.observable.value.WritableValue;
+import org.eclipse.core.runtime.Assert;
+
+import javax.swing.LookAndFeel;
+import javax.swing.SwingUtilities;
+
+/**
+ * Wrapper for a {@link LookAndFeel}. Accessing the value of this object must be
+ * done from the AWT event dispatcher thread.
+ */
+public class LafValue extends WritableValue<LookAndFeel> {
+
+	/**
+	 * Constructs a new instance with the Swing realm and a {@code null} value.
+	 */
+	public LafValue() {
+		this(null);
+	}
+
+	/**
+	 * Constructs a new instance with the Swing realm and the given value.
+	 *
+	 * @param laf May be {@code null}.
+	 */
+	public LafValue(LookAndFeel laf) {
+		super(SwingRealm.getRealm(), laf, LookAndFeel.class);
+		Assert.isTrue(SwingUtilities.isEventDispatchThread(), "Must be created from AWT event dispatcher thread");
+	}
+}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/laf/model/PluginLafInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/laf/model/PluginLafInfo.java
@@ -26,8 +26,6 @@ import org.osgi.framework.Bundle;
 import java.lang.ref.Reference;
 import java.lang.ref.SoftReference;
 
-import javax.swing.LookAndFeel;
-
 /**
  * Class representing look-n-feel loaded from using Eclipse plugin API.
  *
@@ -68,16 +66,21 @@ public class PluginLafInfo extends AbstractCustomLafInfo {
 	// Instance
 	//
 	////////////////////////////////////////////////////////////////////////////
-	private Reference<LookAndFeel> m_instanceReference;
+	private Reference<javax.swing.LookAndFeel> m_instanceReference;
 
 	@Override
-	public LookAndFeel getLookAndFeelInstance() throws Exception {
-		if (m_instanceReference == null || m_instanceReference.get() == null) {
+	public LafValue getLookAndFeelInstance() throws Exception {
+		javax.swing.LookAndFeel laf = null;
+		if (m_instanceReference != null) {
+			laf = m_instanceReference.get();
+		}
+		if (laf == null) {
 			m_initializer.initialize();
 			Class<?> lafClass = m_extensionBundle.loadClass(getClassName());
-			m_instanceReference = new SoftReference<>((LookAndFeel) lafClass.getDeclaredConstructor().newInstance());
+			laf = (javax.swing.LookAndFeel) lafClass.getDeclaredConstructor().newInstance();
+			m_instanceReference = new SoftReference<>(laf);
 		}
-		return m_instanceReference.get();
+		return new LafValue(laf);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/laf/model/SeparatorLafInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/laf/model/SeparatorLafInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,8 +13,6 @@
 package org.eclipse.wb.internal.swing.laf.model;
 
 import org.eclipse.wb.internal.swing.model.ModelMessages;
-
-import javax.swing.LookAndFeel;
 
 /**
  * Used just to indicate separator in list of LAFs.
@@ -42,7 +40,7 @@ public class SeparatorLafInfo extends LafInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public LookAndFeel getLookAndFeelInstance() throws Exception {
+	public LafValue getLookAndFeelInstance() throws Exception {
 		throw new RuntimeException(ModelMessages.SeparatorLafInfo_canNotInstantiate);
 	}
 }

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/laf/model/UserDefinedLafInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/laf/model/UserDefinedLafInfo.java
@@ -16,8 +16,6 @@ import java.io.File;
 import java.net.URL;
 import java.net.URLClassLoader;
 
-import javax.swing.LookAndFeel;
-
 /**
  * Class representing user-defined Look-n-Feel.
  *
@@ -46,12 +44,12 @@ public class UserDefinedLafInfo extends AbstractCustomLafInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public LookAndFeel getLookAndFeelInstance() throws Exception {
+	public LafValue getLookAndFeelInstance() throws Exception {
 		if (m_lafClass == null) {
 			ClassLoader classLoader = getClassLoader();
 			m_lafClass = classLoader.loadClass(getClassName());
 		}
-		return (LookAndFeel) m_lafClass.getDeclaredConstructor().newInstance();
+		return new LafValue((javax.swing.LookAndFeel) m_lafClass.getDeclaredConstructor().newInstance());
 	}
 
 	private ClassLoader getClassLoader() throws Exception {

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/SwingRealm.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/SwingRealm.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.internal.swing.model;
+
+import org.eclipse.core.databinding.observable.Realm;
+
+import javax.swing.SwingUtilities;
+
+/**
+ * This class is used to get a {@link Realm} for the Swing event dispatcher
+ * thread.
+ */
+public final class SwingRealm extends Realm {
+	private static final Realm INSTANCE = new SwingRealm();
+	private SwingRealm() {
+		// Singleton
+	}
+
+	/**
+	 * Returns the shared realm representing the Swing UI thread.
+	 *
+	 * @return the realm representing the Swing UI thread.
+	 */
+	public static Realm getRealm() {
+		return INSTANCE;
+	}
+
+	@Override
+	public boolean isCurrent() {
+		return SwingUtilities.isEventDispatchThread();
+	}
+}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/preferences/laf/LafCanvas.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/preferences/laf/LafCanvas.java
@@ -59,7 +59,7 @@ public final class LafCanvas extends EmbeddedSwingComposite {
 	 */
 	private void setLookAndFeel() throws Exception {
 		oldLookAndFeel = UIManager.getLookAndFeel();
-		LookAndFeel lookAndFeelInstance = selection.getLookAndFeelInstance();
+		LookAndFeel lookAndFeelInstance = selection.getLookAndFeelInstance().getValue();
 		UIManager.setLookAndFeel(lookAndFeelInstance);
 	}
 


### PR DESCRIPTION
Access to the Swing objects must be done from the AWT event dispatcher thread (aka the Swing UI thread). Rather than explicitly checking whether any method is called from this thread via e.g. the EventQueue, we can take advantage of the "Realm" concept provided by the Eclipse.

The LookAndFeel is stored within an ObservableValue. The realm of this value is the Swing UI thread. Modifying this value from any other thread is guaranteed to throw an exception.