### PR TITLE
Restore highlight visited nodes preference

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/core/model/JavaInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/core/model/JavaInfo.java
@@ -92,11 +92,13 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 /**
  * Abstract model for any Java-based model object. It has some presentation in AST.
@@ -1199,8 +1201,11 @@ public class JavaInfo extends ObjectInfo implements HasSourcePosition {
 			String unitSource = editor.getModelUnit().getSource();
 			boolean isCommitted = editorSource.equals(unitSource);
 			if (isCommitted) {
-				// TODO(scheglov)
-				//        site.highlightVisitedNodes(visitedNodes.getNodes());
+				Set<Integer> lines = new HashSet<>();
+				for (ASTNode node : visitedNodes.getNodes()) {
+					lines.add(editor.getLineNumber(node.getStartPosition()));
+				}
+				site.highlightVisitedLines(lines);
 			}
 		}
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/DesignPage.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/DesignPage.java
@@ -60,6 +60,7 @@ import org.eclipse.ui.IWorkbenchPart;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -541,11 +542,11 @@ public final class DesignPage implements IDesignPage {
 					m_designerEditor.getMultiMode().showSource();
 				}
 
-				// TODO(scheglov)
-				//        @Override
-				//        public void highlightVisitedNodes(Collection<ASTNode> nodes) {
-				//          m_designerEditor.highlightVisitedNodes(nodes);
-				//        }
+				@Override
+				public void highlightVisitedLines(Collection<Integer> lines) {
+					m_designerEditor.highlightVisitedLines(lines);
+				}
+
 				@Override
 				public void handleException(Throwable e) {
 					handleDesignException(e);

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/multi/DesignerEditor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/multi/DesignerEditor.java
@@ -25,7 +25,6 @@ import org.eclipse.wb.internal.core.views.IDesignCompositeProvider;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.ICompilationUnit;
-import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.internal.ui.javaeditor.CompilationUnitEditor;
 import org.eclipse.jdt.ui.IWorkingCopyManager;
 import org.eclipse.jdt.ui.JavaUI;
@@ -200,12 +199,12 @@ IDesignCompositeProvider {
 	}
 
 	/**
-	 * Highlight lines with visited {@link ASTNode}s.
+	 * Highlight the given lines, which were visited while evaluating the components.
 	 */
-	public void highlightVisitedNodes(final Collection<ASTNode> nodes) {
+	public void highlightVisitedLines(final Collection<Integer> lines) {
 		ExecutionUtils.runIgnore(() -> {
 			if (m_linesHighlighter != null) {
-				m_linesHighlighter.setVisitedNodes(nodes);
+				m_linesHighlighter.setVisitedLines(lines);
 			}
 		});
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/multi/VisitedLinesHighlighter.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/multi/VisitedLinesHighlighter.java
@@ -19,7 +19,6 @@ import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.preferences.IPreferenceConstants;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 
-import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.PreferenceConverter;
 import org.eclipse.jface.text.IDocument;
@@ -39,9 +38,7 @@ import org.eclipse.swt.graphics.RGB;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Helper for highlighting lines visited during rendering.
@@ -108,16 +105,10 @@ public class VisitedLinesHighlighter implements IPainter, LineBackgroundListener
 	// Access
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public void setVisitedNodes(Collection<ASTNode> nodes) throws Exception {
+	public void setVisitedLines(Collection<Integer> lines) throws Exception {
 		// unmanage previous positions
 		for (Position position : m_linePositions) {
 			m_positionManager.unmanagePosition(position);
-		}
-		// prepare lines
-		Set<Integer> lines = new HashSet<>();
-		for (ASTNode node : nodes) {
-			int line = m_document.getLineOfOffset(node.getStartPosition());
-			lines.add(line);
 		}
 		// create new positions
 		m_linePositions.clear();

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/DesignPageSite.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/DesignPageSite.java
@@ -20,6 +20,8 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.viewers.TreeViewer;
 
+import java.util.Collection;
+
 /**
  * Provides access to the {@link DesignPage}.
  *
@@ -49,12 +51,12 @@ public abstract class DesignPageSite implements IDesignPageSite {
 	public void openSourcePosition(int position) {
 	}
 
-	// TODO(scheglov)
-	//  /**
-	//   * Highlight in editor lines with visited {@link ASTNode}s.
-	//   */
-	//  public void highlightVisitedNodes(Collection<ASTNode> nodes) {
-	//  }
+	/**
+	 * Highlight in editor the given lines, which were visited while evaluating the components.
+	 */
+	public void highlightVisitedLines(Collection<Integer> lines) {
+	}
+
 	/**
 	 * Handles any unexpected {@link Exception}.
 	 */


### PR DESCRIPTION
The highlight visited lines preference was disabled because the wiring between JavaInfo and the editor was commented out. It had been cut because DesignPageSite lives in org.eclipse.wb.core, which must not depend on JDT, while the visited nodes were represented as org.eclipse.jdt.core.dom.ASTNode.

Convert the visited ASTNodes to plain line numbers in JavaInfo before handing them to the site, using the existing AstEditor.getLineNumber helper. This keeps org.eclipse.wb.core free of JDT types while restoring the call chain from JavaInfo through DesignPageSite and DesignPage down to DesignerEditor and VisitedLinesHighlighter, which already knew how to paint the highlighted lines.

Fixes eclipse-windowbuilder/windowbuilder#1590