### PR TITLE
[GEF] `ICreationFactory` should extend `CreationFactory`

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/core/editor/palette/model/entry/ComponentEntryInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/core/editor/palette/model/entry/ComponentEntryInfo.java
@@ -17,7 +17,7 @@ import org.eclipse.wb.core.editor.palette.model.EntryInfo;
 import org.eclipse.wb.core.editor.palette.model.IPaletteSite;
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.gef.core.IEditPartViewer;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
+import org.eclipse.wb.gef.core.requests.DesignCreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.editor.Messages;
@@ -47,6 +47,7 @@ import org.eclipse.wb.internal.core.utils.ui.UiUtils;
 
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.gef.Tool;
+import org.eclipse.gef.requests.CreationFactory;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.window.Window;
@@ -427,7 +428,7 @@ public final class ComponentEntryInfo extends ToolEntryInfo {
 			return null;
 		}
 		// prepare factory
-		ICreationFactory factory = new ICreationFactory() {
+		CreationFactory factory = new DesignCreationFactory() {
 			private JavaInfo m_javaInfo;
 
 			@Override
@@ -440,7 +441,7 @@ public final class ComponentEntryInfo extends ToolEntryInfo {
 			}
 
 			@Override
-			public Object getNewObject() {
+			public JavaInfo getNewObject() {
 				return m_javaInfo;
 			}
 		};

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/model/entry/InstanceFactoryEntryInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/model/entry/InstanceFactoryEntryInfo.java
@@ -15,7 +15,7 @@ package org.eclipse.wb.internal.core.editor.palette.model.entry;
 import org.eclipse.wb.core.editor.palette.model.CategoryInfo;
 import org.eclipse.wb.core.editor.palette.model.EntryInfo;
 import org.eclipse.wb.core.model.JavaInfo;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
+import org.eclipse.wb.gef.core.requests.DesignCreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.editor.Messages;
@@ -28,6 +28,7 @@ import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 
 import org.eclipse.gef.Tool;
+import org.eclipse.gef.requests.CreationFactory;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.dialogs.ElementListSelectionDialog;
 
@@ -97,7 +98,7 @@ public final class InstanceFactoryEntryInfo extends FactoryEntryInfo {
 			}
 		}
 		// prepare creation factory
-		ICreationFactory creationFactory = new ICreationFactory() {
+		CreationFactory creationFactory = new DesignCreationFactory() {
 			private JavaInfo m_javaInfo;
 
 			@Override
@@ -110,7 +111,7 @@ public final class InstanceFactoryEntryInfo extends FactoryEntryInfo {
 			}
 
 			@Override
-			public Object getNewObject() {
+			public JavaInfo getNewObject() {
 				return m_javaInfo;
 			}
 		};

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/model/entry/StaticFactoryEntryInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/model/entry/StaticFactoryEntryInfo.java
@@ -15,13 +15,14 @@ package org.eclipse.wb.internal.core.editor.palette.model.entry;
 import org.eclipse.wb.core.editor.palette.model.CategoryInfo;
 import org.eclipse.wb.core.editor.palette.model.EntryInfo;
 import org.eclipse.wb.core.model.JavaInfo;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
+import org.eclipse.wb.gef.core.requests.DesignCreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
 import org.eclipse.wb.internal.core.model.creation.CreationSupport;
 import org.eclipse.wb.internal.core.model.creation.factory.StaticFactoryCreationSupport;
 
 import org.eclipse.gef.Tool;
+import org.eclipse.gef.requests.CreationFactory;
 
 /**
  * Implementation of {@link EntryInfo} for "static-factory-method" contribution.
@@ -79,7 +80,7 @@ public final class StaticFactoryEntryInfo extends FactoryEntryInfo {
 			return null;
 		}
 		// prepare factory
-		ICreationFactory factory = new ICreationFactory() {
+		CreationFactory factory = new DesignCreationFactory() {
 			private JavaInfo m_javaInfo;
 
 			@Override
@@ -91,7 +92,7 @@ public final class StaticFactoryEntryInfo extends FactoryEntryInfo {
 			}
 
 			@Override
-			public Object getNewObject() {
+			public JavaInfo getNewObject() {
 				return m_javaInfo;
 			}
 		};

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/requests/CreateRequest.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/requests/CreateRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,6 +13,7 @@
 package org.eclipse.wb.gef.core.requests;
 
 import org.eclipse.gef.RequestConstants;
+import org.eclipse.gef.requests.CreationFactory;
 
 /**
  * A {@link Request} to create a new object.
@@ -22,7 +23,7 @@ import org.eclipse.gef.RequestConstants;
  */
 public class CreateRequest extends AbstractCreateRequest {
 	private static final int SNAP_TO = 16;
-	private final ICreationFactory m_factory;
+	private final CreationFactory m_factory;
 	private Object m_newObject;
 	private Object m_selectObject;
 	private int m_flags = 0;
@@ -35,7 +36,7 @@ public class CreateRequest extends AbstractCreateRequest {
 	/**
 	 * Constructs a {@link CreateRequest} with the specified <i>type</i> and <i>factory</i>.
 	 */
-	public CreateRequest(ICreationFactory factory) {
+	public CreateRequest(CreationFactory factory) {
 		super(RequestConstants.REQ_CREATE);
 		m_factory = factory;
 	}

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/requests/DesignCreationFactory.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/requests/DesignCreationFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,15 +12,19 @@
  *******************************************************************************/
 package org.eclipse.wb.gef.core.requests;
 
+import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 
+import org.eclipse.gef.requests.CreationFactory;
+
 /**
- * A factory used to create new objects.
+ * A factory used to create new {@link ObjectInfo} objects.
  *
  * @author lobas_av
  * @coverage gef.core
  */
-public interface ICreationFactory {
+public abstract class DesignCreationFactory implements CreationFactory {
+
 	/**
 	 * Activates this factory, during {@link CreationTool} activation (including reloading). This
 	 * allows factory do any operations that are too expensive to perform them in
@@ -28,10 +32,13 @@ public interface ICreationFactory {
 	 *
 	 * If any exception thrown, then {@link CreationTool} will be unloaded.
 	 */
-	void activate() throws Exception;
+	public abstract void activate() throws Exception;
 
-	/**
-	 * @return the new object.
-	 */
-	Object getNewObject();
+	@Override
+	public abstract ObjectInfo getNewObject();
+
+	@Override
+	public Object getObjectType() {
+		return ObjectInfo.class;
+	}
 }

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/CreationTool.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/tools/CreationTool.java
@@ -13,14 +13,15 @@
 package org.eclipse.wb.gef.core.tools;
 
 import org.eclipse.wb.gef.core.requests.CreateRequest;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
+import org.eclipse.wb.gef.core.requests.DesignCreationFactory;
 
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.Request;
+import org.eclipse.gef.requests.CreationFactory;
 
 /**
- * The {@link CreationTool} creates new {@link EditPart EditParts} via a {@link ICreationFactory}.
+ * The {@link CreationTool} creates new {@link EditPart EditParts} via a {@link CreationFactory}.
  * If the user simply clicks on the viewer, the default sized {@link EditPart} will be created at
  * that point. If the user clicks and drags, the created {@link EditPart} will be sized based on
  * where the user clicked and dragged.
@@ -29,14 +30,14 @@ import org.eclipse.gef.Request;
  * @coverage gef.core
  */
 public class CreationTool extends AbstractCreationTool {
-	private final ICreationFactory m_factory;
+	private final CreationFactory m_factory;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Constructor
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public CreationTool(ICreationFactory factory) {
+	public CreationTool(CreationFactory factory) {
 		m_factory = factory;
 	}
 
@@ -49,16 +50,18 @@ public class CreationTool extends AbstractCreationTool {
 	public void activate() {
 		super.activate();
 		try {
-			m_factory.activate();
+			if (m_factory instanceof DesignCreationFactory factory) {
+				factory.activate();
+			}
 		} catch (Throwable e) {
 			getDomain().loadDefaultTool();
 		}
 	}
 
 	/**
-	 * @return the {@link ICreationFactory} used to create the new {@link EditPart}'s.
+	 * @return the {@link CreationFactory} used to create the new {@link EditPart}'s.
 	 */
-	public final ICreationFactory getFactory() {
+	public final CreationFactory getFactory() {
 		return m_factory;
 	}
 

--- a/org.eclipse.wb.rcp.SWT_AWT/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp.SWT_AWT/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.rcp.SWT_AWT;singleton:=true
-Bundle-Version: 1.11.0.qualifier
+Bundle-Version: 1.11.100.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.31.100,4.0.0)",
  org.eclipse.gef;bundle-version="[3.21.100,4.0.0)",

--- a/org.eclipse.wb.rcp.SWT_AWT/src/org/eclipse/wb/internal/rcp/swtawt/palette/SwingCompositeEntryInfo.java
+++ b/org.eclipse.wb.rcp.SWT_AWT/src/org/eclipse/wb/internal/rcp/swtawt/palette/SwingCompositeEntryInfo.java
@@ -16,7 +16,7 @@ import org.eclipse.wb.core.editor.palette.model.EntryInfo;
 import org.eclipse.wb.core.editor.palette.model.entry.ToolEntryInfo;
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.broadcast.JavaEventListener;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
+import org.eclipse.wb.gef.core.requests.DesignCreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
 import org.eclipse.wb.internal.core.model.creation.ConstructorCreationSupport;
@@ -30,6 +30,7 @@ import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 import org.eclipse.wb.internal.swing.model.layout.BorderLayoutInfo;
 
 import org.eclipse.gef.Tool;
+import org.eclipse.gef.requests.CreationFactory;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.awt.SWT_AWT;
@@ -78,7 +79,7 @@ public final class SwingCompositeEntryInfo extends ToolEntryInfo {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public Tool createTool() throws Exception {
-		ICreationFactory factory = new ICreationFactory() {
+		CreationFactory factory = new DesignCreationFactory() {
 			private JavaInfo m_javaInfo;
 
 			@Override
@@ -87,7 +88,7 @@ public final class SwingCompositeEntryInfo extends ToolEntryInfo {
 			}
 
 			@Override
-			public Object getNewObject() {
+			public JavaInfo getNewObject() {
 				return m_javaInfo;
 			}
 		};

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/jface/FieldEditorDropRequestProcessor.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/jface/FieldEditorDropRequestProcessor.java
@@ -15,13 +15,13 @@ package org.eclipse.wb.internal.rcp.gef.policy.jface;
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.gef.core.RequestProcessor;
 import org.eclipse.wb.gef.core.requests.CreateRequest;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
 import org.eclipse.wb.internal.rcp.model.jface.FieldEditorInfo;
 import org.eclipse.wb.internal.rcp.model.jface.FieldLayoutPreferencePageInfo;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
+import org.eclipse.gef.requests.SimpleFactory;
 
 /**
  * Implementation of {@link RequestProcessor} for dropping {@link FieldEditorInfo} on
@@ -56,13 +56,9 @@ public final class FieldEditorDropRequestProcessor extends RequestProcessor {
 				// after CREATE select "composite"
 				editorCreateRequest.setSelectObject(composite);
 				// prepare CreateRequest, that creates our ActionInfo
-				CreateRequest createRequest = new CreateRequest(new ICreationFactory() {
+				CreateRequest createRequest = new CreateRequest(new SimpleFactory<>(CompositeInfo.class) {
 					@Override
-					public void activate() throws Exception {
-					}
-
-					@Override
-					public Object getNewObject() {
+					public CompositeInfo getNewObject() {
 						return composite;
 					}
 				});

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/jface/action/ActionDropRequestProcessor.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/jface/action/ActionDropRequestProcessor.java
@@ -16,7 +16,6 @@ import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.broadcast.JavaEventListener;
 import org.eclipse.wb.gef.core.RequestProcessor;
 import org.eclipse.wb.gef.core.requests.CreateRequest;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
 import org.eclipse.wb.internal.rcp.model.jface.action.ActionContributionItemInfo;
 import org.eclipse.wb.internal.rcp.model.jface.action.ActionInfo;
 import org.eclipse.wb.internal.rcp.model.jface.action.ContributionItemInfo;
@@ -24,6 +23,7 @@ import org.eclipse.wb.internal.rcp.model.jface.action.MenuManagerInfo;
 
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
+import org.eclipse.gef.requests.SimpleFactory;
 
 /**
  * Implementation of {@link RequestProcessor} for dropping {@link ActionInfo} on
@@ -56,13 +56,9 @@ public final class ActionDropRequestProcessor extends RequestProcessor {
 			final ActionInfo action = actionDropRequest.getAction();
 			scheduleActionItemSelection(actionDropRequest);
 			// prepare CreateRequest, that creates our ActionInfo
-			CreateRequest createRequest = new CreateRequest(new ICreationFactory() {
+			CreateRequest createRequest = new CreateRequest(new SimpleFactory<>(ActionInfo.class) {
 				@Override
-				public void activate() throws Exception {
-				}
-
-				@Override
-				public Object getNewObject() {
+				public ActionInfo getNewObject() {
 					return action;
 				}
 			});

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/DoubleFieldEditorEntryInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/DoubleFieldEditorEntryInfo.java
@@ -15,7 +15,7 @@ package org.eclipse.wb.internal.rcp.palette;
 import org.eclipse.wb.core.editor.palette.model.EntryInfo;
 import org.eclipse.wb.core.editor.palette.model.entry.ToolEntryInfo;
 import org.eclipse.wb.core.model.JavaInfo;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
+import org.eclipse.wb.gef.core.requests.DesignCreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.internal.core.BundleResourceProvider;
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
@@ -25,6 +25,7 @@ import org.eclipse.wb.internal.core.utils.jdt.core.ProjectUtils;
 import org.eclipse.wb.internal.rcp.Activator;
 
 import org.eclipse.gef.Tool;
+import org.eclipse.gef.requests.CreationFactory;
 import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
@@ -63,7 +64,7 @@ public final class DoubleFieldEditorEntryInfo extends ToolEntryInfo {
 	public Tool createTool() throws Exception {
 		ProjectUtils.ensureResourceType(m_javaProject, Activator.getDefault().getBundle(), TYPE_NAME);
 		// create tool
-		ICreationFactory factory = new ICreationFactory() {
+		CreationFactory factory = new DesignCreationFactory() {
 			private JavaInfo m_javaInfo;
 
 			@Override
@@ -74,7 +75,7 @@ public final class DoubleFieldEditorEntryInfo extends ToolEntryInfo {
 			}
 
 			@Override
-			public Object getNewObject() {
+			public JavaInfo getNewObject() {
 				return m_javaInfo;
 			}
 		};

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/TableCompositeEntryInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/TableCompositeEntryInfo.java
@@ -18,7 +18,6 @@ import org.eclipse.wb.core.editor.palette.model.entry.ToolEntryInfo;
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.broadcast.JavaEventListener;
 import org.eclipse.wb.gef.core.IEditPartViewer;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
 import org.eclipse.wb.internal.core.model.creation.ConstructorCreationSupport;
@@ -30,6 +29,7 @@ import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 
 import org.eclipse.gef.Tool;
+import org.eclipse.gef.requests.CreationFactory;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Table;
@@ -87,7 +87,7 @@ public final class TableCompositeEntryInfo extends ToolEntryInfo {
 		m_rootJavaInfo.addBroadcastListener(new JavaEventListener() {
 			@Override
 			public void addAfter(JavaInfo parent, JavaInfo child) throws Exception {
-				ICreationFactory creationFactory = creationTool.getFactory();
+				CreationFactory creationFactory = creationTool.getFactory();
 				CompositeInfo composite = (CompositeInfo) creationFactory.getNewObject();
 				if (child == composite) {
 					composite.removeBroadcastListener(this);

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/TableViewerCompositeEntryInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/TableViewerCompositeEntryInfo.java
@@ -18,7 +18,6 @@ import org.eclipse.wb.core.editor.palette.model.entry.ToolEntryInfo;
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.broadcast.JavaEventListener;
 import org.eclipse.wb.gef.core.IEditPartViewer;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
 import org.eclipse.wb.internal.core.model.creation.ConstructorCreationSupport;
@@ -31,6 +30,7 @@ import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 
 import org.eclipse.gef.Tool;
+import org.eclipse.gef.requests.CreationFactory;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.swt.widgets.Composite;
@@ -89,7 +89,7 @@ public final class TableViewerCompositeEntryInfo extends ToolEntryInfo {
 		m_rootJavaInfo.addBroadcastListener(new JavaEventListener() {
 			@Override
 			public void addAfter(JavaInfo parent, JavaInfo child) throws Exception {
-				ICreationFactory creationFactory = creationTool.getFactory();
+				CreationFactory creationFactory = creationTool.getFactory();
 				CompositeInfo composite = (CompositeInfo) creationFactory.getNewObject();
 				if (child == composite) {
 					composite.removeBroadcastListener(this);

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/TreeCompositeEntryInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/TreeCompositeEntryInfo.java
@@ -18,7 +18,6 @@ import org.eclipse.wb.core.editor.palette.model.entry.ToolEntryInfo;
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.broadcast.JavaEventListener;
 import org.eclipse.wb.gef.core.IEditPartViewer;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
 import org.eclipse.wb.internal.core.model.creation.ConstructorCreationSupport;
@@ -30,6 +29,7 @@ import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 
 import org.eclipse.gef.Tool;
+import org.eclipse.gef.requests.CreationFactory;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Tree;
@@ -87,7 +87,7 @@ public final class TreeCompositeEntryInfo extends ToolEntryInfo {
 		m_rootJavaInfo.addBroadcastListener(new JavaEventListener() {
 			@Override
 			public void addAfter(JavaInfo parent, JavaInfo child) throws Exception {
-				ICreationFactory creationFactory = creationTool.getFactory();
+				CreationFactory creationFactory = creationTool.getFactory();
 				CompositeInfo composite = (CompositeInfo) creationFactory.getNewObject();
 				if (child == composite) {
 					composite.removeBroadcastListener(this);

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/TreeViewerCompositeEntryInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/palette/TreeViewerCompositeEntryInfo.java
@@ -18,7 +18,6 @@ import org.eclipse.wb.core.editor.palette.model.entry.ToolEntryInfo;
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.broadcast.JavaEventListener;
 import org.eclipse.wb.gef.core.IEditPartViewer;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
 import org.eclipse.wb.internal.core.model.creation.ConstructorCreationSupport;
@@ -31,6 +30,7 @@ import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 
 import org.eclipse.gef.Tool;
+import org.eclipse.gef.requests.CreationFactory;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.swt.widgets.Composite;
@@ -89,7 +89,7 @@ public final class TreeViewerCompositeEntryInfo extends ToolEntryInfo {
 		m_rootJavaInfo.addBroadcastListener(new JavaEventListener() {
 			@Override
 			public void addAfter(JavaInfo parent, JavaInfo child) throws Exception {
-				ICreationFactory creationFactory = creationTool.getFactory();
+				CreationFactory creationFactory = creationTool.getFactory();
 				CompositeInfo composite = (CompositeInfo) creationFactory.getNewObject();
 				if (child == composite) {
 					composite.removeBroadcastListener(this);

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/palette/DefaultComponentFactoryCreateLabelEntryInfo.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/palette/DefaultComponentFactoryCreateLabelEntryInfo.java
@@ -14,13 +14,14 @@ package org.eclipse.wb.internal.swing.FormLayout.palette;
 
 import org.eclipse.wb.core.editor.palette.model.EntryInfo;
 import org.eclipse.wb.core.model.JavaInfo;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
+import org.eclipse.wb.gef.core.requests.DesignCreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
 import org.eclipse.wb.internal.swing.FormLayout.Activator;
 import org.eclipse.wb.internal.swing.FormLayout.parser.DefaultComponentFactoryCreationSupport;
 
 import org.eclipse.gef.Tool;
+import org.eclipse.gef.requests.CreationFactory;
 import org.eclipse.jface.resource.ImageDescriptor;
 
 import com.jgoodies.forms.factories.DefaultComponentFactory;
@@ -64,7 +65,7 @@ DefaultComponentFactoryEntryInfo {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public Tool createTool() throws Exception {
-		ICreationFactory factory = new ICreationFactory() {
+		CreationFactory factory = new DesignCreationFactory() {
 			private JavaInfo m_javaInfo;
 
 			@Override
@@ -79,7 +80,7 @@ DefaultComponentFactoryEntryInfo {
 			}
 
 			@Override
-			public Object getNewObject() {
+			public JavaInfo getNewObject() {
 				return m_javaInfo;
 			}
 		};

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/palette/DefaultComponentFactoryCreateTitleEntryInfo.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/palette/DefaultComponentFactoryCreateTitleEntryInfo.java
@@ -14,13 +14,14 @@ package org.eclipse.wb.internal.swing.FormLayout.palette;
 
 import org.eclipse.wb.core.editor.palette.model.EntryInfo;
 import org.eclipse.wb.core.model.JavaInfo;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
+import org.eclipse.wb.gef.core.requests.DesignCreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
 import org.eclipse.wb.internal.swing.FormLayout.Activator;
 import org.eclipse.wb.internal.swing.FormLayout.parser.DefaultComponentFactoryCreationSupport;
 
 import org.eclipse.gef.Tool;
+import org.eclipse.gef.requests.CreationFactory;
 import org.eclipse.jface.resource.ImageDescriptor;
 
 import com.jgoodies.forms.factories.DefaultComponentFactory;
@@ -64,7 +65,7 @@ DefaultComponentFactoryEntryInfo {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public Tool createTool() throws Exception {
-		ICreationFactory factory = new ICreationFactory() {
+		CreationFactory factory = new DesignCreationFactory() {
 			private JavaInfo m_javaInfo;
 
 			@Override
@@ -79,7 +80,7 @@ DefaultComponentFactoryEntryInfo {
 			}
 
 			@Override
-			public Object getNewObject() {
+			public JavaInfo getNewObject() {
 				return m_javaInfo;
 			}
 		};

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/palette/AbsoluteLayoutEntryInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/palette/AbsoluteLayoutEntryInfo.java
@@ -13,12 +13,13 @@
 package org.eclipse.wb.internal.swing.palette;
 
 import org.eclipse.wb.core.editor.palette.model.entry.ToolEntryInfo;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
+import org.eclipse.wb.gef.core.requests.DesignCreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.internal.core.editor.constants.CoreImages;
 import org.eclipse.wb.internal.swing.model.layout.absolute.AbsoluteLayoutInfo;
 
 import org.eclipse.gef.Tool;
+import org.eclipse.gef.requests.CreationFactory;
 import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
@@ -56,7 +57,7 @@ public final class AbsoluteLayoutEntryInfo extends ToolEntryInfo {
 	@Override
 	public Tool createTool() throws Exception {
 		// prepare factory
-		ICreationFactory factory = new ICreationFactory() {
+		CreationFactory factory = new DesignCreationFactory() {
 			private AbsoluteLayoutInfo m_layout;
 
 			@Override
@@ -66,7 +67,7 @@ public final class AbsoluteLayoutEntryInfo extends ToolEntryInfo {
 			}
 
 			@Override
-			public Object getNewObject() {
+			public AbsoluteLayoutInfo getNewObject() {
 				return m_layout;
 			}
 		};

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/palette/ActionUseEntryInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/palette/ActionUseEntryInfo.java
@@ -14,7 +14,6 @@ package org.eclipse.wb.internal.swing.palette;
 
 import org.eclipse.wb.core.editor.palette.model.EntryInfo;
 import org.eclipse.wb.core.editor.palette.model.entry.ToolEntryInfo;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.swing.Activator;
@@ -22,6 +21,8 @@ import org.eclipse.wb.internal.swing.model.ModelMessages;
 import org.eclipse.wb.internal.swing.model.bean.ActionInfo;
 
 import org.eclipse.gef.Tool;
+import org.eclipse.gef.requests.CreationFactory;
+import org.eclipse.gef.requests.SimpleFactory;
 import org.eclipse.jface.resource.ImageDescriptor;
 
 import org.apache.commons.lang3.ObjectUtils;
@@ -80,13 +81,9 @@ public final class ActionUseEntryInfo extends ToolEntryInfo {
 	 */
 	static Tool createActionTool(final ActionInfo action) {
 		// prepare factory
-		ICreationFactory factory = new ICreationFactory() {
+		CreationFactory factory = new SimpleFactory<>(ActionInfo.class) {
 			@Override
-			public void activate() throws Exception {
-			}
-
-			@Override
-			public Object getNewObject() {
+			public ActionInfo getNewObject() {
 				return action;
 			}
 		};

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/palette/AbsoluteLayoutEntryInfo.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/palette/AbsoluteLayoutEntryInfo.java
@@ -13,7 +13,7 @@
 package org.eclipse.wb.internal.swt.palette;
 
 import org.eclipse.wb.core.editor.palette.model.entry.ToolEntryInfo;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
+import org.eclipse.wb.gef.core.requests.DesignCreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.internal.core.editor.constants.CoreImages;
 import org.eclipse.wb.internal.core.model.description.ToolkitDescription;
@@ -22,6 +22,7 @@ import org.eclipse.wb.internal.swt.model.layout.absolute.AbsoluteLayoutCreationS
 import org.eclipse.wb.internal.swt.model.layout.absolute.AbsoluteLayoutInfo;
 
 import org.eclipse.gef.Tool;
+import org.eclipse.gef.requests.CreationFactory;
 import org.eclipse.jface.resource.ImageDescriptor;
 
 /**
@@ -59,7 +60,7 @@ public final class AbsoluteLayoutEntryInfo extends ToolEntryInfo {
 	@Override
 	public Tool createTool() throws Exception {
 		// prepare factory
-		ICreationFactory factory = new ICreationFactory() {
+		CreationFactory factory = new DesignCreationFactory() {
 			private AbsoluteLayoutInfo m_layout;
 
 			@Override
@@ -71,7 +72,7 @@ public final class AbsoluteLayoutEntryInfo extends ToolEntryInfo {
 			}
 
 			@Override
-			public Object getNewObject() {
+			public AbsoluteLayoutInfo getNewObject() {
 				return m_layout;
 			}
 		};

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/palette/ChooseComponentEntryInfoTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/palette/ChooseComponentEntryInfoTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,7 +17,7 @@ import org.eclipse.wb.core.editor.palette.model.IPaletteSite;
 import org.eclipse.wb.core.editor.palette.model.PaletteInfo;
 import org.eclipse.wb.core.editor.palette.model.entry.ChooseComponentEntryInfo;
 import org.eclipse.wb.core.model.JavaInfo;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
+import org.eclipse.wb.gef.core.requests.DesignCreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.editor.DesignPageSite;
@@ -190,7 +190,7 @@ public class ChooseComponentEntryInfoTest extends AbstractPaletteTest {
 		}
 		// check tool
 		{
-			ICreationFactory creationFactory = creationTool.getFactory();
+			DesignCreationFactory creationFactory = (DesignCreationFactory) creationTool.getFactory();
 			creationFactory.activate();
 			// check new object
 			JavaInfo javaInfo = (JavaInfo) creationFactory.getNewObject();

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/palette/ComponentEntryInfoTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/palette/ComponentEntryInfoTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,7 +17,7 @@ import org.eclipse.wb.core.editor.palette.model.IPaletteSite;
 import org.eclipse.wb.core.editor.palette.model.PaletteInfo;
 import org.eclipse.wb.core.editor.palette.model.entry.ComponentEntryInfo;
 import org.eclipse.wb.core.model.JavaInfo;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
+import org.eclipse.wb.gef.core.requests.DesignCreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.editor.palette.PaletteManager;
@@ -393,7 +393,7 @@ public class ComponentEntryInfoTest extends AbstractPaletteTest {
 		// check tool
 		{
 			CreationTool creationTool = (CreationTool) componentEntry.createTool();
-			ICreationFactory creationFactory = creationTool.getFactory();
+			DesignCreationFactory creationFactory = (DesignCreationFactory) creationTool.getFactory();
 			creationFactory.activate();
 			// check new object
 			JavaInfo javaInfo = (JavaInfo) creationFactory.getNewObject();
@@ -482,7 +482,7 @@ public class ComponentEntryInfoTest extends AbstractPaletteTest {
 		assertTrue(componentEntry.initialize(null, m_lastParseInfo));
 		// check tool
 		CreationTool creationTool = (CreationTool) componentEntry.createTool();
-		ICreationFactory creationFactory = creationTool.getFactory();
+		DesignCreationFactory creationFactory = (DesignCreationFactory) creationTool.getFactory();
 		creationFactory.activate();
 		// check new object
 		JavaInfo javaInfo = (JavaInfo) creationFactory.getNewObject();
@@ -660,10 +660,10 @@ public class ComponentEntryInfoTest extends AbstractPaletteTest {
 				// do initialize
 				assertTrue(componentEntry.initialize(null, panel));
 				// create tool
-				ICreationFactory creationFactory;
+				DesignCreationFactory creationFactory;
 				{
 					CreationTool creationTool = (CreationTool) componentEntry.createTool();
-					creationFactory = creationTool.getFactory();
+					creationFactory = (DesignCreationFactory) creationTool.getFactory();
 					creationFactory.activate();
 				}
 				// check new object
@@ -736,10 +736,10 @@ public class ComponentEntryInfoTest extends AbstractPaletteTest {
 				// do initialize
 				assertTrue(componentEntry.initialize(null, panel));
 				// create tool
-				ICreationFactory creationFactory;
+				DesignCreationFactory creationFactory;
 				{
 					CreationTool creationTool = (CreationTool) componentEntry.createTool();
-					creationFactory = creationTool.getFactory();
+					creationFactory = (DesignCreationFactory) creationTool.getFactory();
 					creationFactory.activate();
 				}
 				// check new object
@@ -1137,7 +1137,7 @@ public class ComponentEntryInfoTest extends AbstractPaletteTest {
 		// prepare new component
 		ComponentInfo newComponent;
 		{
-			ICreationFactory creationFactory = creationTool.getFactory();
+			DesignCreationFactory creationFactory = (DesignCreationFactory) creationTool.getFactory();
 			creationFactory.activate();
 			newComponent = (ComponentInfo) creationFactory.getNewObject();
 		}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/palette/InstanceFactoryEntryInfoTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/palette/InstanceFactoryEntryInfoTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,7 +15,7 @@ package org.eclipse.wb.tests.designer.core.palette;
 import org.eclipse.wb.core.editor.palette.model.CategoryInfo;
 import org.eclipse.wb.core.editor.palette.model.PaletteInfo;
 import org.eclipse.wb.core.model.JavaInfo;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
+import org.eclipse.wb.gef.core.requests.DesignCreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.internal.core.editor.palette.model.entry.InstanceFactoryEntryInfo;
 import org.eclipse.wb.internal.core.model.creation.factory.InstanceFactoryCreationSupport;
@@ -147,7 +147,7 @@ public class InstanceFactoryEntryInfoTest extends AbstractPaletteTest {
 		InstanceFactoryInfo instanceFactory = getTestInstanceFactories().get(0);
 		// check factory
 		{
-			ICreationFactory factory = creationTool.getFactory();
+			DesignCreationFactory factory = (DesignCreationFactory) creationTool.getFactory();
 			factory.activate();
 			// check JavaInfo
 			JavaInfo javaInfo = (JavaInfo) factory.getNewObject();
@@ -201,7 +201,7 @@ public class InstanceFactoryEntryInfoTest extends AbstractPaletteTest {
 		assertEditor(initialSource, m_lastEditor);
 		// check factory
 		{
-			ICreationFactory factory = creationTool.getFactory();
+			DesignCreationFactory factory = (DesignCreationFactory) creationTool.getFactory();
 			factory.activate();
 			// check JavaInfo
 			JavaInfo javaInfo = (JavaInfo) factory.getNewObject();
@@ -279,7 +279,7 @@ public class InstanceFactoryEntryInfoTest extends AbstractPaletteTest {
 		assertEditor(initialSource, m_lastEditor);
 		// check factory
 		{
-			ICreationFactory factory = creationTool.getFactory();
+			DesignCreationFactory factory = (DesignCreationFactory) creationTool.getFactory();
 			factory.activate();
 			// check JavaInfo
 			JavaInfo javaInfo = (JavaInfo) factory.getNewObject();

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/palette/StaticFactoryEntryInfoTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/palette/StaticFactoryEntryInfoTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,7 +15,7 @@ package org.eclipse.wb.tests.designer.core.palette;
 import org.eclipse.wb.core.editor.palette.model.CategoryInfo;
 import org.eclipse.wb.core.editor.palette.model.PaletteInfo;
 import org.eclipse.wb.core.model.JavaInfo;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
+import org.eclipse.wb.gef.core.requests.DesignCreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.internal.core.editor.palette.model.entry.StaticFactoryEntryInfo;
 import org.eclipse.wb.internal.core.model.creation.factory.StaticFactoryCreationSupport;
@@ -425,7 +425,7 @@ public class StaticFactoryEntryInfoTest extends AbstractPaletteTest {
 		assertTrue(entry.initialize(null, panel));
 		// create tool
 		CreationTool creationTool = (CreationTool) entry.createTool();
-		ICreationFactory factory = creationTool.getFactory();
+		DesignCreationFactory factory = (DesignCreationFactory) creationTool.getFactory();
 		factory.activate();
 		// check JavaInfo
 		JavaInfo javaInfo = (JavaInfo) factory.getNewObject();
@@ -467,7 +467,7 @@ public class StaticFactoryEntryInfoTest extends AbstractPaletteTest {
 		assertTrue(entry.initialize(null, panel));
 		// create tool
 		CreationTool creationTool = (CreationTool) entry.createTool();
-		ICreationFactory factory = creationTool.getFactory();
+		DesignCreationFactory factory = (DesignCreationFactory) creationTool.getFactory();
 		factory.activate();
 		// check JavaInfo
 		JavaInfo javaInfo = (JavaInfo) factory.getNewObject();

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/DesignerEditorTestCase.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/DesignerEditorTestCase.java
@@ -15,7 +15,6 @@ package org.eclipse.wb.tests.designer.editor;
 import org.eclipse.wb.core.editor.IDesignPage;
 import org.eclipse.wb.core.editor.IDesignerEditor;
 import org.eclipse.wb.core.model.JavaInfo;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.databinding.parser.DatabindingRootProcessor;
@@ -47,6 +46,8 @@ import org.eclipse.wb.tests.gef.UiContext;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.gef.EditPart;
+import org.eclipse.gef.requests.CreationFactory;
+import org.eclipse.gef.requests.SimpleFactory;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jface.action.IAction;
@@ -335,13 +336,9 @@ public abstract class DesignerEditorTestCase extends AbstractJavaInfoTest {
 			newComponent.putArbitraryValue(JavaInfo.FLAG_MANUAL_COMPONENT, Boolean.TRUE);
 		}
 		// load CreationTool
-		ICreationFactory factory = new ICreationFactory() {
+		CreationFactory factory = new SimpleFactory<>(JavaInfo.class) {
 			@Override
-			public void activate() {
-			}
-
-			@Override
-			public Object getNewObject() {
+			public JavaInfo getNewObject() {
 				return newComponent;
 			}
 		};

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/AbstractColumnLayoutTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/AbstractColumnLayoutTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,7 +14,7 @@ package org.eclipse.wb.tests.designer.rcp.model.jface;
 
 import org.eclipse.wb.core.editor.palette.model.entry.ToolEntryInfo;
 import org.eclipse.wb.core.model.association.InvocationSecondaryAssociation;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
+import org.eclipse.wb.gef.core.requests.DesignCreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.internal.core.model.generic.SimpleContainer;
 import org.eclipse.wb.internal.core.model.generic.SimpleContainerFactory;
@@ -913,7 +913,7 @@ public class AbstractColumnLayoutTest extends RcpModelTest {
 		CompositeInfo newComposite;
 		{
 			CreationTool creationTool = (CreationTool) entry.createTool();
-			ICreationFactory creationFactory = creationTool.getFactory();
+			DesignCreationFactory creationFactory = (DesignCreationFactory) creationTool.getFactory();
 			creationFactory.activate();
 			newComposite = (CompositeInfo) creationFactory.getNewObject();
 		}
@@ -964,7 +964,7 @@ public class AbstractColumnLayoutTest extends RcpModelTest {
 		CompositeInfo newComposite;
 		{
 			CreationTool creationTool = (CreationTool) entry.createTool();
-			ICreationFactory creationFactory = creationTool.getFactory();
+			DesignCreationFactory creationFactory = (DesignCreationFactory) creationTool.getFactory();
 			creationFactory.activate();
 			newComposite = (CompositeInfo) creationFactory.getNewObject();
 		}
@@ -1021,7 +1021,7 @@ public class AbstractColumnLayoutTest extends RcpModelTest {
 		CompositeInfo newComposite;
 		{
 			CreationTool creationTool = (CreationTool) entry.createTool();
-			ICreationFactory creationFactory = creationTool.getFactory();
+			DesignCreationFactory creationFactory = (DesignCreationFactory) creationTool.getFactory();
 			creationFactory.activate();
 			newComposite = (CompositeInfo) creationFactory.getNewObject();
 		}
@@ -1072,7 +1072,7 @@ public class AbstractColumnLayoutTest extends RcpModelTest {
 		CompositeInfo newComposite;
 		{
 			CreationTool creationTool = (CreationTool) entry.createTool();
-			ICreationFactory creationFactory = creationTool.getFactory();
+			DesignCreationFactory creationFactory = (DesignCreationFactory) creationTool.getFactory();
 			creationFactory.activate();
 			newComposite = (CompositeInfo) creationFactory.getNewObject();
 		}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/DoubleFieldEditorEntryInfoTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/DoubleFieldEditorEntryInfoTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,7 +13,7 @@
 package org.eclipse.wb.tests.designer.rcp.model.jface;
 
 import org.eclipse.wb.core.editor.palette.model.entry.ToolEntryInfo;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
+import org.eclipse.wb.gef.core.requests.DesignCreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.internal.rcp.model.jface.FieldEditorInfo;
 import org.eclipse.wb.internal.rcp.model.jface.FieldEditorPreferencePageInfo;
@@ -65,7 +65,7 @@ public class DoubleFieldEditorEntryInfoTest extends RcpModelTest {
 		FieldEditorInfo newField;
 		{
 			CreationTool creationTool = (CreationTool) entry.createTool();
-			ICreationFactory creationFactory = creationTool.getFactory();
+			DesignCreationFactory creationFactory = (DesignCreationFactory) creationTool.getFactory();
 			creationFactory.activate();
 			newField = (FieldEditorInfo) creationFactory.getNewObject();
 		}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/widgets/SwtAwtTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/widgets/SwtAwtTest.java
@@ -13,7 +13,7 @@
 package org.eclipse.wb.tests.designer.rcp.model.widgets;
 
 import org.eclipse.wb.core.editor.palette.model.entry.ToolEntryInfo;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
+import org.eclipse.wb.gef.core.requests.DesignCreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.internal.rcp.swtawt.palette.SwingCompositeEntryInfo;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
@@ -186,7 +186,7 @@ public class SwtAwtTest extends RcpModelTest {
 		CompositeInfo composite;
 		{
 			CreationTool creationTool = (CreationTool) entry.createTool();
-			ICreationFactory creationFactory = creationTool.getFactory();
+			DesignCreationFactory creationFactory = (DesignCreationFactory) creationTool.getFactory();
 			creationFactory.activate();
 			composite = (CompositeInfo) creationFactory.getNewObject();
 		}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/FormLayout/DefaultComponentFactoryTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/FormLayout/DefaultComponentFactoryTest.java
@@ -13,7 +13,7 @@
 package org.eclipse.wb.tests.designer.swing.model.layout.FormLayout;
 
 import org.eclipse.wb.core.editor.palette.model.entry.ToolEntryInfo;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
+import org.eclipse.wb.gef.core.requests.DesignCreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
 import org.eclipse.wb.internal.swing.FormLayout.palette.DefaultComponentFactoryCreateLabelEntryInfo;
@@ -126,7 +126,7 @@ public class DefaultComponentFactoryTest extends AbstractFormLayoutTest {
 		assertTrue(entry.initialize(null, m_lastParseInfo));
 		// check tool
 		CreationTool creationTool = (CreationTool) entry.createTool();
-		ICreationFactory creationFactory = creationTool.getFactory();
+		DesignCreationFactory creationFactory = (DesignCreationFactory) creationTool.getFactory();
 		creationFactory.activate();
 		// get object
 		ComponentInfo newComponent = (ComponentInfo) creationFactory.getNewObject();
@@ -218,7 +218,7 @@ public class DefaultComponentFactoryTest extends AbstractFormLayoutTest {
 		assertTrue(entry.initialize(null, m_lastParseInfo));
 		// check tool
 		CreationTool creationTool = (CreationTool) entry.createTool();
-		ICreationFactory creationFactory = creationTool.getFactory();
+		DesignCreationFactory creationFactory = (DesignCreationFactory) creationTool.getFactory();
 		creationFactory.activate();
 		// get object
 		ComponentInfo newComponent = (ComponentInfo) creationFactory.getNewObject();

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/CreationToolCursorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/CreationToolCursorTest.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.gef;
 
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.gef.graphical.tools.SelectionTool;
 import org.eclipse.wb.internal.gef.core.SharedCursors;
@@ -20,6 +19,8 @@ import org.eclipse.wb.internal.gef.core.SharedCursors;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Tool;
 import org.eclipse.gef.commands.Command;
+import org.eclipse.gef.requests.CreationFactory;
+import org.eclipse.gef.requests.SimpleFactory;
 import org.eclipse.swt.graphics.Cursor;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -55,13 +56,9 @@ public class CreationToolCursorTest extends GefCursorTestCase {
 	public void setUp() throws Exception {
 		super.setUp();
 		// create test factory
-		ICreationFactory factory = new ICreationFactory() {
+		CreationFactory factory = new SimpleFactory<>(String.class) {
 			@Override
-			public void activate() {
-			}
-
-			@Override
-			public Object getNewObject() {
+			public String getNewObject() {
 				return "_NewObject_";
 			}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/CreationToolTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/CreationToolTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,8 +13,10 @@
 package org.eclipse.wb.tests.gef;
 
 import org.eclipse.wb.gef.core.requests.CreateRequest;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
+
+import org.eclipse.gef.requests.CreationFactory;
+import org.eclipse.gef.requests.SimpleFactory;
 
 /**
  * @author lobas_av
@@ -30,13 +32,9 @@ public class CreationToolTest extends AbstractCreationToolTest {
 	@Override
 	protected void configureTestCase() {
 		// create test factory
-		ICreationFactory factory = new ICreationFactory() {
+		CreationFactory factory = new SimpleFactory<>(String.class) {
 			@Override
-			public void activate() {
-			}
-
-			@Override
-			public Object getNewObject() {
+			public String getNewObject() {
 				return "_NewObject_";
 			}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/RequestsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/RequestsTest.java
@@ -13,7 +13,6 @@
 package org.eclipse.wb.tests.gef;
 
 import org.eclipse.wb.gef.core.requests.CreateRequest;
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
 import org.eclipse.wb.gef.core.requests.PasteRequest;
 import org.eclipse.wb.gef.graphical.DesignEditPart;
 
@@ -27,9 +26,11 @@ import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.RequestConstants;
 import org.eclipse.gef.requests.ChangeBoundsRequest;
+import org.eclipse.gef.requests.CreationFactory;
 import org.eclipse.gef.requests.GroupRequest;
 import org.eclipse.gef.requests.LocationRequest;
 import org.eclipse.gef.requests.SelectionRequest;
+import org.eclipse.gef.requests.SimpleFactory;
 import org.eclipse.swt.SWT;
 
 import org.junit.jupiter.api.Assertions;
@@ -205,13 +206,9 @@ public class RequestsTest extends Assertions {
 
 	@Test
 	public void test_CreateRequest() throws Exception {
-		ICreationFactory factory = new ICreationFactory() {
+		CreationFactory factory = new SimpleFactory<>(Integer.class) {
 			@Override
-			public void activate() {
-			}
-
-			@Override
-			public Object getNewObject() {
+			public Integer getNewObject() {
 				// Has to be larger than then integer cache from [-128, 127]
 				return Integer.valueOf(273);
 			}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/TreeCreateToolTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/TreeCreateToolTest.java
@@ -12,11 +12,12 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.gef;
 
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.gef.TreeEditPart;
+import org.eclipse.gef.requests.CreationFactory;
+import org.eclipse.gef.requests.SimpleFactory;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,13 +37,9 @@ public class TreeCreateToolTest extends TreeToolTest {
 	public void setUp() throws Exception {
 		super.setUp();
 		// create test factory
-		ICreationFactory factory = new ICreationFactory() {
+		CreationFactory factory = new SimpleFactory<>(String.class) {
 			@Override
-			public void activate() {
-			}
-
-			@Override
-			public Object getNewObject() {
+			public String getNewObject() {
 				return "_NewObject_";
 			}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/utils/AbsoluteCreationTool.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/utils/AbsoluteCreationTool.java
@@ -12,11 +12,11 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.utils;
 
-import org.eclipse.wb.gef.core.requests.ICreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.internal.gef.graphical.GraphicalViewer;
 
 import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.gef.requests.CreationFactory;
 
 import java.util.Collection;
 import java.util.function.Supplier;
@@ -31,7 +31,7 @@ import java.util.function.Supplier;
  */
 public class AbsoluteCreationTool extends CreationTool {
 
-	public AbsoluteCreationTool(ICreationFactory factory) {
+	public AbsoluteCreationTool(CreationFactory factory) {
 		super(factory);
 	}
 


### PR DESCRIPTION
This renames the `ICreationFactory` to `DesignCreationFactory`. We need a custom factory in case the creation of an object is an expensive operation, which should not be done in the `getNewObject()` method.

It is primarily used for creating `JavaInfo` instances. Where appropriate, we use the `SimpleFactory` class instead. This factoy needs to be harmonized before we can migrate the `CreateRequest`.