### PR TITLE
Simplify calculation of compatible border composite in BorderField

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/BorderField.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/BorderField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,15 +16,6 @@ import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 import org.eclipse.wb.internal.swing.model.property.editor.border.BorderDialog;
 import org.eclipse.wb.internal.swing.model.property.editor.border.pages.AbstractBorderComposite;
-import org.eclipse.wb.internal.swing.model.property.editor.border.pages.BevelBorderComposite;
-import org.eclipse.wb.internal.swing.model.property.editor.border.pages.CompoundBorderComposite;
-import org.eclipse.wb.internal.swing.model.property.editor.border.pages.EmptyBorderComposite;
-import org.eclipse.wb.internal.swing.model.property.editor.border.pages.EtchedBorderComposite;
-import org.eclipse.wb.internal.swing.model.property.editor.border.pages.LineBorderComposite;
-import org.eclipse.wb.internal.swing.model.property.editor.border.pages.MatteBorderComposite;
-import org.eclipse.wb.internal.swing.model.property.editor.border.pages.SoftBevelBorderComposite;
-import org.eclipse.wb.internal.swing.model.property.editor.border.pages.SwingBorderComposite;
-import org.eclipse.wb.internal.swing.model.property.editor.border.pages.TitledBorderComposite;
 
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
@@ -114,7 +105,8 @@ public final class BorderField extends AbstractBorderField {
 	public String getSource() throws Exception {
 		// try to use AbstractBorderComposite's to convert Border into source
 		if (m_border != null) {
-			for (Class<?> compositeClass : COMPOSITE_CLASSES) {
+			Class<?> compositeClass = AbstractBorderComposite.getCompositeClass(m_border.getClass());
+			if (compositeClass != null) {
 				AbstractBorderComposite borderComposite = getBorderComposite(compositeClass);
 				try {
 					if (borderComposite.setBorder(m_border)) {
@@ -135,16 +127,6 @@ public final class BorderField extends AbstractBorderField {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	private static final Shell INVISIBLE_SHELL = new Shell();
-	private static final Class<?>[] COMPOSITE_CLASSES = {
-			BevelBorderComposite.class,
-			CompoundBorderComposite.class,
-			EmptyBorderComposite.class,
-			EtchedBorderComposite.class,
-			LineBorderComposite.class,
-			MatteBorderComposite.class,
-			SoftBevelBorderComposite.class,
-			TitledBorderComposite.class,
-			SwingBorderComposite.class,};
 	private static final List<AbstractBorderComposite> m_borderComposites = new LinkedList<>();
 
 	/**

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/AbstractBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/AbstractBorderComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -28,6 +28,10 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Predicate;
+
 import javax.swing.border.Border;
 
 /**
@@ -37,6 +41,7 @@ import javax.swing.border.Border;
  * @coverage swing.property.editor
  */
 public abstract class AbstractBorderComposite extends Composite {
+	protected static final Map<Class<?>, Predicate<Class<?>>> COMPOSITE_CLASSES = new HashMap<>();
 	private final String m_title;
 	protected BorderDialog m_borderDialog;
 
@@ -81,6 +86,25 @@ public abstract class AbstractBorderComposite extends Composite {
 	 * @return the source for updated {@link Border}.
 	 */
 	public abstract String getSource() throws Exception;
+
+	/**
+	 * Used by the {@link BorderField} for the source code generation.
+	 * <i>Important</i> This method should only be called after the
+	 * {@link BorderDialog} has been created at least once.
+	 *
+	 * @return the composite class managing the given border.
+	 */
+	public static Class<?> getCompositeClass(Class<?> clazz) {
+		if (clazz == null) {
+			return NoBorderComposite.class;
+		}
+		for (Map.Entry<Class<?>, Predicate<Class<?>>> entry : COMPOSITE_CLASSES.entrySet()) {
+			if (entry.getValue().test(clazz)) {
+				return entry.getKey();
+			}
+		}
+		return null;
+	}
 
 	////////////////////////////////////////////////////////////////////////////
 	//

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/BevelBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/BevelBorderComposite.java
@@ -62,6 +62,10 @@ public final class BevelBorderComposite extends AbstractBorderComposite {
 		ExecutionUtils.runRethrow(() -> m_typeField.setValue(BevelBorder.LOWERED));
 	}
 
+	static {
+		COMPOSITE_CLASSES.put(BevelBorderComposite.class, BevelBorder.class::isAssignableFrom);
+	}
+
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Access

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/CompoundBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/CompoundBorderComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -75,6 +75,10 @@ public final class CompoundBorderComposite extends AbstractBorderComposite {
 				}
 			});
 		}
+	}
+
+	static {
+		COMPOSITE_CLASSES.put(CompoundBorderComposite.class, CompoundBorder.class::isAssignableFrom);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/EmptyBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/EmptyBorderComposite.java
@@ -54,6 +54,11 @@ public final class EmptyBorderComposite extends AbstractBorderComposite {
 		m_rightField.setValue(0);
 	}
 
+	static {
+		// Check for identity because EmptyBorder is sub-classed by MatteBorder
+		COMPOSITE_CLASSES.put(EmptyBorderComposite.class, EmptyBorder.class::equals);
+	}
+
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Access

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/EtchedBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/EtchedBorderComposite.java
@@ -56,6 +56,10 @@ public final class EtchedBorderComposite extends AbstractBorderComposite {
 		ExecutionUtils.runRethrow(() -> m_typeField.setValue(EtchedBorder.LOWERED));
 	}
 
+	static {
+		COMPOSITE_CLASSES.put(EtchedBorderComposite.class, EtchedBorder.class::isAssignableFrom);
+	}
+
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Access

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/LineBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/LineBorderComposite.java
@@ -75,6 +75,10 @@ public final class LineBorderComposite extends AbstractBorderComposite {
 		}
 	}
 
+	static {
+		COMPOSITE_CLASSES.put(LineBorderComposite.class, LineBorder.class::isAssignableFrom);
+	}
+
 	@Override
 	public String getSource() {
 		String colorSource = m_colorField.getSource();

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/MatteBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/MatteBorderComposite.java
@@ -59,6 +59,10 @@ public final class MatteBorderComposite extends AbstractBorderComposite {
 		m_rightField.setValue(1);
 	}
 
+	static {
+		COMPOSITE_CLASSES.put(MatteBorderComposite.class, MatteBorder.class::isAssignableFrom);
+	}
+
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Access

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/SoftBevelBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/SoftBevelBorderComposite.java
@@ -63,6 +63,10 @@ public final class SoftBevelBorderComposite extends AbstractBorderComposite {
 		ExecutionUtils.runRethrow(() -> m_typeField.setValue(BevelBorder.LOWERED));
 	}
 
+	static {
+		COMPOSITE_CLASSES.put(SoftBevelBorderComposite.class, SoftBevelBorder.class::isAssignableFrom);
+	}
+
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Access

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/SwingBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/SwingBorderComposite.java
@@ -69,6 +69,10 @@ public final class SwingBorderComposite extends AbstractBorderComposite {
 		m_bordersList.deselectAll();
 	}
 
+	static {
+		COMPOSITE_CLASSES.put(SwingBorderComposite.class, SwingBorderComposite::contains);
+	}
+
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Access
@@ -118,6 +122,13 @@ public final class SwingBorderComposite extends AbstractBorderComposite {
 	////////////////////////////////////////////////////////////////////////////
 	private static java.util.List<String> m_borderKeys;
 	private static java.util.List<Border> m_borders;
+
+	/**
+	 * @return {@code true}, if this composite can manage the given border.
+	 */
+	private static boolean contains(Class<?> border) {
+		return m_borders.stream().map(Border::getClass).anyMatch(border::equals);
+	}
 
 	/**
 	 * Prepares {@link FontInfo}'s for {@link Font}'s from {@link UIManager}.

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/TitledBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/TitledBorderComposite.java
@@ -90,6 +90,10 @@ public final class TitledBorderComposite extends AbstractBorderComposite {
 		});
 	}
 
+	static {
+		COMPOSITE_CLASSES.put(TitledBorderComposite.class, TitledBorder.class::isAssignableFrom);
+	}
+
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Access


### PR DESCRIPTION
Rather than iterating over a list of all composite classes, define a simple lookup-table. In addition to being faster, it also avoids having two maintain two lists of composites; One for the BorderField and one for the BorderDialog.