### PR TITLE
Don't traverse lambda expressions unless necessary

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/eval/ExecutionFlowProvider.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/eval/ExecutionFlowProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,8 +12,15 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.eval;
 
+import org.eclipse.wb.internal.core.utils.ast.AstNodeUtils;
+
+import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
+import org.eclipse.jdt.core.dom.ClassInstanceCreation;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.LambdaExpression;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 
 import java.awt.EventQueue;
@@ -36,7 +43,34 @@ public class ExecutionFlowProvider {
 		return null;
 	}
 
-	public boolean shouldVisit(AnonymousClassDeclaration anonymous) throws Exception {
+	public boolean shouldVisit(ASTNode node) {
 		return false;
+	}
+
+	protected MethodInvocation getMethodInvocation(ASTNode node) {
+		return switch (node) {
+		case AnonymousClassDeclaration declaration -> {
+			ClassInstanceCreation creation = (ClassInstanceCreation) declaration.getParent();
+			if (creation.getLocationInParent() == MethodInvocation.ARGUMENTS_PROPERTY) {
+				yield (MethodInvocation) creation.getParent();
+			}
+			yield null;
+		}
+		case LambdaExpression expression -> {
+			if (expression.getLocationInParent() == MethodInvocation.ARGUMENTS_PROPERTY) {
+				yield (MethodInvocation) expression.getParent();
+			}
+			yield null;
+		}
+		default -> null;
+		};
+	}
+
+	protected ITypeBinding getTypeBinding(ASTNode node) {
+		return switch (node) {
+		case AnonymousClassDeclaration declaration -> AstNodeUtils.getTypeBinding(declaration);
+		case LambdaExpression expression -> AstNodeUtils.getTypeBinding(expression);
+		default -> null;
+		};
 	}
 }

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/parser/RcpExecutionFlowProvider.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/parser/RcpExecutionFlowProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,8 +15,7 @@ package org.eclipse.wb.internal.rcp.parser;
 import org.eclipse.wb.internal.core.eval.ExecutionFlowProvider;
 import org.eclipse.wb.internal.core.utils.ast.AstNodeUtils;
 
-import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
-import org.eclipse.jdt.core.dom.ClassInstanceCreation;
+import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
@@ -75,12 +74,10 @@ public class RcpExecutionFlowProvider extends ExecutionFlowProvider {
 	}
 
 	@Override
-	public boolean shouldVisit(AnonymousClassDeclaration anonymous) throws Exception {
-		// Realm.runWithDefault()
-		if (AstNodeUtils.isSuccessorOf(anonymous, "java.lang.Runnable")) {
-			ClassInstanceCreation creation = (ClassInstanceCreation) anonymous.getParent();
-			if (creation.getLocationInParent() == MethodInvocation.ARGUMENTS_PROPERTY) {
-				MethodInvocation invocation = (MethodInvocation) creation.getParent();
+	public boolean shouldVisit(ASTNode node) {
+		if (AstNodeUtils.isSuccessorOf(getTypeBinding(node), "java.lang.Runnable")) {
+			MethodInvocation invocation = getMethodInvocation(node);
+			if (invocation != null) {
 				return AstNodeUtils.isMethodInvocation(
 						invocation,
 						"org.eclipse.core.databinding.observable.Realm",
@@ -88,6 +85,6 @@ public class RcpExecutionFlowProvider extends ExecutionFlowProvider {
 			}
 		}
 		// unknown pattern
-		return false;
+		return super.shouldVisit(node);
 	}
 }

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/parser/SwingExecutionFlowProvider.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/parser/SwingExecutionFlowProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,8 +15,7 @@ package org.eclipse.wb.internal.swing.parser;
 import org.eclipse.wb.internal.core.eval.ExecutionFlowProvider;
 import org.eclipse.wb.internal.core.utils.ast.AstNodeUtils;
 
-import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
-import org.eclipse.jdt.core.dom.ClassInstanceCreation;
+import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
@@ -45,11 +44,10 @@ public class SwingExecutionFlowProvider extends ExecutionFlowProvider {
 	}
 
 	@Override
-	public boolean shouldVisit(AnonymousClassDeclaration anonymous) throws Exception {
-		if (AstNodeUtils.isSuccessorOf(anonymous.resolveBinding(), "java.lang.Runnable")) {
-			ClassInstanceCreation creation = (ClassInstanceCreation) anonymous.getParent();
-			if (creation.getLocationInParent() == MethodInvocation.ARGUMENTS_PROPERTY) {
-				MethodInvocation invocation = (MethodInvocation) creation.getParent();
+	public boolean shouldVisit(ASTNode node) {
+		if (AstNodeUtils.isSuccessorOf(getTypeBinding(node), "java.lang.Runnable")) {
+			MethodInvocation invocation = getMethodInvocation(node);
+			if (invocation != null) {
 				return AstNodeUtils.isMethodInvocation(
 						invocation,
 						"java.awt.EventQueue",
@@ -68,6 +66,6 @@ public class SwingExecutionFlowProvider extends ExecutionFlowProvider {
 								"invokeAndWait(java.lang.Runnable)");
 			}
 		}
-		return super.shouldVisit(anonymous);
+		return super.shouldVisit(node);
 	}
 }

--- a/org.eclipse.wb.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.tests/META-INF/MANIFEST.MF
@@ -50,6 +50,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.31.100,4.0.0)",
  org.objenesis;bundle-version="[3.4.0,4.0.0)",
  net.bytebuddy.byte-buddy;bundle-version="[1.14.16,2.0.0)",
  junit-jupiter-api;bundle-version="[5.10.2,6.0.0)",
+ junit-jupiter-params;bundle-version="[5.10.2,6.0.0)",
  junit-platform-suite-api;bundle-version="[1.10.2,2.0.0)",
  org.opentest4j;bundle-version="[1.3.0,2.0.0)"
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
We already skip anonymous classes outside of a few exceptions (e.g. EventQueue.invokeLater(Runnable)). Given that Java allows the Runnable to be implemented as both an anonymous class and a lambda expression, WindowBuilder needs to be extended to support both variants.