### PR TITLE
The getSource() methods in the BorderDialog shouldn't throw exceptions

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/BooleanField.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/BooleanField.java
@@ -88,7 +88,7 @@ public final class BooleanField extends AbstractBorderField {
 	}
 
 	@Override
-	public String getSource() throws Exception {
+	public String getSource() {
 		return m_source;
 	}
 }

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/ColorField.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/ColorField.java
@@ -105,7 +105,7 @@ public final class ColorField extends AbstractBorderField {
 	}
 
 	@Override
-	public String getSource() throws Exception {
+	public String getSource() {
 		return m_colorInfo != null ? ColorPropertyEditor.external_getSource(m_colorInfo) : "null";
 	}
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/ComboField.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/ComboField.java
@@ -86,7 +86,7 @@ public final class ComboField extends AbstractBorderField {
 	}
 
 	@Override
-	public String getSource() throws Exception {
+	public String getSource() {
 		return m_source;
 	}
 }

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/IntegerField.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/IntegerField.java
@@ -64,7 +64,7 @@ public final class IntegerField extends AbstractBorderField {
 	}
 
 	@Override
-	public String getSource() throws Exception {
+	public String getSource() {
 		int value = m_spinner.getSelection();
 		return Integer.toString(value);
 	}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/RadioField.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/RadioField.java
@@ -87,7 +87,7 @@ public final class RadioField extends AbstractBorderField {
 	}
 
 	@Override
-	public String getSource() throws Exception {
+	public String getSource() {
 		return m_source;
 	}
 }

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/TextField.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/TextField.java
@@ -69,7 +69,7 @@ public final class TextField extends AbstractBorderField {
 	}
 
 	@Override
-	public String getSource() throws Exception {
+	public String getSource() {
 		return StringConverter.INSTANCE.toJavaSource(null, m_text.getText());
 	}
 }

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/BevelBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/BevelBorderComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -82,7 +82,7 @@ public final class BevelBorderComposite extends AbstractBorderComposite {
 	}
 
 	@Override
-	public String getSource() throws Exception {
+	public String getSource() {
 		String typeSource = m_typeField.getSource();
 		String highlightOuterSource = m_highlightOuterField.getSource();
 		String highlightInnerSource = m_highlightInnerField.getSource();

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/DefaultBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/DefaultBorderComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -46,7 +46,7 @@ public final class DefaultBorderComposite extends AbstractBorderComposite {
 	}
 
 	@Override
-	public String getSource() throws Exception {
+	public String getSource() {
 		return null;
 	}
 }

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/EmptyBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/EmptyBorderComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -76,7 +76,7 @@ public final class EmptyBorderComposite extends AbstractBorderComposite {
 	}
 
 	@Override
-	public String getSource() throws Exception {
+	public String getSource() {
 		return "new javax.swing.border.EmptyBorder("
 				+ m_topField.getSource()
 				+ ", "

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/EtchedBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/EtchedBorderComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -74,7 +74,7 @@ public final class EtchedBorderComposite extends AbstractBorderComposite {
 	}
 
 	@Override
-	public String getSource() throws Exception {
+	public String getSource() {
 		String typeSource = m_typeField.getSource();
 		String highlightSource = m_highlightField.getSource();
 		String shadowSource = m_shadowField.getSource();

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/LineBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/LineBorderComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -75,7 +75,7 @@ public final class LineBorderComposite extends AbstractBorderComposite {
 	}
 
 	@Override
-	public String getSource() throws Exception {
+	public String getSource() {
 		String colorSource = m_colorField.getSource();
 		String thinknessSource = m_thicknessField.getSource();
 		String cornersSource = m_typeField.getSource();

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/MatteBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/MatteBorderComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -81,7 +81,7 @@ public final class MatteBorderComposite extends AbstractBorderComposite {
 	}
 
 	@Override
-	public String getSource() throws Exception {
+	public String getSource() {
 		return "new javax.swing.border.MatteBorder("
 				+ m_topField.getSource()
 				+ ", "

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/NoBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/NoBorderComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -43,7 +43,7 @@ public final class NoBorderComposite extends AbstractBorderComposite {
 	}
 
 	@Override
-	public String getSource() throws Exception {
+	public String getSource() {
 		return "null";
 	}
 }

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/SoftBevelBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/SoftBevelBorderComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -83,7 +83,7 @@ public final class SoftBevelBorderComposite extends AbstractBorderComposite {
 	}
 
 	@Override
-	public String getSource() throws Exception {
+	public String getSource() {
 		String typeSource = m_typeField.getSource();
 		String highlightOuterSource = m_highlightOuterField.getSource();
 		String highlightInnerSource = m_highlightInnerField.getSource();

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/SwingBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/SwingBorderComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -101,7 +101,7 @@ public final class SwingBorderComposite extends AbstractBorderComposite {
 	}
 
 	@Override
-	public String getSource() throws Exception {
+	public String getSource() {
 		int index = m_bordersList.getSelectionIndex();
 		if (index != -1) {
 			String key = m_borderKeys.get(index);

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/TitledBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/TitledBorderComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at


### PR DESCRIPTION
The signature of the abstract base classes allows sub-classes to throw a generic exception. However, the implementations should only keep it in their signatures if they are able to fail.

Otherwise calling methods of those sub-classes need to be wrapped in try-catch blocks for no reason.