### PR TITLE
Create ExternalAction as ICompilationUnit

### DIFF
--- a/org.eclipse.wb.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: WindowBuilder Tests
 Bundle-SymbolicName: org.eclipse.wb.tests;singleton:=true
-Bundle-Version: 1.8.0.qualifier
+Bundle-Version: 1.8.100.qualifier
 Bundle-Activator: org.eclipse.wb.tests.designer.tests.Activator
 Bundle-Vendor: Google
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/org.eclipse.wb.tests/pom.xml
+++ b/org.eclipse.wb.tests/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.wb</groupId>
   <artifactId>org.eclipse.wb.tests</artifactId>
-  <version>1.8.0-SNAPSHOT</version>
+  <version>1.8.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <name>[bundle] WindowBuilder Tests</name>
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/bean/ActionGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/bean/ActionGefTest.java
@@ -435,7 +435,7 @@ public class ActionGefTest extends SwingGefTest {
 	 * Creates class with <code>ExternalAction</code>.
 	 */
 	private void createExternalAction() throws Exception {
-		setFileContentSrc("test/ExternalAction.java", getTestSource("""
+		createASTCompilationUnit("test", "ExternalAction.java", getTestSource("""
 				public class ExternalAction extends AbstractAction {
 					public ExternalAction() {
 						putValue(NAME, "My name");


### PR DESCRIPTION
The `test_JToolBar_ActionExternalEntryInfo` frequently fails because the "Open Type" dialog is unable to detect the newly added class. Rather than adding this class as a simple file, we now create it as a compilation unit, which should hopefully make sure that this class is visible to JDT.