### PR TITLE
Move initialization of Border dialog fields to constructor

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/BevelBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/BevelBorderComposite.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.model.property.editor.border.pages;
 
+import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
 import org.eclipse.wb.internal.swing.model.ModelMessages;
 import org.eclipse.wb.internal.swing.model.property.editor.border.fields.ColorField;
@@ -57,6 +58,8 @@ public final class BevelBorderComposite extends AbstractBorderComposite {
 				createColorField(ModelMessages.BevelBorderComposite_highlightInnerColor);
 		m_shadowOuterField = createColorField(ModelMessages.BevelBorderComposite_shadowOuterColor);
 		m_shadowInnerField = createColorField(ModelMessages.BevelBorderComposite_shadowInnerColor);
+		// set defaults values
+		ExecutionUtils.runRethrow(() -> m_typeField.setValue(BevelBorder.LOWERED));
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -75,7 +78,6 @@ public final class BevelBorderComposite extends AbstractBorderComposite {
 			// OK, this is our Border
 			return true;
 		} else {
-			m_typeField.setValue(BevelBorder.LOWERED);
 			// no, we don't know this Border
 			return false;
 		}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/EmptyBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/EmptyBorderComposite.java
@@ -47,6 +47,11 @@ public final class EmptyBorderComposite extends AbstractBorderComposite {
 		m_leftField = createIntegerField(ModelMessages.EmptyBorderComposite_left);
 		m_bottomField = createIntegerField(ModelMessages.EmptyBorderComposite_bottom);
 		m_rightField = createIntegerField(ModelMessages.EmptyBorderComposite_right);
+		// set defaults values
+		m_topField.setValue(0);
+		m_leftField.setValue(0);
+		m_bottomField.setValue(0);
+		m_rightField.setValue(0);
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -66,10 +71,6 @@ public final class EmptyBorderComposite extends AbstractBorderComposite {
 			// OK, this is our Border
 			return true;
 		} else {
-			m_topField.setValue(0);
-			m_leftField.setValue(0);
-			m_bottomField.setValue(0);
-			m_rightField.setValue(0);
 			// no, we don't know this Border
 			return false;
 		}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/EtchedBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/EtchedBorderComposite.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.model.property.editor.border.pages;
 
+import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
 import org.eclipse.wb.internal.swing.model.ModelMessages;
 import org.eclipse.wb.internal.swing.model.property.editor.border.fields.ColorField;
@@ -51,6 +52,8 @@ public final class EtchedBorderComposite extends AbstractBorderComposite {
 								ModelMessages.EtchedBorderComposite_etchRaised});
 		m_highlightField = createColorField(ModelMessages.EtchedBorderComposite_highlightColor);
 		m_shadowField = createColorField(ModelMessages.EtchedBorderComposite_shadowColor);
+		// set defaults values
+		ExecutionUtils.runRethrow(() -> m_typeField.setValue(EtchedBorder.LOWERED));
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -67,7 +70,6 @@ public final class EtchedBorderComposite extends AbstractBorderComposite {
 			// OK, this is our Border
 			return true;
 		} else {
-			m_typeField.setValue(EtchedBorder.LOWERED);
 			// no, we don't know this Border
 			return false;
 		}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/LineBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/LineBorderComposite.java
@@ -50,6 +50,10 @@ public final class LineBorderComposite extends AbstractBorderComposite {
 				createBooleanField(ModelMessages.LineBorderComposite_corners, new String[]{
 						ModelMessages.LineBorderComposite_cornersSquare,
 						ModelMessages.LineBorderComposite_cornersRounded});
+		// set defaults values
+		m_colorField.setValue(Color.BLACK);
+		m_thicknessField.setValue(1);
+		m_typeField.setValue(false);
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -66,9 +70,6 @@ public final class LineBorderComposite extends AbstractBorderComposite {
 			// OK, this is our Border
 			return true;
 		} else {
-			m_colorField.setValue(Color.BLACK);
-			m_thicknessField.setValue(1);
-			m_typeField.setValue(false);
 			// no, we don't know this Border
 			return false;
 		}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/MatteBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/MatteBorderComposite.java
@@ -51,6 +51,12 @@ public final class MatteBorderComposite extends AbstractBorderComposite {
 		m_leftField = createIntegerField(ModelMessages.MatteBorderComposite_left);
 		m_bottomField = createIntegerField(ModelMessages.MatteBorderComposite_bottom);
 		m_rightField = createIntegerField(ModelMessages.MatteBorderComposite_right);
+		// set defaults values
+		m_colorField.setValue(Color.BLACK);
+		m_topField.setValue(1);
+		m_leftField.setValue(1);
+		m_bottomField.setValue(1);
+		m_rightField.setValue(1);
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -70,11 +76,6 @@ public final class MatteBorderComposite extends AbstractBorderComposite {
 			// OK, this is our Border
 			return true;
 		} else {
-			m_colorField.setValue(Color.BLACK);
-			m_topField.setValue(1);
-			m_leftField.setValue(1);
-			m_bottomField.setValue(1);
-			m_rightField.setValue(1);
 			// no, we don't know this Border
 			return false;
 		}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/SoftBevelBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/SoftBevelBorderComposite.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.model.property.editor.border.pages;
 
+import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
 import org.eclipse.wb.internal.swing.model.ModelMessages;
 import org.eclipse.wb.internal.swing.model.property.editor.border.fields.ColorField;
@@ -58,6 +59,8 @@ public final class SoftBevelBorderComposite extends AbstractBorderComposite {
 				createColorField(ModelMessages.SoftBevelBorderComposite_highlightInnerColor);
 		m_shadowOuterField = createColorField(ModelMessages.SoftBevelBorderComposite_shadowOuterColor);
 		m_shadowInnerField = createColorField(ModelMessages.SoftBevelBorderComposite_shadowInnerColor);
+		// set defaults values
+		ExecutionUtils.runRethrow(() -> m_typeField.setValue(BevelBorder.LOWERED));
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -76,7 +79,6 @@ public final class SoftBevelBorderComposite extends AbstractBorderComposite {
 			// OK, this is our Border
 			return true;
 		} else {
-			m_typeField.setValue(BevelBorder.LOWERED);
 			// no, we don't know this Border
 			return false;
 		}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/SwingBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/SwingBorderComposite.java
@@ -65,6 +65,8 @@ public final class SwingBorderComposite extends AbstractBorderComposite {
 				m_borderDialog.borderUpdated();
 			}
 		});
+		// set defaults values
+		m_bordersList.deselectAll();
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -96,7 +98,6 @@ public final class SwingBorderComposite extends AbstractBorderComposite {
 			}
 		}
 		// no, we don't know this Border
-		m_bordersList.deselectAll();
 		return false;
 	}
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/TitledBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/TitledBorderComposite.java
@@ -13,6 +13,7 @@
 package org.eclipse.wb.internal.swing.model.property.editor.border.pages;
 
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
+import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
 import org.eclipse.wb.internal.swing.model.ModelMessages;
@@ -81,6 +82,12 @@ public final class TitledBorderComposite extends AbstractBorderComposite {
 		GridDataFactory.create(m_titleField).fillH();
 		GridDataFactory.create(m_titleJustificationField).fillH();
 		GridDataFactory.create(m_titlePositionField).fillH();
+		// set defaults values
+		ExecutionUtils.runRethrow(() -> {
+			m_titleField.setValue("");
+			m_titleJustificationField.setValue(TitledBorder.LEADING);
+			m_titlePositionField.setValue(TitledBorder.TOP);
+		});
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -105,11 +112,6 @@ public final class TitledBorderComposite extends AbstractBorderComposite {
 			// OK, this is our Border
 			return true;
 		} else {
-			m_titleField.setValue("");
-			m_titleJustificationField.setValue(TitledBorder.LEADING);
-			m_titlePositionField.setValue(TitledBorder.TOP);
-			m_titleColorField.setValue(null);
-			m_borderField.setBorder(null);
 			// no, we don't know this Border
 			return false;
 		}


### PR DESCRIPTION
The fields for the Border composite pages that describe primitive types should be initialized in the constructor. Otherwise the code generation converts them to "null", leading to compilation errors.

This is currently avoid by iterating over all pages and calling setBorder(...), causing an unnecessary overhead.