### PR TITLE
Calculate occupied grid cells using component coordinates #1591

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/gbl/AbstractGridBagLayoutInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/gbl/AbstractGridBagLayoutInfo.java
@@ -51,9 +51,7 @@ import org.apache.commons.collections4.BidiMap;
 import org.apache.commons.collections4.bidimap.DualHashBidiMap;
 import org.apache.commons.collections4.bidimap.UnmodifiableBidiMap;
 
-import java.awt.Component;
 import java.awt.Container;
-import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -186,8 +184,6 @@ public abstract class AbstractGridBagLayoutInfo extends LayoutInfo implements IP
 	////////////////////////////////////////////////////////////////////////////
 	protected final Set<Integer> m_refreshFilledColumns = new TreeSet<>();
 	protected final Set<Integer> m_refreshFilledRows = new TreeSet<>();
-	private final Map<ComponentInfo, Rectangle> m_gridBounds = new HashMap<>();
-	private final GridBagConstraints m_defaultContraints = new GridBagConstraints();
 
 	@Override
 	public void refresh_dispose() throws Exception {
@@ -217,7 +213,6 @@ public abstract class AbstractGridBagLayoutInfo extends LayoutInfo implements IP
 		int gridWidth = dimensions[0].length;
 		int gridHeight = dimensions[1].length;
 		// fetch fields
-		refresh_LayoutInfo(containerObject, gridWidth, gridHeight);
 		for (ComponentInfo component : getComponents()) {
 			getConstraints(component).getCurrentObjectFields(false);
 		}
@@ -269,140 +264,6 @@ public abstract class AbstractGridBagLayoutInfo extends LayoutInfo implements IP
 				getContainer().getContainer().doLayout();
 				((AbstractComponentInfo) getRoot()).getTopBoundsSupport().apply();
 			}
-		}
-	}
-
-	/**
-	 * A simplified version of the algorithm used within the
-	 * {@link GridBagLayout#getLayoutInfo(Container,int)} method, which calculates
-	 * the cells occupied by each component.
-	 */
-	private void refresh_LayoutInfo(Container parent, int width, int height) {
-		int px;
-		int py;
-		int curRow = -1;
-		int curCol = -1;
-
-		GridBagLayout gridBagLayout = getLayoutManager();
-
-		// Calculate maximum dimension of the grid
-		int xMax = 0;
-		int yMax = 0;
-
-		for (ComponentInfo componentInfo : getComponents()) {
-			Component component = componentInfo.getComponent();
-			if (!component.isVisible()) {
-				continue;
-			}
-
-			GridBagConstraints constraints = gridBagLayout.getConstraints(component);
-			xMax = Math.max(xMax, constraints.gridwidth);
-			yMax = Math.max(xMax, constraints.gridheight);
-		}
-
-		int[] xMaxArray = new int[height + yMax];
-		int[] yMaxArray = new int[width + xMax];
-
-		// Calculate the cells occupied by each component
-		for (ComponentInfo componentInfo : getComponents()) {
-			Component component = componentInfo.getComponent();
-			if (!component.isVisible()) {
-				continue;
-			}
-
-			GridBagConstraints constraints = gridBagLayout.getConstraints(component);
-			Rectangle curBounds = new Rectangle();
-
-			curBounds.x = constraints.gridx;
-			curBounds.y = constraints.gridy;
-			curBounds.width = constraints.gridwidth;
-			curBounds.height = constraints.gridheight;
-
-			// If x or y is negative, then use relative positioning
-			if (curBounds.x < 0 && curBounds.y < 0) {
-				if (curRow >= 0) {
-					curBounds.y = curRow;
-				} else if (curCol >= 0) {
-					curBounds.x = curCol;
-				} else {
-					curBounds.y = 0;
-				}
-			}
-
-			if (curBounds.x < 0) {
-				if (curBounds.height <= 0) {
-					curBounds.height += height - curBounds.y;
-					if (curBounds.height < 1) {
-						curBounds.height = 1;
-					}
-				}
-
-				px = 0;
-				for (int i = curBounds.y; i < curBounds.bottom(); i++) {
-					px = Math.max(px, xMaxArray[i]);
-				}
-
-				curBounds.x = px - curBounds.x - 1;
-				if (curBounds.x < 0) {
-					curBounds.x = 0;
-				}
-			} else if (curBounds.y < 0) {
-				if (curBounds.width <= 0) {
-					curBounds.width += width - curBounds.x;
-					if (curBounds.width < 1) {
-						curBounds.width = 1;
-					}
-				}
-
-				py = 0;
-				for (int i = curBounds.x; i < curBounds.right(); i++) {
-					py = Math.max(py, yMaxArray[i]);
-				}
-
-				curBounds.y = py - curBounds.y - 1;
-				if (curBounds.y < 0) {
-					curBounds.y = 0;
-				}
-			}
-
-			if (curBounds.width <= 0) {
-				curBounds.width += width - curBounds.x;
-				if (curBounds.width < 1) {
-					curBounds.width = 1;
-				}
-			}
-
-			if (curBounds.height <= 0) {
-				curBounds.height += height - curBounds.y;
-				if (curBounds.height < 1) {
-					curBounds.height = 1;
-				}
-			}
-
-			px = curBounds.right();
-			py = curBounds.bottom();
-
-			for (int i = curBounds.x; i < curBounds.right(); i++) {
-				yMaxArray[i] = py;
-			}
-
-			for (int i = curBounds.y; i < curBounds.bottom(); i++) {
-				xMaxArray[i] = px;
-			}
-
-			// Make negative sizes start a new row/column
-			if (constraints.gridheight == 0 && constraints.gridwidth == 0) {
-				curRow = -1;
-				curCol = -1;
-			}
-
-			if (constraints.gridheight == 0 && curRow < 0) {
-				curCol = curBounds.right();
-			} else if (constraints.gridwidth == 0 && curCol < 0) {
-				curRow = curBounds.bottom();
-			}
-
-			m_gridBounds.put(componentInfo, curBounds);
 		}
 	}
 
@@ -1039,14 +900,6 @@ public abstract class AbstractGridBagLayoutInfo extends LayoutInfo implements IP
 
 	protected Interval[] checkRowIntervals(Interval[] rowIntervals) {
 		return rowIntervals;
-	}
-
-	/* package */ Rectangle getGridBounds(ComponentInfo componentInfo) {
-		int x = m_defaultContraints.gridx;
-		int y = m_defaultContraints.gridy;
-		int width = m_defaultContraints.gridwidth;
-		int height = m_defaultContraints.gridheight;
-		return m_gridBounds.getOrDefault(componentInfo, new Rectangle(x, y, width, height));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/gbl/GridBagConstraintsInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/gbl/GridBagConstraintsInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -36,6 +36,8 @@ import java.text.MessageFormat;
  * @coverage swing.model.layout
  */
 public final class GridBagConstraintsInfo extends AbstractGridBagConstraintsInfo {
+	private static final Rectangle TMP_RECTANGLE = new Rectangle();
+
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Constructor
@@ -70,19 +72,63 @@ public final class GridBagConstraintsInfo extends AbstractGridBagConstraintsInfo
 				return;
 			}
 			// get constraints
-			GridBagLayout gridBagLayout = gridBagLayoutInfo.getLayoutManager();
-			constraints = gridBagLayout.getConstraints(component);
+			constraints = gridBagLayoutInfo.getLayoutManager().getConstraints(component);
 			// location
-			Rectangle gridBounds = gridBagLayoutInfo.getGridBounds(componentInfo);
-			x = gridBounds.x;
-			y = gridBounds.y;
-			width = gridBounds.width;
-			height = gridBounds.height;
+			getLogicalGridBounds(gridBagLayoutInfo, componentInfo);
+			x = TMP_RECTANGLE.x;
+			y = TMP_RECTANGLE.y;
+			width = TMP_RECTANGLE.width;
+			height = TMP_RECTANGLE.height;
 		}
 		// fetch fields
 		insets = CoordinateUtils.get(constraints.insets);
 		anchor = constraints.anchor;
 		fill = constraints.fill;
+	}
+
+	/**
+	 * A simplified algorithm which calculates the cells occupied by the given
+	 * component in the grid-bag layout. The cell bounds are stored in
+	 * {@link #TMP_RECTANGLE}.
+	 */
+	private void getLogicalGridBounds(GridBagLayoutInfo gridBagLayoutInfo, ComponentInfo componentInfo) {
+		GridBagLayout gridBagLayout = gridBagLayoutInfo.getLayoutManager();
+		Component component = componentInfo.getComponent();
+
+		GridBagConstraints c = gridBagLayout.getConstraints(component);
+		int gridx = c.gridx;
+		int gridy = c.gridy;
+		int gridwidth = c.gridwidth;
+		int gridheight = c.gridheight;
+
+		// No RELATIVE or REMAINDER
+		if (gridx >= 0 && gridy >= 0 && gridwidth > 0 && gridheight > 0) {
+			TMP_RECTANGLE.setBounds(gridx, gridy, gridwidth, gridheight);
+			return;
+
+		}
+
+		java.awt.Rectangle bounds = componentInfo.getComponent().getBounds();
+		java.awt.Point topLeft = gridBagLayout.location(bounds.x, bounds.y);
+		java.awt.Point bottomRight = gridBagLayout.location(bounds.x + bounds.width - 1, bounds.y + bounds.height - 1);
+
+		if (gridx < 0) {
+			gridx = topLeft.x;
+		}
+
+		if (gridy < 0) {
+			gridy = topLeft.y;
+		}
+
+		if (gridwidth <= 0) {
+			gridwidth = bottomRight.x - topLeft.x + 1;
+		}
+
+		if (gridheight <= 0) {
+			gridheight = bottomRight.x - topLeft.x + 1;
+		}
+
+		TMP_RECTANGLE.setBounds(gridx, gridy, gridwidth, gridheight);
 	}
 
 	////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This adapts the algorithm for calculating the cell info introduced with c1e8592d18bf08bf02e2878eb8a40afc57632ac7, to better handle unmapped components.

By assuming that the occupied cells of a component always form a rectangle, we can determine those using the component bounds. The values `gridx` and `gridy` can be derived using the top-left position of the component, while the `gridwidth` and `gridheight` are described by its bottom-right position.

Closes https://github.com/eclipse-windowbuilder/windowbuilder/issues/1591