### PR TITLE
ExecutionUtils.runLogLater() should return a CompletableFuture

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/execution/ExecutionUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/execution/ExecutionUtils.java
@@ -208,15 +208,13 @@ public class ExecutionUtils {
 
 	/**
 	 * Runs given {@link RunnableEx} as {@link #runLog(RunnableEx)}, but using
+	 * {@link CompletableFuture#runAsync(Runnable)} and
 	 * {@link Display#asyncExec(Runnable)}.
+	 * 
+	 * @return the new CompletableFuture
 	 */
-	public static void runLogLater(final RunnableEx runnable) {
-		Display.getDefault().asyncExec(new Runnable() {
-			@Override
-			public void run() {
-				ExecutionUtils.runLog(runnable);
-			}
-		});
+	public static CompletableFuture<Void> runLogLater(final RunnableEx runnable) {
+		return CompletableFuture.runAsync(() -> runLog(runnable), Display.getDefault()::asyncExec);
 	}
 
 	////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This method should return a CompletableFuture, rather than a void, so that additional tasks can easily be chained via the returned object.