### PR TITLE
Remove checked exception from Border accessors

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/BooleanField.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/BooleanField.java
@@ -75,7 +75,7 @@ public final class BooleanField extends AbstractBorderField {
 	/**
 	 * Sets the value, that should correspond to the one of the field values.
 	 */
-	public void setValue(Object value) throws Exception {
+	public void setValue(Object value) {
 		if (Objects.equals(Boolean.FALSE, value)) {
 			m_source = "false";
 			m_buttons[0].setSelection(true);

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/ColorField.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/ColorField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -95,7 +95,7 @@ public final class ColorField extends AbstractBorderField {
 	/**
 	 * Sets the value, that should correspond to the one of the field values.
 	 */
-	public void setValue(Color color) throws Exception {
+	public void setValue(Color color) {
 		if (color != null) {
 			m_colorInfo = new ColorInfo(color.getRed(), color.getGreen(), color.getBlue());
 		} else {

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/IntegerField.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/IntegerField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -59,7 +59,7 @@ public final class IntegerField extends AbstractBorderField {
 	/**
 	 * Sets the value, that should correspond to the one of the field values.
 	 */
-	public void setValue(int value) throws Exception {
+	public void setValue(int value) {
 		m_spinner.setSelection(value);
 	}
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/TextField.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/TextField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -59,7 +59,7 @@ public final class TextField extends AbstractBorderField {
 	/**
 	 * Sets the value to edit.
 	 */
-	public void setValue(String value) throws Exception {
+	public void setValue(String value) {
 		m_text.removeListener(SWT.Modify, m_modifyListener);
 		try {
 			m_text.setText(value);


### PR DESCRIPTION
The setValue() of the BooleanField, ColorField, IntegerField and TextField don't throw a checked exception, so there is no purpose for the signature to contain "throws Exception".