### PR TITLE
[Draw2D] Migrate to Draw2D Figures for Menu edit-parts

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/MacMenuEditPart.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/MacMenuEditPart.java
@@ -13,10 +13,10 @@
 package org.eclipse.wb.internal.core.gef.part.menu;
 
 import org.eclipse.wb.core.gef.part.menu.MenuEditPartFactory;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.internal.core.model.menu.IMenuInfo;
 
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.GraphicalEditPart;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/MacMenuImageFigure.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/MacMenuImageFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,7 +16,6 @@ import org.eclipse.wb.internal.core.model.menu.IMenuInfo;
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Graphics;
-import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.swt.SWT;
 
 /**
@@ -41,14 +40,13 @@ public final class MacMenuImageFigure extends MenuImageFigure {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void paintClientArea(Graphics graphics) {
-		super.paintClientArea(graphics);
+	protected void paintFigure(Graphics graphics) {
+		super.paintFigure(graphics);
 		// draw border on MacOSX because the fill color of menu is the same as fill color of window client area
 		{
-			Rectangle clientArea = getClientArea();
 			graphics.setForegroundColor(ColorConstants.buttonLightest);
 			graphics.setLineStyle(SWT.LINE_DASH);
-			graphics.drawRectangle(0, 0, clientArea.width - 1, clientArea.height - 1);
+			graphics.drawRectangle(bounds.x, bounds.y, bounds.width - 1, bounds.height - 1);
 		}
 	}
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/MenuEditPart.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/MenuEditPart.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.gef.part.menu;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.gef.core.tools.SelectEditPartTracker;
 import org.eclipse.wb.internal.core.EnvironmentUtils;
@@ -21,6 +20,7 @@ import org.eclipse.wb.internal.core.gef.policy.menu.MenuSelectionEditPolicy;
 import org.eclipse.wb.internal.core.model.menu.IMenuInfo;
 import org.eclipse.wb.internal.core.model.menu.IMenuItemInfo;
 
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
@@ -40,7 +40,7 @@ import java.util.List;
  * @author scheglov_ke
  * @coverage core.gef.menu
  */
-public class MenuEditPart extends MenuObjectEditPart {
+public sealed class MenuEditPart extends MenuObjectEditPart permits MacMenuEditPart {
 	// TODO(scheglov) move TOP_LOCATION to shared location
 	public static final Point TOP_LOCATION = EnvironmentUtils.IS_MAC
 			? new Point(20, 28)

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/MenuImageFigure.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/MenuImageFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.gef.part.menu;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.internal.core.model.menu.IMenuInfo;
 
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
@@ -43,10 +43,16 @@ public class MenuImageFigure extends Figure {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void paintClientArea(Graphics graphics) {
+	protected void paintFigure(Graphics graphics) {
 		ImageDescriptor imageDescriptor = m_menu.getImageDescriptor();
 		Image image = imageDescriptor.createImage();
-		graphics.drawImage(image, 0, 0);
+		graphics.drawImage(image, bounds.x, bounds.y);
 		image.dispose();
+	}
+
+	@Override
+	protected boolean useLocalCoordinates() {
+		// model bounds of menu items are relative to the top-left corner of a menu
+		return true;
 	}
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/MenuItemEditPart.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/MenuItemEditPart.java
@@ -12,14 +12,13 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.gef.part.menu;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.internal.core.model.menu.IMenuInfo;
 import org.eclipse.wb.internal.core.model.menu.IMenuItemInfo;
 
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
-import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.EditPart;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
@@ -53,23 +52,22 @@ public final class MenuItemEditPart extends SubmenuAwareEditPart {
 	protected IFigure createFigure() {
 		return new Figure() {
 			@Override
-			protected void paintClientArea(Graphics graphics) {
+			protected void paintFigure(Graphics graphics) {
 				// draw image
 				{
 					ImageDescriptor imageDescriptor = m_item.getImageDescriptor();
 					if (imageDescriptor != null) {
 						Image image = imageDescriptor.createImage();
-						graphics.drawImage(image, 0, 0);
+						graphics.drawImage(image, bounds.x, bounds.y);
 						image.dispose();
 					}
 				}
 				// highlight "item" with displayed "menu"
 				if (!getModelChildren().isEmpty()) {
-					Rectangle area = getFigure().getClientArea();
 					graphics.setForegroundColor(ColorConstants.menuBackgroundSelected);
 					graphics.setBackgroundColor(ColorConstants.white);
 					graphics.setLineWidth(2);
-					graphics.drawRectangle(1, 1, area.width - 2, area.height - 2);
+					graphics.drawRectangle(bounds.x + 1, bounds.y + 1, bounds.width - 2, bounds.height - 2);
 				}
 			}
 		};

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/MenuPopupEditPart.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/MenuPopupEditPart.java
@@ -12,14 +12,13 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.gef.part.menu;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.internal.core.model.menu.IMenuInfo;
 import org.eclipse.wb.internal.core.model.menu.IMenuPopupInfo;
 
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
-import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.EditPart;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
@@ -53,23 +52,22 @@ public final class MenuPopupEditPart extends SubmenuAwareEditPart {
 	protected IFigure createFigure() {
 		return new Figure() {
 			@Override
-			protected void paintClientArea(Graphics graphics) {
+			protected void paintFigure(Graphics graphics) {
 				// draw image
 				{
 					ImageDescriptor imageDescriptor = m_popup.getImageDescriptor();
 					if (imageDescriptor != null) {
 						Image image = imageDescriptor.createImage();
-						graphics.drawImage(image, 0, 0);
+						graphics.drawImage(image, bounds.x, bounds.y);
 						image.dispose();
 					}
 				}
 				// highlight "item" with displayed "menu"
 				if (!getModelChildren().isEmpty()) {
-					Rectangle area = getFigure().getClientArea();
 					graphics.setForegroundColor(ColorConstants.menuBackgroundSelected);
 					graphics.setBackgroundColor(ColorConstants.white);
 					graphics.setLineWidth(2);
-					graphics.drawRectangle(1, 1, area.width - 2, area.height - 2);
+					graphics.drawRectangle(bounds.x + 1, bounds.y + 1, bounds.width - 2, bounds.height - 2);
 				}
 			}
 		};


### PR DESCRIPTION
Note that the coordinates of a MenuItem are relative to the top-left corner of the menu, hence why the `MenuImageFigure` needs to use local coordinates.