### PR TITLE
Undo explicit discarding of working CU

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/AbstractJavaProjectTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/AbstractJavaProjectTest.java
@@ -266,13 +266,8 @@ public abstract class AbstractJavaProjectTest extends DesignerTestCase {
 			String unitName,
 			String code) throws Exception {
 		IPackageFragment pkg = m_testProject.getPackage(packageName);
-		// discard cached unit
-		ICompilationUnit compilationUnit = pkg.getCompilationUnit(unitName);
-		while (compilationUnit.isWorkingCopy()) {
-			compilationUnit.discardWorkingCopy();
-		}
 		// create unit
-		compilationUnit = m_testProject.createUnit(pkg, unitName, code);
+		ICompilationUnit compilationUnit = m_testProject.createUnit(pkg, unitName, code);
 		IFile resource = (IFile) compilationUnit.getUnderlyingResource();
 		m_createdResources.add(resource);
 		// OK, return unit


### PR DESCRIPTION
Motivation for this change was to stabilize `test_PASTE_notItem`. But the test case is still failing sporadically. So there must be something else keeping this old cache entry alive.

This reverts revision 7ac46a464430258250ee55ad20bd59bb528807ba.