### PR TITLE
Add new workflow for updating all Maven dependencies

### DIFF
--- a/.github/workflows/bump-target.yml
+++ b/.github/workflows/bump-target.yml
@@ -1,0 +1,52 @@
+name: Update Eclipse Target Platform
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: update-target-platform
+  cancel-in-progress: true
+
+jobs:
+  update:
+    name: Update target platform
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Set up Java
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: maven
+
+      - name: Update target platform
+        run: |
+          mvn -B \
+            org.eclipse.tycho.extras:tycho-version-bump-plugin:update-target
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+          branch: wb-bot/update-target-platform
+          delete-branch: true
+
+          commit-message: "Update Maven target dependencies"
+          title: "Update Maven target dependencies"
+
+          body: |
+            Update Maven dependencies to their latest version.
+
+          add-paths: |
+            ${{ env.TARGET_FILE }}

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,15 @@
           <version>${tycho.version}</version>
         </plugin>
         <plugin>
+          <groupId>org.eclipse.tycho.extras</groupId>
+          <artifactId>tycho-version-bump-plugin</artifactId>
+          <version>${tycho.version}</version>
+          <configuration>
+            <targetFile>${maven.multiModuleProjectDirectory}/target-platform/mvn/wb-mvn.target</targetFile>
+            <mavenRulesUri>${maven.multiModuleProjectDirectory}/target-platform/mvn/rules.xml</mavenRulesUri>
+          </configuration>
+        </plugin>
+        <plugin>
           <groupId>org.asciidoctor</groupId>
           <artifactId>asciidoctor-maven-plugin</artifactId>
           <version>3.2.0</version>

--- a/target-platform/mvn/rules.xml
+++ b/target-platform/mvn/rules.xml
@@ -1,0 +1,12 @@
+<ruleset xmlns="https://www.mojohaus.org/VERSIONS/RULE/3.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.mojohaus.org/VERSIONS/RULE/3.0.0 https://www.mojohaus.org/versions/versions-model/xsd/rule-3.0.0.xsd">
+    <rules>
+        <rule groupId="net.bytebuddy" artifactId="*">
+            <ignoreVersions>
+                <ignoreVersion type="regex">.+-jdk\d</ignoreVersion>
+            </ignoreVersions>
+        </rule>
+    </rules>
+    <ignoreVersions>
+        <ignoreVersion type="regex">(.+-SNAPSHOT|.+-M\d)</ignoreVersion>
+    </ignoreVersions>
+</ruleset>


### PR DESCRIPTION
This workflow automatically updates the dependencies specified in the wb-mvn.target file to their latest version using the Tycho Version Bump plugin. Unwanted versions are excluded using the version rule-set.